### PR TITLE
fix: #4273 Program#update_cache 失敗時に invalidate_cache でフェイルセーフ

### DIFF
--- a/app/lib/mulukhiya/program.rb
+++ b/app/lib/mulukhiya/program.rb
@@ -158,6 +158,10 @@ module Mulukhiya
 
     def update_cache(programs)
       return redis[REDIS_KEY] = programs.to_json
+    rescue => e
+      invalidate_cache rescue nil
+      e.alert
+      return nil
     end
 
     def write_yaml(programs)

--- a/test/unit/model/program.rb
+++ b/test/unit/model/program.rb
@@ -194,5 +194,28 @@ module Mulukhiya
     def test_auto_update_default_true
       assert_true(@program.auto_update?)
     end
+
+    def test_update_cache_invalidates_on_redis_write_failure
+      original = @program.data
+      @program.save({'sentinel' => {'series' => 'sentinel'}})
+
+      failing_redis = Object.new
+      unlinks = []
+      failing_redis.define_singleton_method(:[]=) {|_k, _v| raise 'simulated redis failure'}
+      failing_redis.define_singleton_method(:unlink) do |k|
+        unlinks << k
+        1
+      end
+      original_redis = @program.instance_variable_get(:@redis)
+      @program.instance_variable_set(:@redis, failing_redis)
+
+      result = @program.send(:update_cache, {'after' => {'series' => 'after'}})
+
+      assert_nil(result)
+      assert_equal([Program::REDIS_KEY], unlinks)
+    ensure
+      @program.instance_variable_set(:@redis, original_redis)
+      @program.save(original) if original
+    end
   end
 end


### PR DESCRIPTION
## Summary

5.20.0 リリース前レビュー 並行性赤 R2 の送り。`Program#save` は `write_yaml` → `update_cache` の順で実行するため、`update_cache` が Redis 障害で失敗すると YAML は新値・Redis は旧値で乖離が固定化していた。次回 `data` 呼び出しで `cached_data` (旧値) が読まれ `load_from_yaml` までフォールバックしない。

## 対応

`update_cache` 内で Redis 例外を捕捉し、`invalidate_cache` (UNLINK) を先に実行してから `e.alert` を呼ぶ。alert 側で更に例外が出ても invalidate は完了しているので、次回読みは確実に `load_from_yaml` にフォールバックする。

```ruby
def update_cache(programs)
  return redis[REDIS_KEY] = programs.to_json
rescue => e
  invalidate_cache rescue nil
  e.alert
  return nil
end
```

## ベース

このPRは [#4291 (#4270)](https://github.com/pooza/mulukhiya-toot-proxy/pull/4291) の上に積んでいます。
スタック順: develop → #4288 → #4289 → #4290 → #4291 → 本PR (#4273)。

## Test plan

- [x] `bundle exec rubocop` 緑
- [x] `bin/test.rb program` ロード成功（CI でフル実行）
  - `test_update_cache_invalidates_on_redis_write_failure`: failing redis スタブで update_cache が nil を返し UNLINK が呼ばれることを検証
- [ ] ステージングで Redis 一時停止 → 番組表更新 → Redis 復旧時に YAML から正常に読み込まれることを確認

## 関連

- 親: #4234 番組表リニューアル
- 出元: 5.20.0 リリース前レビュー 並行性赤 R2

🤖 Generated with [Claude Code](https://claude.com/claude-code)