### PR TITLE
fix: Authorization ヘッダがBearer形式の場合のみトークンとして採用する

### DIFF
--- a/app/lib/mulukhiya/controller/api_controller.rb
+++ b/app/lib/mulukhiya/controller/api_controller.rb
@@ -690,7 +690,9 @@ module Mulukhiya
     end
 
     def token
-      return @headers['Authorization'].split(/\s+/).last if @headers['Authorization']
+      if (header = @headers['Authorization']) && header =~ /\ABearer\s+(\S+)/i
+        return Regexp.last_match(1)
+      end
       return params[:token].decrypt
     rescue
       return params[:token]


### PR DESCRIPTION
## Summary
- PR #4231 への Codex レビュー（P2）対応
- \`APIController#token\` で \`Authorization\` ヘッダを採用する条件を \`Bearer <token>\` 形式にマッチした場合のみに限定
- 非Bearer/空のヘッダがリバースプロキシ等から差し込まれた場合に \`params[:token]\` フォールバックが効くように修正

closes #4238

## Test plan
- [ ] \`Authorization: Bearer xxx\` 付きリクエストで従来通り認証できること
- [ ] \`Authorization: Basic xxx\` 等の非Bearerヘッダ + \`token\` パラメータ で認証できること
- [ ] \`Authorization\` ヘッダ無し + \`token\` パラメータで従来通り認証できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)