### PR TITLE
fix: #4379 harness 注入値を config.reload を跨いで保持する

### DIFF
--- a/app/lib/mulukhiya/test_harness.rb
+++ b/app/lib/mulukhiya/test_harness.rb
@@ -14,13 +14,18 @@ module Mulukhiya
     end
 
     # 接続情報を config に流し込む。適用したコントローラの接続情報を返す（無ければ nil）。
+    # TestCase#teardown の `config.reload` を跨いで残るよう、フラットキー代入ではなく
+    # raw['local'] 層へ deep-merge してから reload する。reload は raw のキャッシュから
+    # 再適用するため、フラットキー代入だけだと毎テスト巻き戻ってしまう。
     def apply!
       info = connections
       return nil unless type = target_controller(info)
       return nil unless conn = info[type]
-      config['/controller'] = type
-      config["/#{type}/url"] = conn[:url]
-      config['/agent/test/token'] = conn[:token]
+      merge_local(
+        'controller' => type,
+        type => {'url' => conn[:url]},
+        'agent' => {'test' => {'token' => conn[:token]}},
+      )
       return conn
     end
 
@@ -35,6 +40,13 @@ module Mulukhiya
     end
 
     private
+
+    # raw['local'] 層に deep-merge して reload する（config.reload を跨いで残す）。
+    def merge_local(values)
+      raw = config.raw
+      raw['local'] = Ginseng::Config.deep_merge(raw['local'] || {}, values)
+      config.reload
+    end
 
     # 直接 ENV (README 推奨の `source .env.test`) を優先し、足りない分を
     # MULUKHIYA_HARNESS_DIR 配下の <controller>/.env.test から補う。

--- a/docs/test-harness.md
+++ b/docs/test-harness.md
@@ -26,6 +26,29 @@ MASTODON_ACCESS_TOKEN=xxxxxxxx...
 - **`MULUKHIYA_HARNESS_DIR`**: ハーネスのルートを指すと、`<controller>/.env.test`
   を自動で読み込む（直接 ENV があればそちらを優先）。
 
+## Mastodon DB への直接接続（重要）
+
+mulukhiya は `Mastodon::Account < Sequel::Model(:accounts)` のように **Mastodon の
+Postgres を直接読む** Sequel モデルを持つ。そのため `account` / `status` 系をはじめ
+多くの実インスタンステストは、HTTP（URL+トークン）だけでなく **Mastodon の DB 接続**
+（`config['/postgres/dsn']`）も必要になる（tomato-shrieker 直接経路は純 HTTP なので
+この差がある）。
+
+ハーネスの `compose.yml` は既定では proxy(3000) のみを host に公開し Postgres を
+公開しない。ローカルで DB 依存テストまで動かすには:
+
+1. ハーネスの DB を host に公開する（compose override で `127.0.0.1:5433:5432` を publish）。
+2. `config/local.yaml` に DSN を設定:
+
+   ```yaml
+   postgres:
+     dsn: postgres://mastodon:mastodon@127.0.0.1:5433/mastodon_production
+   ```
+
+> ハーネス側で Postgres を公開し `.env.test` に DB DSN を出力する恒久対応、
+> および `info` エージェントアカウント・公開投稿の provisioning は chubo2 側の
+> 後続課題（harness を mulukhiya の全テスト要件に合わせる）。
+
 ## 手順（Mastodon）
 
 ```sh

--- a/test/unit/lib/test_harness.rb
+++ b/test/unit/lib/test_harness.rb
@@ -9,10 +9,13 @@ module Mulukhiya
     def setup
       @saved = ENV_KEYS.to_h {|key| [key, ENV.fetch(key, nil)]}
       ENV_KEYS.each {|key| ENV.delete(key)}
+      # apply! は raw['local'] を恒久変更するため、退避して後続テストへの漏れを防ぐ。
+      @saved_local = config.raw['local']&.dup
     end
 
     def teardown
       @saved.each {|key, value| value.nil? ? ENV.delete(key) : ENV[key] = value}
+      config.raw['local'] = @saved_local
       super
     end
 


### PR DESCRIPTION
## 概要

#4379（PR #4385）で追加した `Mulukhiya::TestHarness` を**実際にハーネス相手に動かしたところ、全くテストが走っていなかった**ため修正する。

## 不具合

`apply!` は接続情報をフラットキー代入（`config['/agent/test/token'] = ...`）で注入していたが、`TestCase#teardown` の `config.reload` が `raw` キャッシュ層から flat キーを再適用するため、**最初のテストの teardown 後に harness 値が巻き戻り**、2 件目以降は従来どおり全スキップしていた（`account_class.test_token` が nil → `disable?` true）。assertions 0 のまま「100% passed」に見えるため気付きにくい。

## 修正

`apply!` を **`raw['local']` 層への deep-merge + `config.reload`** に変更。`reload` は raw キャッシュから再適用するため、harness 値が reload を跨いで残る。

```ruby
def merge_local(values)
  raw = config.raw
  raw['local'] = Ginseng::Config.deep_merge(raw['local'] || {}, values)
  config.reload
end
```

- `TestHarnessTest` に `raw['local']` の退避/復元を追加（merge_local が恒久変更するため後続テストへの漏れを防ぐ）。
- `docs/test-harness.md` に「mulukhiya は Mastodon DB を直接読む Sequel モデルを持つため、account/status 系は URL+トークンに加え `postgres.dsn` も必要」を追記。

## 動作確認（実機ハーネス）

chubo2 fedi-test-harness/mastodon を起動し、`MULUKHIYA_HARNESS_DIR` 経由で実行:

| | assertions | 結果 |
|---|---|---|
| 修正前 | **0** | 全スキップ（巻き戻り） |
| 修正後 | **110+** | access_token / toot_parser / account / status が実インスタンス相手に実行 |

残る 2 failures（`test_info_account` / `test_uri`）はハーネスのデータ provisioning 起因（info エージェントアカウント未作成 / ローカル status の uri カラム null）で、配線ロジックの問題ではない。chubo2 側の harness 拡張で対応予定。

- test_harness 単体: 9 tests green、lint green。

## 関連

- #4379 / PR #4385（本不具合の作り込み元）

🤖 Generated with [Claude Code](https://claude.com/claude-code)