### PR TITLE
5.20.2

### DIFF
--- a/config/application.yaml
+++ b/config/application.yaml
@@ -438,7 +438,7 @@ package:
     - tkoishi@b-shock.co.jp
   license: MIT
   url: https://github.com/pooza/mulukhiya-toot-proxy
-  version: 5.20.1
+  version: 5.20.2
 parser:
   note:
     fields:

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -601,7 +601,7 @@ sidekiq:
       every: 5m
     media_catalog_update:
       class: Mulukhiya::MediaCatalogUpdateWorker
-      every: 3m
+      every: 30m
     media_cleaning:
       class: Mulukhiya::MediaCleaningWorker
       every: 10m


### PR DESCRIPTION
## ホットフィックス: Sidekiq default キュー詰まりによるユーザー操作起点ジョブの大幅遅延を緩和

`MediaCatalogUpdateWorker` の DB クエリ劣化（OFFSET ページングが 170〜200 秒、1 ジョブ完走 12〜16 分）に対し `every: 3m` で投入し続けた結果、concurrency=5 のスロットを使い切り Sidekiq `default` キュー全体が詰まっていた。タグセットクリア通知（`UserTagInitializeWorker` の `at:` 経路）が想定 4 分→実 43 分遅延、デコレーション復元（`DecorationInitializeWorker`）等も同様に遅延する事象を確認。発生レートを抑える短期対処として `every: 30m` に緩和。

詳細: #4306（根本対応はここで継続）。関連: #4302 / #4303。

- **#4306 fix: media_catalog_update のスケジュール間隔を 3m → 30m に緩和** — cursor ページング切替・専用キュー分離など根治対応は #4306 で別途対応する