### PR TITLE
fix: #4380 Misskey お気に入りの上流 400 を冪等成功として扱う

### DIFF
--- a/app/lib/mulukhiya/controller/misskey_controller.rb
+++ b/app/lib/mulukhiya/controller/misskey_controller.rb
@@ -88,6 +88,16 @@ module Mulukhiya
       @renderer.status = reporter.response.code
       return @renderer.to_s
     rescue Ginseng::GatewayError => e
+      # お気に入りは冪等操作。上流が 400 (大半は ALREADY_FAVORITED) を返しても、
+      # 呼び出し後 note は必ずお気に入り状態にあるため成功として扱う。
+      # Ginseng::HTTP は上流ボディを捨てて "Bad response 400" にするため
+      # ALREADY_FAVORITED か否かは判別できないが、favorites/create の 400 は
+      # 実質これに限られる (capsicum #565)。
+      if e.source_status == 400
+        @renderer.message = {}
+        @renderer.status = 200
+        return @renderer.to_s
+      end
       e.alert unless e.source_status == 401
       @renderer.message = {error: e.message}
       @renderer.status = e.source_status


### PR DESCRIPTION
Closes #4380

## 概要

既にお気に入り済みの note への `POST /api/notes/favorites/create` で、上流 Misskey は `400 ALREADY_FAVORITED` を返す。しかし `Ginseng::HTTP` が上流ボディを捨てて `"Bad response 400"` の `GatewayError` にするため、mulukhiya のコントローラ時点で `ALREADY_FAVORITED` か否かを判別できず、クライアントには `{error: "Bad response 400"}`（status 400）として届き「操作に失敗しました」と誤表示される（capsicum #565）。

## 変更

お気に入りは冪等操作（呼び出し後、note は必ずお気に入り状態）なので、`favorites/create` の上流 400 を **200 + 空ボディ**の成功として扱う。401 等それ以外のステータスは従来どおり surface させる。

```ruby
rescue Ginseng::GatewayError => e
  if e.source_status == 400
    @renderer.message = {}
    @renderer.status = 200
    return @renderer.to_s
  end
  e.alert unless e.source_status == 401
  ...
```

## トレードオフ

`NO_SUCH_NOTE`（不正 noteId）も 400 のため success に丸まる。ただし Ginseng::HTTP が上流コードを捨てる以上、controller では判別不能。本来は ginseng-core 側で `GatewayError` に上流 response を保持させ `ALREADY_FAVORITED` のみ握りつぶすのが正攻法だが、影響範囲が大きいため本 PR は controller 内で完結する簡潔策を採った（#4380 の対応案 1）。

## 検証

- 構文: `ruby -c` OK
- この作業端末は ruby バージョン不整合 (.ruby-version=4.0.5 / gem は 4.0.4) のため rubocop/minitest をローカル実行できず、CI とステージング検証に委ねる
- ステージング再現手順: capsicum で mulukhiya 導入 Misskey の既お気に入り投稿に再度お気に入り → 「操作に失敗しました」が出ないこと