### PR TITLE
fix: #4268 連合しない投稿（チャンネル / localOnly）でタグ付与系ハンドラをスキップ

### DIFF
--- a/app/lib/mulukhiya/handler.rb
+++ b/app/lib/mulukhiya/handler.rb
@@ -199,8 +199,8 @@ module Mulukhiya
 
     def non_federated_payload?
       return false unless payload
-      return true if payload[:channelId].present?
-      return true if payload['localOnly'] == true
+      return true if payload[:channelId].present? || payload['channelId'].present?
+      return true if payload[:localOnly] == true || payload['localOnly'] == true
       return false
     end
 

--- a/app/lib/mulukhiya/handler.rb
+++ b/app/lib/mulukhiya/handler.rb
@@ -197,6 +197,13 @@ module Mulukhiya
       return handler_config(:toggleable) == true
     end
 
+    def non_federated_payload?
+      return false unless payload
+      return true if payload[:channelId].present?
+      return true if payload['localOnly'] == true
+      return false
+    end
+
     def payload=(payload)
       @payload = payload
       @status = payload[text_field] || payload[text_field.to_sym] || ''

--- a/app/lib/mulukhiya/handler/tagging_handler.rb
+++ b/app/lib/mulukhiya/handler/tagging_handler.rb
@@ -6,6 +6,17 @@ module Mulukhiya
 
     def handle_pre_toot(payload, params = {})
       self.payload = payload
+      return if non_federated_payload?
+      rebuild_status_with_tags
+    end
+
+    def self.normalize_rules
+      return new.handler_config(:normalize, :rules) || []
+    end
+
+    private
+
+    def rebuild_status_with_tags
       lines = status_lines.clone
       lines.clone.reverse_each do |line|
         break unless tags_line?(line)
@@ -16,12 +27,6 @@ module Mulukhiya
       lines.push(tags.create_tags.join(' '))
       parser.text = payload[text_field] = lines.join("\n")
     end
-
-    def self.normalize_rules
-      return new.handler_config(:normalize, :rules) || []
-    end
-
-    private
 
     def tags_line?(line)
       return /^[[:blank:]]*(#[[:word:]]+[[:blank:]]*)+$/.match?(line)

--- a/app/lib/mulukhiya/tag_handler.rb
+++ b/app/lib/mulukhiya/tag_handler.rb
@@ -12,6 +12,7 @@ module Mulukhiya
     def executable?
       return false if parser.command?
       return false if parser.accts.any?(&:agent?)
+      return false if non_federated_payload?
       return true if payload[visibility_field].empty?
       return true if payload[visibility_field] == controller_class.visibility_name(:public)
       return false

--- a/test/unit/handler/default_tag_handler.rb
+++ b/test/unit/handler/default_tag_handler.rb
@@ -9,5 +9,23 @@ module Mulukhiya
 
       assert_predicate(@handler.addition_tags.count, :positive?)
     end
+
+    def test_skips_when_channel_post
+      @handler.handle_pre_toot(
+        status_field => "つよく、やさしく、美しく。\n#キュアマーメイド",
+        :channelId => 'channel-123',
+      )
+
+      assert_false(@handler.executable?)
+    end
+
+    def test_skips_when_local_only
+      @handler.handle_pre_toot(
+        status_field => "つよく、やさしく、美しく。\n#キュアマーメイド",
+        'localOnly' => true,
+      )
+
+      assert_false(@handler.executable?)
+    end
   end
 end

--- a/test/unit/handler/default_tag_handler.rb
+++ b/test/unit/handler/default_tag_handler.rb
@@ -19,10 +19,28 @@ module Mulukhiya
       assert_false(@handler.executable?)
     end
 
+    def test_skips_when_channel_post_string_key
+      @handler.handle_pre_toot(
+        status_field => "つよく、やさしく、美しく。\n#キュアマーメイド",
+        'channelId' => 'channel-123',
+      )
+
+      assert_false(@handler.executable?)
+    end
+
     def test_skips_when_local_only
       @handler.handle_pre_toot(
         status_field => "つよく、やさしく、美しく。\n#キュアマーメイド",
         'localOnly' => true,
+      )
+
+      assert_false(@handler.executable?)
+    end
+
+    def test_skips_when_local_only_symbol_key
+      @handler.handle_pre_toot(
+        status_field => "つよく、やさしく、美しく。\n#キュアマーメイド",
+        :localOnly => true,
       )
 
       assert_false(@handler.executable?)

--- a/test/unit/handler/tagging_handler.rb
+++ b/test/unit/handler/tagging_handler.rb
@@ -40,5 +40,23 @@ module Mulukhiya
 
       assert_equal(":nyatoran_anime: :pegitan_anime: :rabirin_anime:\n\n", @handler.payload[status_field])
     end
+
+    def test_skips_when_channel_post
+      @handler.clear
+      original = "本文\n本文\n#1行目\n#2行目"
+      @handler.tags.merge(['additional_tag'])
+      @handler.handle_pre_toot(status_field => original, :channelId => 'channel-123')
+
+      assert_equal(original, @handler.payload[status_field])
+    end
+
+    def test_skips_when_local_only
+      @handler.clear
+      original = "本文\n本文\n#1行目\n#2行目"
+      @handler.tags.merge(['additional_tag'])
+      @handler.handle_pre_toot(status_field => original, 'localOnly' => true)
+
+      assert_equal(original, @handler.payload[status_field])
+    end
   end
 end


### PR DESCRIPTION
## Summary

連合 TL に載らない投稿にはタグづけ不要という原則があり、これらの投稿に対してモロヘイヤ側のタグ付与系ハンドラ（`DefaultTag` / `DictionaryTag` / `UserTag` / `GroupTag` / `RemoteTag` / `RemovalRuleTag` / `MediaTag`、および `TaggingHandler` 本体）を実行すべきでない。

現行の `TagHandler#executable?` は visibility 判定のみで、以下を取りこぼしていた:

- **チャンネル投稿**: payload に `:channelId` が present
- **非連合投稿 (localOnly フラグ付き)**: `payload['localOnly']` が true

## 対応

`Handler` 基底に `non_federated_payload?` を追加:

```ruby
def non_federated_payload?
  return false unless payload
  return true if payload[:channelId].present?
  return true if payload['localOnly'] == true
  return false
end
```

`TagHandler#executable?` と `TaggingHandler#handle_pre_toot` 冒頭から横断的にスキップ。`TaggingHandler` は AbcSize 対応のため本処理を `rebuild_status_with_tags` に切り出し。

## 独立 PR

このPRは他の 5.21.0 PR と独立しており、develop に直接 base を置いています。

## 影響範囲

Misskey のみ。Mastodon 本家にチャンネル機能なし、localOnly フラグもなし。

## Test plan

- [x] `bundle exec rubocop` 緑
- [x] `bin/test.rb` のロード成功（CI で Misskey controller でフル実行）
  - DefaultTagHandler: `:channelId` / `localOnly` で `executable?` が false
  - TaggingHandler: 同条件で payload の status が変更されない
- [ ] ステージング (Misskey) でチャンネル投稿に余分なタグが付与されないことを確認
- [ ] ステージング (Misskey) で localOnly 投稿に余分なタグが付与されないことを確認

## クロスリファレンス

- [pooza/capsicum#378](https://github.com/pooza/capsicum/issues/378) チャンネル投稿リプライの channelId 継承漏れ
- [pooza/capsicum#383](https://github.com/pooza/capsicum/issues/383) capsicum 側「削除してタグづけ」表示条件整理（本 Issue と対）
- [pooza/capsicum#384](https://github.com/pooza/capsicum/issues/384) capsicum 側「削除して再編集」channelId 継承

🤖 Generated with [Claude Code](https://claude.com/claude-code)