### PR TITLE
chore: #4276 ProgramEntryContract をホワイトリスト経由で抽出する

### DIFF
--- a/app/lib/mulukhiya/contract/program_entry_contract.rb
+++ b/app/lib/mulukhiya/contract/program_entry_contract.rb
@@ -1,5 +1,11 @@
 module Mulukhiya
   class ProgramEntryContract < Contract
+    PARAMS_KEYS = [
+      :key, :series, :minutes, :episode, :episode_suffix, :subtitle,
+      :air, :livecure, :enable, :extra_tags,
+      :annict_work_id, :annict_episode_id, :source_type, :source_url
+    ].freeze
+
     params do
       optional(:key).value(:string)
       required(:series).value(:string)

--- a/app/lib/mulukhiya/controller/api_controller.rb
+++ b/app/lib/mulukhiya/controller/api_controller.rb
@@ -611,7 +611,8 @@ module Mulukhiya
         @renderer.message = {errors:}
         return @renderer.to_s
       end
-      attributes = params.to_h.except(:key, 'key')
+      attributes = params.to_h.transform_keys(&:to_sym)
+        .slice(*ProgramEntryContract::PARAMS_KEYS).except(:key)
       key = params[:key].to_s
       key = Program.instance.generate_key(attributes) if key.empty?
       entry = Program.instance.add_entry(key, attributes)
@@ -633,7 +634,8 @@ module Mulukhiya
         @renderer.message = {errors:}
         return @renderer.to_s
       end
-      attributes = params.to_h.except(:key, 'key')
+      attributes = params.to_h.transform_keys(&:to_sym)
+        .slice(*ProgramEntryContract::PARAMS_KEYS).except(:key)
       entry = Program.instance.update_entry(params[:key], attributes)
       @renderer.message = {key: params[:key], entry:}
       return @renderer.to_s

--- a/test/contract/program_entry_contract.rb
+++ b/test/contract/program_entry_contract.rb
@@ -72,5 +72,11 @@ module Mulukhiya
 
       assert_empty(errors)
     end
+
+    def test_params_keys_match_schema_definition
+      schema_keys = ProgramEntryContract.schema.key_map.map(&:name).to_set(&:to_sym)
+
+      assert_equal(schema_keys, ProgramEntryContract::PARAMS_KEYS.to_set)
+    end
   end
 end


### PR DESCRIPTION
## Summary

5.20.0 リリース前レビュー API 契約黄の送り。POST/PUT `/admin/program/entry` のコントローラが `params.to_h.except(:key, 'key')` で属性を構築していたため、contract に宣言していない任意キー（`evil_field=1` 等）もすり抜けて `var/program.yaml` に永続化されていた。admin 限定で影響は限定的だが、ホワイトリスト方式の方が堅牢。

## 対応

- `ProgramEntryContract::PARAMS_KEYS` 定数を追加（POST/PUT 共有）
- POST/PUT コントローラを `params.to_h.transform_keys(&:to_sym).slice(*PARAMS_KEYS).except(:key)` に切替
- テスト: `PARAMS_KEYS` が schema 定義（`schema.key_map`）と一致することを検証（drift 検知）

## ベース

このPRは [#4289 (#4274 PR)](https://github.com/pooza/mulukhiya-toot-proxy/pull/4289) の上に積んでいます。
スタック順: develop → #4288 (#4282) → #4289 (#4274) → 本PR (#4276)。

## Test plan

- [x] `bundle exec rubocop` 緑
- [x] `bin/test.rb program_entry_contract,program_entry_update_contract` 18/18 緑
  - `test_params_keys_match_schema_definition` が drift を検知
- [ ] ステージングで未宣言キーを送信した場合に YAML に保存されないことを確認

## 関連

- 親: #4234 番組表リニューアル
- 出元: 5.20.0 リリース前レビュー API 契約黄
- 関連: #4288 (#4282) / #4289 (#4274)

🤖 Generated with [Claude Code](https://claude.com/claude-code)