### PR TITLE
fix: #4275 /program/works/:id/episodes の url を正しく返す

### DIFF
--- a/app/lib/mulukhiya/service/annict_service.rb
+++ b/app/lib/mulukhiya/service/annict_service.rb
@@ -51,6 +51,7 @@ module Mulukhiya
 
     def episodes(ids)
       return unless entries = query(:episodes, {ids:}).dig('data', 'searchWorks', 'nodes')
+      return [] if entries.empty?
       all_episodes = entries.flat_map do |work|
         work.dig('episodes', 'nodes').map {|ep| ep.merge('work_annict_id' => work['annictId'])}
       end

--- a/app/lib/mulukhiya/service/annict_service.rb
+++ b/app/lib/mulukhiya/service/annict_service.rb
@@ -51,21 +51,29 @@ module Mulukhiya
 
     def episodes(ids)
       return unless entries = query(:episodes, {ids:}).dig('data', 'searchWorks', 'nodes')
-      all_episodes = entries.flat_map {|v| v.dig('episodes', 'nodes')}
+      all_episodes = entries.flat_map do |work|
+        work.dig('episodes', 'nodes').map {|ep| ep.merge('work_annict_id' => work['annictId'])}
+      end
+      work_title = entries.first['title']
       return Parallel.map(all_episodes, in_threads: Parallel.processor_count * 2) do |episode|
-        next unless subtitle = episode['title']
-        episode['title'] = self.class.trim_ruby(subtitle) if self.class.subtitle_trim_ruby?
-        episode.merge(
-          'hashtag' => episode['title'].to_hashtag,
-          'hashtag_uri' => sns.create_tag_uri(episode['title']),
-          'command_toot' => self.class.create_command_toot(
-            title: entries.first['title'],
-            subtitle: episode['title'],
-            number_text: episode['numberText'],
-            minutes: config['/webui/episode/minutes'],
-          ),
-        )
+        enrich_episode(episode, work_title)
       end.compact
+    end
+
+    def enrich_episode(episode, work_title)
+      return nil unless subtitle = episode['title']
+      episode['title'] = self.class.trim_ruby(subtitle) if self.class.subtitle_trim_ruby?
+      return episode.merge(
+        'hashtag' => episode['title'].to_hashtag,
+        'hashtag_uri' => sns.create_tag_uri(episode['title']),
+        'url' => self.class.create_episode_uri(episode['work_annict_id'], episode['annictId']),
+        'command_toot' => self.class.create_command_toot(
+          title: work_title,
+          subtitle: episode['title'],
+          number_text: episode['numberText'],
+          minutes: config['/webui/episode/minutes'],
+        ),
+      )
     end
 
     def crawl(params = {})
@@ -240,6 +248,11 @@ module Mulukhiya
 
     def self.create_record_uri(work_id, episode_id)
       return new.service.create_uri("/works/#{work_id}/episodes/#{episode_id}")
+    end
+
+    def self.create_episode_uri(work_id, episode_id)
+      return nil unless work_id.present? && episode_id.present?
+      return create_record_uri(work_id, episode_id)
     end
 
     def self.create_review_uri(work_id)

--- a/test/unit/service/annict_service.rb
+++ b/test/unit/service/annict_service.rb
@@ -54,6 +54,9 @@ module Mulukhiya
         assert_kind_of(String, episode['title'])
         assert_kind_of(String, episode['hashtag'])
         assert_kind_of(Ginseng::URI, episode['hashtag_uri'])
+        assert_kind_of(Ginseng::URI, episode['url'])
+        assert_predicate(episode['url'], :absolute?)
+        assert_match(%r{/works/#{id}/episodes/\d+\z}, episode['url'].to_s)
         assert_kind_of(String, episode['command_toot'])
       end
     end
@@ -100,6 +103,15 @@ module Mulukhiya
 
     def test_create_record_uri
       assert_equal('https://annict.com/works/7879/episodes/138263', AnnictService.create_record_uri(7879, 138_263).to_s)
+    end
+
+    def test_create_episode_uri
+      assert_equal(
+        'https://annict.com/works/7879/episodes/138263',
+        AnnictService.create_episode_uri(7879, 138_263).to_s,
+      )
+      assert_nil(AnnictService.create_episode_uri(nil, 138_263))
+      assert_nil(AnnictService.create_episode_uri(7879, nil))
     end
 
     def test_create_review_uri


### PR DESCRIPTION
## Summary

5.20.0 リリース前レビュー API 契約黄の送り。`docs/api.md` には `"url": "https://annict.com/works/.../episodes/..."` が記載されていたが、`app/query/annict/episodes.graphql` に `url` フィールドが含まれず、コントローラの `episode['url'].to_s` は常に空文字を返していた。

## 対応

`AnnictService#episodes` 側で URL を組み立てて返すように変更:

- `entries` 走査時に各エピソードに `work_annict_id` を付与（GraphQL の `searchWorks` ノードから work id を引き継ぐ）
- 既存の `create_record_uri` と同じパス形式 `/works/{work_id}/episodes/{episode_id}` を返す、nil-safe なクラスメソッド `create_episode_uri` を追加
- 副次対応: `enrich_episode` を helper に切り出し AbcSize 警告を解消

## 独立 PR

このPRは他の 5.21.0 PR (#4288/#4289/#4290/#4291/#4292) と独立しており、develop に直接 base を置いています。

## Test plan

- [x] `bundle exec rubocop` 緑
- [x] `bin/test.rb annict_service` ロード成功（CI で Annict トークン設定環境ならフル実行）
  - `test_create_episode_uri`: 正常系 + nil 引数で nil を返すケース
  - `test_episodes`: レスポンスに `Ginseng::URI` 型の `url` が含まれ `/works/:id/episodes/:eid` パターンに一致することを検証
- [ ] ステージングでエピソードブラウザの URL リンクが正しく機能することを確認

## 関連

- 親: #4234 番組表リニューアル
- 出元: 5.20.0 リリース前レビュー API 契約黄
- 参考: `app/lib/mulukhiya/controller/api_controller.rb:241`、`docs/api.md:863`

🤖 Generated with [Claude Code](https://claude.com/claude-code)