### PR TITLE
docs: #4351 runbook ロールアウト方針を Gate 0 本番先行フローに整合させる

### DIFF
--- a/docs/media-catalog-index-plan.md
+++ b/docs/media-catalog-index-plan.md
@@ -208,10 +208,15 @@ EXPLAIN 改善を確認してから、chubo2 配下の zugoga overlay で
 
 ## ロールアウト方針
 
-daisskey 先行事例に準拠:
+daisskey 先行事例に準拠しつつ、**EXPLAIN ベースライン・候補適用の検証は本番で先行する**
+（ステージング dev 系は本番と桁違いに少データで性能・index 検証に使えないため。
+本ドキュメント冒頭および「実行 runbook（#4351）」Gate 0〜2 と同じ方針）:
 
-- 検証は dev 系（ステージング）で先行。効果確認後に本番 Mastodon 3 台
-  （shallu / zugoga / lbock）へ `CREATE INDEX CONCURRENTLY` を SQL 直適用。
+- 検証〜適用は **zugoga 本番で先行**（Gate 0 で本番 EXPLAIN ベースライン取得 →
+  Gate 1 で候補 A を `CREATE INDEX CONCURRENTLY` 直適用・再計測 → Gate 2 で
+  overlay flip と観測）。dev 系での事前検証は行わない。
+- zugoga で効果を確認後、残る本番 Mastodon（shallu / lbock）へ同手順を
+  横展開（#4352）。各台で本番 EXPLAIN を取り直す。
 - 恒久反映が必要なら `pooza/mastodon` の feature ブランチに
   `IF NOT EXISTS` 化した migration を起票（直適用済みインデックスと冪等共存）。
   **upstream Mastodon の migration / `db/schema.rb` と名前衝突しないこと**を


### PR DESCRIPTION
## 概要

media_catalog index 計画 runbook の「ロールアウト方針」節が dev/staging 先行検証を指示しており、ドキュメント冒頭および「実行 runbook（#4351）」Gate 0〜2 の「ステージングは少データで使えないため zugoga 本番で先行 EXPLAIN」方針と矛盾していた。

Codex review (PR #4376, P2) の指摘に対応。

## 変更

- 「ロールアウト方針」を本番先行フローに書き換え:
  - 検証〜適用は zugoga 本番で先行（Gate 0 ベースライン → Gate 1 候補 A 適用 → Gate 2 overlay flip）
  - zugoga 確認後に shallu / lbock へ横展開（#4352）、各台で本番 EXPLAIN を取り直す
- dev 系での事前検証を行わない旨を明記し Gate 0 フローと整合

## 関連

- #4351 / #4323
- Codex 指摘: PR #4376

🤖 Generated with [Claude Code](https://claude.com/claude-code)