### PR TITLE
5.19.1

### DIFF
--- a/app/lib/mulukhiya/controller/api_controller.rb
+++ b/app/lib/mulukhiya/controller/api_controller.rb
@@ -706,7 +706,9 @@ module Mulukhiya
 
     def token
       if (header = @headers['Authorization']) && header =~ /\ABearer\s+(\S+)/i
-        return Regexp.last_match(1)
+        bearer = Regexp.last_match(1)
+        plain = bearer.decrypt rescue bearer
+        return plain
       end
       return params[:token].decrypt
     rescue

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -433,7 +433,7 @@ package:
     - tkoishi@b-shock.co.jp
   license: MIT
   url: https://github.com/pooza/mulukhiya-toot-proxy
-  version: 5.19.0
+  version: 5.19.1
 parser:
   note:
     fields:

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -408,6 +408,26 @@ rack 3.2 + Sinatra 4.2 で「異なるアカウントの投稿として送信さ
 診断スクリプト: `bin/diag/concurrent_token_test.rb`。
 詳細は [postmortem-2025-10-rack32.md](archive/postmortem-2025-10-rack32.md) を参照。
 
+### 認証トークンの復号パターン
+
+ユーザー由来の OAuth トークンは「平文」と「暗号化済み（`.encrypt`）」の両形式で入って来うる:
+
+- **平文**: Mastodon / Misskey 純正クライアントが送る生 OAuth トークン、直 API アクセス等
+- **暗号化**: モロヘイヤ WebUI / capsicum のように `/oauth/callback` の `access_token_crypt` を localStorage 等に保存して Bearer で送るパス
+
+どちらでも扱えるよう正規化する場合は慣用句 `token.decrypt rescue token` を使う（`Account.get` / `UserConfig` / `AnnictService` / `LineService` / `LineAlertHandler` / `APIController#token` 等）。復号失敗は平文フォールバック。
+
+一方、**管理者が設定ファイルに書く値は暗号化前提**なので `config['/path/to/secret'].decrypt`（rescue なし）とする。失敗＝設定不備でフェイルストップさせるのが正しい（Spotify / YouTube / Sidekiq auth 等）。
+
+Controller 層での注意:
+
+- **APIController#token** はモロヘイヤ固有 API 用。WebUI/capsicum の暗号化 Bearer を受けるので Bearer 分岐でも `.decrypt rescue bearer` する（5.19.1 / #4260 で修正）
+- **MastodonController#token / MisskeyController#token** は純正クライアント向けプロキシ。Bearer は平文 OAuth トークン前提でそのままパススルー
+
+内部の `@sns.token` には**常に平文**が入るのが不変条件。これが崩れると `sns.post` / `sns.toot` / Misskey の `body[:i]` / Mastodon の `Authorization: Bearer` 等、SNS 本家へ出る段階で 401 になる。
+
+**Ruby 構文の落とし穴**: `return X rescue Y` を `def ... rescue ... end` のメソッド末尾 rescue と併用すると、`return` が発火せず次行にフォールスルーする（`return X; rescue Y` と解釈される）。必ず `plain = X rescue Y; return plain` か `return (X rescue Y)` と書くこと。5.19.1 の初版修正で実際に踏んだ罠で、[LineAlertHandler#token](app/lib/mulukhiya/handler/line_alert_handler.rb#L17-L19) のように外側 rescue がない関数では同じ書き方が動くため気づきにくい。
+
 ### Webhook digest の安定性
 
 `Webhook.create_digest` は Webhook URL の一部となる digest を生成する。入力は SNS の URI、OAuth トークン、`/crypt/salt`（フォールバック: `/crypt/password`）の3要素。

--- a/test/unit/controller/api_controller.rb
+++ b/test/unit/controller/api_controller.rb
@@ -1,0 +1,52 @@
+module Mulukhiya
+  class APIControllerTest < TestCase
+    def setup
+      config['/crypt/password'] = SecureRandom.hex(32)
+      config['/crypt/encoder'] = 'base64'
+      @plain = SecureRandom.hex(32)
+      @controller = APIController.new!
+    end
+
+    def test_token_bearer_decrypts_encrypted
+      encrypted = @plain.encrypt
+      set_request(headers: {'Authorization' => "Bearer #{encrypted}"})
+
+      assert_equal(@plain, @controller.token)
+    end
+
+    def test_token_bearer_passes_plain_through
+      set_request(headers: {'Authorization' => "Bearer #{@plain}"})
+
+      assert_equal(@plain, @controller.token)
+    end
+
+    def test_token_body_decrypts_encrypted
+      encrypted = @plain.encrypt
+      set_request(body: {token: encrypted})
+
+      assert_equal(@plain, @controller.token)
+    end
+
+    def test_token_body_passes_plain_through
+      set_request(body: {token: @plain})
+
+      assert_equal(@plain, @controller.token)
+    end
+
+    def test_token_returns_nil_when_absent
+      set_request
+
+      assert_nil(@controller.token)
+    end
+
+    private
+
+    def set_request(headers: {}, body: {})
+      @controller.instance_variable_set(:@headers, headers)
+      @controller.instance_variable_set(:@params, Sinatra::IndifferentHash.new.merge(body))
+      @controller.define_singleton_method(:params) do
+        @params
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

#4260 ホットフィックス。モロヘイヤ WebUI / capsicum の暗号化 Bearer トークンで Authorization 認証が通らない問題を修正。

- **影響**: 「削除してタグづけ」、予約投稿タグ付け、Misskey Web Push 登録 API (`/sw/register`) 等、capsicum/WebUI 経由の更新系 API が広範囲に 401 で失敗
- **原因**: `APIController#token` の Bearer 分岐が生値のまま返していた (5.19.0 でも存在)
- **修正**: Bearer 値も `.decrypt rescue bearer` で平文化。初版で `return X rescue Y` + メソッド末尾 rescue の Ruby 構文罠を踏んだのでローカル変数経由に修正

## 影響範囲

- [app/lib/mulukhiya/controller/api_controller.rb](../../../blob/dev/5.19.1/app/lib/mulukhiya/controller/api_controller.rb) (1 メソッド 2 行追加)
- `MastodonController` / `MisskeyController` のプロキシ経路は無変更 (純正クライアントの平文 Bearer 前提のまま)

## テスト

- `test/unit/controller/api_controller.rb` 新設: Bearer/暗号化・Bearer/平文・body/暗号化・body/平文・欠落時 nil の 5 ケース、全 pass
- ローカル 美食丼 (Mastodon) / ダイスキー (Misskey) のログで事象再現済み、修正適用後にステージング (dev04 / dev23) で検証予定

## Test plan

- [ ] CI pass
- [ ] dev04 にデプロイ、美食丼ステージング Web UI から「削除してタグづけ」が 200 で通ることを確認
- [ ] dev23 にデプロイ、Misskey ステージング環境から capsicum `/sw/register` が 200 で通ることを確認
- [ ] 本番デプロイ後、既存の純正 UI 投稿が従来どおり通ること (プロキシ経路の無回帰) を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)