### PR TITLE
fix: #4267 Sinatra error ハンドラが Ginseng::Error 以外で落ちて 500 が無ログになる問題を改善

### DIFF
--- a/app/lib/mulukhiya/controller.rb
+++ b/app/lib/mulukhiya/controller.rb
@@ -49,9 +49,21 @@ module Mulukhiya
 
     error do |e|
       @renderer = default_renderer_class.new
-      @renderer.status = e.status
-      @renderer.message = e.to_h.except(:backtrace).merge(error: e.message)
-      e.alert
+      if e.is_a?(Ginseng::Error)
+        @renderer.status = e.status
+        @renderer.message = e.to_h.except(:backtrace).merge(error: e.message)
+        e.alert
+      else
+        @renderer.status = 500
+        @renderer.message = {error: "#{e.class.name}: #{e.message}"}
+        logger.error(
+          error: e.class.name,
+          message: e.message,
+          path: request.path,
+          backtrace: e.backtrace&.first(10),
+        )
+        Sentry.capture_exception(e) if Sentry.initialized?
+      end
       return @renderer.to_s
     end
 


### PR DESCRIPTION
## Summary

`Mulukhiya::Controller#error` は `Ginseng::Error` 専用メソッド（`e.status` / `e.to_h` / `e.alert`）を呼んでいたため、`Slim::Parser::SyntaxError` や `NoMethodError` のような標準例外が来ると、ハンドラ内で再爆発して Sinatra のデフォルト 500 にフォールバックし、アプリログに何も出ずにデバッグが困難になっていた（PR #4266 dev04 ステージング検証で実例）。

## 対応

`e.is_a?(Ginseng::Error)` で分岐:

- **Ginseng::Error 系**: 既存挙動を維持（`status` / `to_h` / `alert`）
- **標準例外**: `status=500` + `{error: "ClassName: message"}` を返しつつ、`logger.error` でクラス名・メッセージ・`path`・`backtrace` 先頭 10 行を必ず出力。Sentry が初期化済みなら `Sentry.capture_exception` でも通知

## 独立 PR

このPRは他の 5.21.0 PR と独立しており、develop に直接 base を置いています。

## 影響範囲

`Mulukhiya::Controller` を継承する全コントローラ（`APIController` / `UIController` / `MastodonController` / `MisskeyController` / `FeedController` / `WebhookController` 等）。

## Test plan

- [x] `bundle exec rubocop` 緑
- [x] CI 緑（既存パスは Ginseng::Error 分岐のみで挙動不変）
- [ ] ステージングで意図的に標準例外を発生させ、500 レスポンスとログ出力を確認

通常のリクエストパスは `Ginseng::Error` で例外設計されているため発火しない。開発時のテンプレート構文ミスや想定外の標準例外で初めて踏むケースを拾えるようになる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)