### PR TITLE
feat: #4379 harness の DB DSN / info トークンを自動配線する

### DIFF
--- a/app/lib/mulukhiya/test_harness.rb
+++ b/app/lib/mulukhiya/test_harness.rb
@@ -21,21 +21,35 @@ module Mulukhiya
       info = connections
       return nil unless type = target_controller(info)
       return nil unless conn = info[type]
-      merge_local(
-        'controller' => type,
-        type => {'url' => conn[:url]},
-        'agent' => {'test' => {'token' => conn[:token]}},
-      )
+      agent = {'test' => {'token' => conn[:token]}}
+      agent['info'] = {'token' => conn[:info_token]} if conn[:info_token]
+      values = {'controller' => type, type => {'url' => conn[:url]}, 'agent' => agent}
+      # mulukhiya は Mastodon の DB を直読みするため DSN があれば postgres.dsn も配線。
+      values['postgres'] = {'dsn' => conn[:db_dsn]} if conn[:db_dsn]
+      merge_local(values)
+      # DB 接続はブート時 (apply! より前) に確立されるため、DSN を後から差した場合は
+      # Sequel のデフォルト DB を張り直す（モデルがロードされる前に必要）。
+      # 到達不可でも apply! 自体は落とさない（DB 依存テストは従来どおりスキップされる）。
+      begin
+        environment_class.dbms_class&.connect if conn[:db_dsn]
+      rescue => e
+        warn "TestHarness: DB 接続に失敗したためスキップ: #{e.message}"
+      end
       return conn
     end
 
-    # 利用可能な接続情報を {'mastodon' => {url:, token:}, ...} で返す。
+    # 利用可能な接続情報を {'mastodon' => {url:, token:, info_token:, db_dsn:}, ...} で返す。
     def connections
       env = harness_env
       return PREFIXES.each_with_object({}) do |(type, prefix), dest|
         url = env["#{prefix}_URL"]
         token = env["#{prefix}_ACCESS_TOKEN"]
-        dest[type] = {url:, token:} if url.present? && token.present?
+        next unless url.present? && token.present?
+        dest[type] = {
+          url:, token:,
+          info_token: env["#{prefix}_INFO_ACCESS_TOKEN"].presence,
+          db_dsn: env["#{prefix}_DB_DSN"].presence
+        }
       end
     end
 

--- a/docs/test-harness.md
+++ b/docs/test-harness.md
@@ -34,20 +34,24 @@ Postgres を直接読む** Sequel モデルを持つ。そのため `account` / 
 （`config['/postgres/dsn']`）も必要になる（tomato-shrieker 直接経路は純 HTTP なので
 この差がある）。
 
-ハーネスの `compose.yml` は既定では proxy(3000) のみを host に公開し Postgres を
-公開しない。ローカルで DB 依存テストまで動かすには:
+chubo2#48 で harness 側が **db / redis を host に公開**（`127.0.0.1:5433` /
+`127.0.0.1:6380`）し、`.env.test` に接続情報を出力するようになった:
 
-1. ハーネスの DB を host に公開する（compose override で `127.0.0.1:5433:5432` を publish）。
-2. `config/local.yaml` に DSN を設定:
+```sh
+MASTODON_INFO_ACCESS_TOKEN=...   # info エージェント (config['/agent/info/token'])
+MASTODON_DB_DSN=postgres://mastodon:mastodon@127.0.0.1:5433/mastodon_production
+MASTODON_REDIS_DSN=redis://127.0.0.1:6380
+```
 
-   ```yaml
-   postgres:
-     dsn: postgres://mastodon:mastodon@127.0.0.1:5433/mastodon_production
-   ```
+`Mulukhiya::TestHarness` はこれらを読み取り、`postgres.dsn` と `agent.info.token` も
+自動で配線する（DSN を差した後に Sequel のデフォルト DB を張り直す）。したがって
+**`config/local.yaml` への DSN 手書きは不要**で、harness を `setup.sh` で立てて
+`MULUKHIYA_HARNESS_DIR` を渡すだけで DB 依存テストまで動く。local.yaml に要るのは
+harness が用意しないもの（`crypt.password` 等）のみ。
 
-> ハーネス側で Postgres を公開し `.env.test` に DB DSN を出力する恒久対応、
-> および `info` エージェントアカウント・公開投稿の provisioning は chubo2 側の
-> 後続課題（harness を mulukhiya の全テスト要件に合わせる）。
+> 既知: ローカル Mastodon の status は `uri` カラムが null のことがあり、
+> `StatusTest#test_uri` が落ちる（harness 起因か mulukhiya テスト側で吸収すべきか
+> 要切り分け。chubo2#48 で追跡）。
 
 ## 手順（Mastodon）
 

--- a/test/unit/lib/test_harness.rb
+++ b/test/unit/lib/test_harness.rb
@@ -3,7 +3,9 @@ require 'tmpdir'
 module Mulukhiya
   class TestHarnessTest < TestCase
     ENV_KEYS = [
-      'MASTODON_URL', 'MASTODON_ACCESS_TOKEN', 'MISSKEY_URL', 'MISSKEY_ACCESS_TOKEN', 'MULUKHIYA_HARNESS_DIR'
+      'MASTODON_URL', 'MASTODON_ACCESS_TOKEN', 'MASTODON_INFO_ACCESS_TOKEN', 'MASTODON_DB_DSN',
+      'MISSKEY_URL', 'MISSKEY_ACCESS_TOKEN', 'MISSKEY_INFO_ACCESS_TOKEN', 'MISSKEY_DB_DSN',
+      'MULUKHIYA_HARNESS_DIR'
     ].freeze
 
     def setup
@@ -99,6 +101,39 @@ module Mulukhiya
 
       assert_nil(TestHarness.apply!)
       assert_equal('mastodon', config['/controller'])
+    end
+
+    def test_connections_captures_info_token_and_db_dsn
+      ENV['MASTODON_URL'] = 'http://localhost:3000'
+      ENV['MASTODON_ACCESS_TOKEN'] = 'mastodon_token'
+      ENV['MASTODON_INFO_ACCESS_TOKEN'] = 'info_token'
+      ENV['MASTODON_DB_DSN'] = 'postgres://mastodon:mastodon@127.0.0.1:5433/mastodon_production'
+      info = TestHarness.new.connections['mastodon']
+
+      assert_equal('info_token', info[:info_token])
+      assert_equal('postgres://mastodon:mastodon@127.0.0.1:5433/mastodon_production', info[:db_dsn])
+    end
+
+    def test_apply_wires_info_token_and_postgres_dsn
+      config['/controller'] = 'mastodon'
+      ENV['MASTODON_URL'] = 'http://localhost:3000'
+      ENV['MASTODON_ACCESS_TOKEN'] = 'mastodon_token'
+      ENV['MASTODON_INFO_ACCESS_TOKEN'] = 'info_token'
+      ENV['MASTODON_DB_DSN'] = 'postgres://u:p@127.0.0.1:5433/db'
+      TestHarness.apply!
+
+      assert_equal('info_token', config['/agent/info/token'])
+      assert_equal('postgres://u:p@127.0.0.1:5433/db', config['/postgres/dsn'])
+    end
+
+    def test_apply_omits_optional_fields_when_absent
+      config['/controller'] = 'mastodon'
+      ENV['MASTODON_URL'] = 'http://localhost:3000'
+      ENV['MASTODON_ACCESS_TOKEN'] = 'mastodon_token'
+      conn = TestHarness.apply!
+
+      assert_nil(conn[:info_token])
+      assert_nil(conn[:db_dsn])
     end
   end
 end


### PR DESCRIPTION
## 概要

chubo2#48（PR pooza/chubo2#49）で harness が `.env.test` に出力するようになった接続情報を `Mulukhiya::TestHarness` が読み取り、自動配線する。これで harness を `setup.sh` で立てて `MULUKHIYA_HARNESS_DIR` を渡すだけで、DB 依存テスト（account/status 等）や info_account 系まで実インスタンス相手に動く。

## 変更

- `connections` が `MASTODON_INFO_ACCESS_TOKEN`（info_token）/ `MASTODON_DB_DSN`（db_dsn）も拾う。
- `apply!` が `agent.info.token` と `postgres.dsn` を配線。DB 接続はブート時（apply! より前）に確立されるため、DSN を後から差した場合は **Sequel のデフォルト DB を張り直す**（モデルロード前に必要）。到達不可でも apply! は落とさず警告のみ（DB 依存テストは従来どおりスキップ）。
- ユニットテスト追加（info_token/db_dsn の取得・配線・任意項目の省略）。
- `docs/test-harness.md` を「DB/info も自動配線・local.yaml への DSN 手書き不要」に更新。

## 動作確認（実機 harness）

`MULUKHIYA_HARNESS_DIR` 経由のみ（local.yaml は crypt.password 等のみ）:

| | assertions | failures |
|---|---|---|
| #4386 時点 | 110 | info_account/uri の 2 |
| 本 PR | **113** | **test_uri の 1 のみ** |

`info_account` / `recent_status` が通過。残る `test_uri` はローカル Mastodon の status の `uri` カラムが null であることに起因（mulukhiya テスト側で吸収すべきか要切り分け、chubo2#48 で追跡）。ユニットテスト（harness env 無し）: 12 tests / 0 失敗、lint green。

## 依存

- chubo2#48 / pooza/chubo2#49（harness が DB公開+DSN出力 / info account / 公開投稿を提供）

## 関連

- #4379 / #4385 / #4386

🤖 Generated with [Claude Code](https://claude.com/claude-code)