### PR TITLE
fix: #4362 Sidekiq 内部ログを syslog へ出し no-reader pipe 消失を防ぐ

### DIFF
--- a/app/initializer/sidekiq.rb
+++ b/app/initializer/sidekiq.rb
@@ -1,13 +1,30 @@
 $LOAD_PATH.unshift(File.join(File.expand_path('../..', __dir__), 'app/lib'))
 
+# FreeBSD rc.d の daemon(8) 起動では FD 1/2 が no-reader pipe になり、書き込みが
+# カーネル buffer 枯渇後に discard される (#4362)。puma initializer と同じく壊れた
+# stdio を /dev/null に張り替えて EPIPE / ログ消失を防ぐ。
+[$stdout, $stderr].each do |io|
+  next if io.tty?
+  begin
+    io.flush
+  rescue Errno::EPIPE, IOError
+    io.reopen(File::NULL, 'w')
+  end
+end
+
 require 'mulukhiya'
+require 'syslog/logger'
 module Mulukhiya
   daemon = SidekiqDaemon.new
   config = YAML.load_file(daemon.config_cache_path).deep_symbolize_keys
   Sidekiq.configure_server do |sidekiq|
     sidekiq.redis = {url: config.dig(:redis, :dsn)}
     sidekiq.concurrency = config[:concurrency]
-    sidekiq.logger = Sidekiq::Logger.new($stdout)
+    # Sidekiq 内部ログ (retry / scheduler / boot 等) を $stdout ではなく syslog へ。
+    # Ginseng::Logger と同じ ident (Package.name) / facility (LOG_USER) を使い、puma・
+    # WorkerLoggingMiddleware と同じ /var/log/mulukhiya-toot-proxy.log に集約する (#4362)。
+    # WorkerLoggingMiddleware が出すジョブライフサイクルログ (#4079) はそのまま維持。
+    sidekiq.logger = Syslog::Logger.new(Package.name)
     sidekiq.logger.level = config.dig(:logger, :level)
     sidekiq.logger.formatter = Sidekiq::Logger::Formatters::JSON.new
     sidekiq.server_middleware do |chain|


### PR DESCRIPTION
## 概要

#4362 対応。FreeBSD 3 台（zugoga / shallu / lbock）で Sidekiq の内部ログが消失していた問題。

## 実機調査による前提の訂正

zugoga で `/var/log/mulukhiya-toot-proxy.log` を確認したところ、**ジョブライフサイクルログ（worker start/done/fail）は 9,500 行以上記録されていた**。これは `WorkerLoggingMiddleware`（#4079, 2026-02-26 導入）が `Mulukhiya::Logger`（syslog）経由で出力しているため。Issue 起票時の「sidekiq 由来は 0 行 / ジョブ稼働ログすべて不可視」は実態と異なっていた。

実際に消失していたのは **Sidekiq の内部 logger（`sidekiq.logger = Sidekiq::Logger.new($stdout)`）の出力のみ**: retry / scheduler enqueue / boot / heartbeat 等。これらは `$stdout`（daemon(8) の no-reader pipe）へ書かれ buffer 枯渇後 discard（grep で retry/scheduler/heartbeat = 0 行を確認）。

## 変更（Option A）

- Sidekiq 内部 logger を `Syslog::Logger.new(Package.name)` に変更。`Ginseng::Logger` と同じ ident (`mulukhiya-toot-proxy`) / facility (`LOG_USER`) のため、puma・middleware と同じ `/var/log/mulukhiya-toot-proxy.log` に集約される。`Syslog::Logger` は block 形式 (`logger.info { }`) と `formatter` 双方に対応するため Sidekiq からの利用に互換（ローカル smoke test 済み）。
- puma initializer と同じ **EPIPE ガード**（壊れた `$stdout`/`$stderr` を `/dev/null` 再オープン）を追加。

## 検証

- ローカル: 構文 OK / rubocop クリーン / `Syslog::Logger` + Sidekiq JSON formatter + level=1 の smoke test（info / block / warn）成功
- 本番: zugoga に先行デプロイ → sidekiq 再起動 → boot / scheduler / retry ログがファイルに出ることを確認後、shallu / lbock へ展開（デプロイ後に結果コメント）

## 関連
- #4079（WorkerLoggingMiddleware、ジョブライフサイクルログ）
- #4264（起票元 daemon 調査）

🤖 Generated with [Claude Code](https://claude.com/claude-code)