### PR TITLE
fix: #4389 TestHarness が DSN 上書き後に Postgres singleton を張り直す

### DIFF
--- a/app/lib/mulukhiya/dbms/postgres.rb
+++ b/app/lib/mulukhiya/dbms/postgres.rb
@@ -12,6 +12,20 @@ module Mulukhiya
       return instance if config?
     end
 
+    # singleton インスタンスが生成済みか。reconnect の張り直し判定に使う。
+    def self.connected?
+      return !instance_variable_get(:@singleton__instance__).nil?
+    end
+
+    # config 変更後に DB 接続を張り直す。Postgres は Singleton のため、既存
+    # インスタンスは生成時の DSN を保持し続け connect では更新されない。既存接続を
+    # 切ってから singleton をリセットし、現在の config['/postgres/dsn'] で繋ぎ直す。
+    def self.reconnect
+      instance.connection.disconnect if connected?
+      Singleton.__init__(self)
+      return connect
+    end
+
     def self.exec(name, params = {})
       return instance.exec(name, params)
     end

--- a/app/lib/mulukhiya/test_harness.rb
+++ b/app/lib/mulukhiya/test_harness.rb
@@ -27,11 +27,12 @@ module Mulukhiya
       # mulukhiya は Mastodon の DB を直読みするため DSN があれば postgres.dsn も配線。
       values['postgres'] = {'dsn' => conn[:db_dsn]} if conn[:db_dsn]
       merge_local(values)
-      # DB 接続はブート時 (apply! より前) に確立されるため、DSN を後から差した場合は
-      # Sequel のデフォルト DB を張り直す（モデルがロードされる前に必要）。
+      # DB 接続はブート時 (apply! より前、mulukhiya.rb の dbms_class&.connect) に
+      # 確立される。Postgres は Singleton のため connect では既存インスタンスが返るだけで
+      # 後から差した DSN を反映しない。reconnect で singleton を張り直し注入 DSN を使わせる。
       # 到達不可でも apply! 自体は落とさない（DB 依存テストは従来どおりスキップされる）。
       begin
-        environment_class.dbms_class&.connect if conn[:db_dsn]
+        environment_class.dbms_class&.reconnect if conn[:db_dsn]
       rescue => e
         warn "TestHarness: DB 接続に失敗したためスキップ: #{e.message}"
       end

--- a/test/unit/dbms/postgres.rb
+++ b/test/unit/dbms/postgres.rb
@@ -1,0 +1,55 @@
+module Mulukhiya
+  class PostgresTest < TestCase
+    class FakeConnection
+      attr_reader :disconnected
+
+      def disconnect
+        @disconnected = true
+      end
+    end
+
+    class FakeInstance
+      attr_reader :connection
+
+      def initialize(connection)
+        @connection = connection
+      end
+    end
+
+    def teardown
+      Singleton.__init__(Postgres)
+      super
+    end
+
+    def test_connected_reflects_singleton_state
+      Singleton.__init__(Postgres)
+
+      assert_false(Postgres.connected?)
+
+      Postgres.instance_variable_set(:@singleton__instance__, FakeInstance.new(FakeConnection.new))
+
+      assert_predicate(Postgres, :connected?)
+    end
+
+    # config['/postgres/dsn'] 未設定なら reconnect は既存接続を切って singleton を
+    # リセットし、再接続は試みない (connect が nil を返す)。
+    def test_reconnect_disconnects_and_resets_existing_instance
+      config['/postgres/dsn'] = nil
+      conn = FakeConnection.new
+      Postgres.instance_variable_set(:@singleton__instance__, FakeInstance.new(conn))
+
+      assert_nil(Postgres.reconnect)
+      assert(conn.disconnected)
+      assert_false(Postgres.connected?)
+    end
+
+    # 既存インスタンスが無い (ブート時 DSN 無し) 場合は切断をスキップして繋ぎ直す。
+    def test_reconnect_without_existing_instance_is_safe
+      config['/postgres/dsn'] = nil
+      Singleton.__init__(Postgres)
+
+      assert_nil(Postgres.reconnect)
+      assert_false(Postgres.connected?)
+    end
+  end
+end


### PR DESCRIPTION
## 概要

#4389 の対応。PR #4387 への Codex レビュー (P2) 指摘。

`Mulukhiya::Postgres` は `include Singleton` のため `connect` (= `instance`) は既存インスタンスを返すだけで、`TestHarness#apply!` が後から差した `config['/postgres/dsn']` を反映しなかった。boot 時 ([mulukhiya.rb の `dbms_class&.connect`](https://github.com/pooza/mulukhiya-toot-proxy/blob/develop/app/lib/mulukhiya.rb#L111)) に旧 `local.yaml` の DSN で singleton が確立済みだと、DB 依存テストが意図と異なるデータベースに対して silent に走る恐れがあった（コメントは「張り直す」と書いてあったが実際には張り直していなかった）。

## 変更

- `Postgres.reconnect` / `Postgres.connected?` を追加。既存接続を `disconnect` → `Singleton.__init__` で singleton をリセット → 現在の DSN で繋ぎ直す。
- `TestHarness#apply!` は `connect` ではなく `reconnect` を呼ぶ。
- 誤解を招くコメントを実態に合わせて修正。
- `test/unit/dbms/postgres.rb` に singleton リセット挙動のテストを追加。

## テスト

- `ruby bin/test.rb postgres` 5 tests 100% passed
- `ruby bin/test.rb test_harness` 12 tests 100% passed（reconnect 経路でも従来どおり接続失敗を握りつぶしスキップ）
- `rubocop` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)