### PR TITLE
test: #4299 Rack::Test 基盤の雛形と Misskey ドライブ folderId 回帰テスト

### DIFF
--- a/app/lib/mulukhiya/controller_test_case.rb
+++ b/app/lib/mulukhiya/controller_test_case.rb
@@ -1,0 +1,35 @@
+module Mulukhiya
+  class ControllerTestCase < TestCase
+    include Rack::Test::Methods
+
+    def setup
+      ensure_db_or_omit
+      WebMock.disable_net_connect!(allow_localhost: true)
+      app.set(:host_authorization, permitted_hosts: ['example.org'])
+      app.set(:raise_errors, true)
+      app.set(:show_exceptions, false)
+    end
+
+    def teardown
+      WebMock.reset!
+      super
+    end
+
+    def app
+      raise NotImplementedError, "#{self.class} must implement #app"
+    end
+
+    def upstream_url(path = '')
+      base = config["/#{Environment.controller_name}/url"]
+      return URI.join(base, path).to_s
+    end
+
+    private
+
+    def ensure_db_or_omit
+      Sequel::Model.db
+    rescue Sequel::Error
+      omit('PostgreSQL connection not configured (local-only limitation; CI provides one)')
+    end
+  end
+end

--- a/test/unit/controller/misskey_controller.rb
+++ b/test/unit/controller/misskey_controller.rb
@@ -1,0 +1,60 @@
+module Mulukhiya
+  class MisskeyControllerTest < ControllerTestCase
+    def app
+      return MisskeyController
+    end
+
+    def setup
+      super
+      config['/controller'] = 'misskey'
+      config['/misskey/url'] = 'https://misskey.example.com'
+    end
+
+    def test_drive_files_create_forwards_folder_id
+      stub_request(:post, upstream_url('/api/drive/files/create'))
+        .to_return(
+          status: 200,
+          body: {id: 'abc123', name: 'test.png'}.to_json,
+          headers: {'Content-Type' => 'application/json'},
+        )
+
+      file = Tempfile.new(['mulukhiya-test', '.png'])
+      file.binmode
+      file.write("\x89PNG\r\n\x1a\n")
+      file.rewind
+
+      post '/api/drive/files/create', {
+        file: Rack::Test::UploadedFile.new(file.path, 'image/png'),
+        folderId: 'a9yox52ls4',
+        name: 'test.png',
+      }
+
+      assert_requested(:post, upstream_url('/api/drive/files/create')) do |req|
+        body = req.body.to_s
+        body.include?('name="folderId"') && body.include?('a9yox52ls4')
+      end
+    ensure
+      file&.close
+      file&.unlink
+    end
+
+    def test_notes_create_forwards_text_and_visibility
+      stub_request(:post, upstream_url('/api/notes/create'))
+        .to_return(
+          status: 200,
+          body: {createdNote: {id: 'note123', user: {id: 'u1'}}}.to_json,
+          headers: {'Content-Type' => 'application/json'},
+        )
+
+      post '/api/notes/create', {
+        text: 'hello world',
+        visibility: 'public',
+      }.to_json, {'CONTENT_TYPE' => 'application/json'}
+
+      assert_requested(:post, upstream_url('/api/notes/create')) do |req|
+        body = JSON.parse(req.body.to_s)
+        body['text'] == 'hello world' && body['visibility'] == 'public'
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- `Mulukhiya::ControllerTestCase` を新設（Rack::Test + WebMock + Sinatra `host_authorization` 設定 + `raise_errors` 設定 + DB 未接続時 `omit`）
- `MisskeyControllerTest` に第一弾として 2 ルートのテストを追加
  - `test_drive_files_create_forwards_folder_id` — #4297 の回帰テスト（multipart の `folderId` が上流リクエストボディに乗ることを `assert_requested` で検証）
  - `test_notes_create_forwards_text_and_visibility` — JSON ボディの `text`/`visibility` が上流に正しく載ることを検証

## 注意 — DB 不在で omit になる現状

CI には Postgres が無い方針（[`docs/CLAUDE.md:350`](docs/CLAUDE.md#L350)）のため、`MisskeyController#before` が `MisskeyService.new` 経由で `Mulukhiya::Misskey::Account < Sequel::Model` を要求する経路で **CI でも omit される** 想定です。

つまり**本 PR は枠組みのみ**で、実回帰検出はまだ動きません。経緯と別 Issue 化候補（Sequel mock スキーマ注入 / CI に Postgres 追加 / Sinatra 抜きテスト）は #4299 のコメントに整理済みです: pooza/mulukhiya-toot-proxy#4299 (comment)

## Test plan

- [x] `bundle exec ruby -Iapp/lib -rmulukhiya -e "Mulukhiya::TestCase.load('misskey_controller')"` で 2 件 omit、`100% passed`
- [x] `bundle exec rake test`（全体）で 522 tests / 0 failures / 5 errors（既知の Redis 接続エラーのみ、回帰なし）/ 2 omissions（本 PR 追加分）
- [x] `bundle exec rubocop app/lib/mulukhiya/controller_test_case.rb test/unit/controller/misskey_controller.rb` 違反なし

## 関連

- Closes 検討中: #4299（コメントで「枠組みまで」のスコープ再定義を提案中）
- 動機となった 5.20.1 ホットフィックス: #4297

🤖 Generated with [Claude Code](https://claude.com/claude-code)