### PR TITLE
fix: /about の nodeinfo リクエスト嵐を修正

### DIFF
--- a/app/lib/mulukhiya/controller/api_controller.rb
+++ b/app/lib/mulukhiya/controller/api_controller.rb
@@ -4,7 +4,9 @@ module Mulukhiya
       sns.token ||= sns.default_token
       about = config.about
       about[:config][:theme] = {color: sns.theme_color}
-      about[:config][:handlers] = Handler.all.reject(&:disable?).map(&:underscore)
+      about[:config][:handlers] = Handler.all_names
+        .reject {|name| config["/handler/#{name}/disable"] == true rescue false}
+        .sort.to_a
       @renderer.message = about
       return @renderer.to_s
     end


### PR DESCRIPTION
## Summary
- `/mulukhiya/api/about` の `handlers` フィールドで `Handler.all`（並列インスタンス化）を廃止
- `Handler.all_names` + config 直接参照に置換し、nodeinfo リクエストの嵐を回避
- v5.3.0 デプロイ時に Mastodon rate limit (429) を引き起こした問題の修正

## Test plan
- [ ] CI パス確認
- [ ] ステージングで `/mulukhiya/api/about` のレスポンスに `handlers` フィールドが含まれることを確認
- [ ] Mastodon の rate limit が発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)