### PR TITLE
fix: #4377 CustomFeed 出力が null/非配列でも FeedUpdateWorker を落とさない

### DIFF
--- a/app/lib/mulukhiya/renderer/rss20_feed_renderer.rb
+++ b/app/lib/mulukhiya/renderer/rss20_feed_renderer.rb
@@ -22,7 +22,7 @@ module Mulukhiya
         raise Ginseng::Error,
           "CustomFeed command failed (exit #{command.status}): #{command.stderr}"
       end
-      self.entries = JSON.parse(command.stdout)
+      self.entries = parse_entries(command.stdout)
       render_storage[command] = feed.to_s
     end
 
@@ -41,6 +41,15 @@ module Mulukhiya
     end
 
     private
+
+    def parse_entries(stdout)
+      entries = JSON.parse(stdout)
+      return entries if entries.is_a?(Array)
+      raise Ginseng::Error, "CustomFeed command returned non-array (#{entries.class})"
+    rescue JSON::ParserError, Ginseng::Error => e
+      e.log
+      return []
+    end
 
     def fetch_image(uri)
       return nil unless uri

--- a/test/unit/renderer/rss20_feed_renderer.rb
+++ b/test/unit/renderer/rss20_feed_renderer.rb
@@ -1,0 +1,40 @@
+module Mulukhiya
+  class RSS20FeedRendererTest < TestCase
+    def disable?
+      return true unless Environment.dbms_class&.config?
+      return super
+    end
+
+    def setup
+      return if disable?
+      @renderer = RSS20FeedRenderer.new
+    end
+
+    def test_parse_entries_array
+      entries = @renderer.send(:parse_entries, '[{"title":"a"},{"title":"b"}]')
+
+      assert_kind_of(Array, entries)
+      assert_equal(2, entries.size)
+    end
+
+    def test_parse_entries_null
+      assert_equal([], @renderer.send(:parse_entries, 'null'))
+    end
+
+    def test_parse_entries_non_array
+      assert_equal([], @renderer.send(:parse_entries, '{"title":"a"}'))
+    end
+
+    def test_parse_entries_invalid_json
+      assert_equal([], @renderer.send(:parse_entries, 'not json'))
+    end
+
+    def test_entries_assignable_from_parsed_null
+      # ginseng の entries= は Array 前提なので nil を渡すと each で落ちる。
+      # parse_entries 経由なら [] に正規化され安全であることを保証する。
+      @renderer.entries = @renderer.send(:parse_entries, 'null')
+
+      assert_empty(@renderer.entries)
+    end
+  end
+end


### PR DESCRIPTION
## 概要

本番 (mulukhiya / 5.24.0) で `FeedUpdateWorker` が `NoMethodError: undefined method 'each' for nil` でクラッシュした件 (#4377 / Sentry MULUKHIYA-TOOT-PROXY-26) の修正。

## 原因

[rss20_feed_renderer.rb](app/lib/mulukhiya/renderer/rss20_feed_renderer.rb) の `cache` が CustomFeed コマンド (cure-api 等) の stdout を `JSON.parse` し、その結果をそのまま ginseng の `entries=` に渡していた。コマンドが `null` を出力すると `JSON.parse` が `nil` を返し、ginseng 側 `entries.each` が `nil.each` で落ちる。コマンドは exit 0 のため status ガードもすり抜ける。`retry: false` のため 1 回で確実に欠損する。

## 変更点

- `parse_entries` を新設し、`JSON.parse` 結果が Array でなければ（nil / 非配列 / `JSON::ParserError`）空配列へ正規化し warn ログを残す
- ユニットテスト `test/unit/renderer/rss20_feed_renderer.rb` を追加（array / null / 非配列 / 不正 JSON / entries= 経由の安全性）。DB 未設定環境では `disable?` でスキップ

## 関連
- #4377（本体）
- Sentry MULUKHIYA-TOOT-PROXY-26（経緯コメント記録済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)