### PR TITLE
feat: #4397 読み付き単語サジェスト API (word/suggest)

### DIFF
--- a/app/lib/mulukhiya/contract/word_suggest_contract.rb
+++ b/app/lib/mulukhiya/contract/word_suggest_contract.rb
@@ -1,0 +1,8 @@
+module Mulukhiya
+  class WordSuggestContract < Contract
+    params do
+      required(:q).value(:string)
+      optional(:limit)
+    end
+  end
+end

--- a/app/lib/mulukhiya/controller/api_controller.rb
+++ b/app/lib/mulukhiya/controller/api_controller.rb
@@ -690,6 +690,24 @@ module Mulukhiya
       return @renderer.to_s
     end
 
+    get '/word/suggest' do
+      dictionary = PronunciationDictionary.new
+      raise Ginseng::NotFoundError, 'Not Found' unless dictionary.enabled?
+      errors = WordSuggestContract.new.exec(params)
+      if errors.present?
+        @renderer.status = 422
+        @renderer.message = {errors:}
+      else
+        @renderer.message = {candidates: dictionary.suggest(params[:q], limit: params[:limit])}
+      end
+      return @renderer.to_s
+    rescue => e
+      e.log
+      @renderer.status = e.status
+      @renderer.message = {error: e.message}
+      return @renderer.to_s
+    end
+
     get '/piefed/communities' do
       raise Ginseng::NotFoundError, 'Not Found' unless controller_class.piefed?
       raise Ginseng::AuthError, 'Unauthorized' unless sns.account

--- a/app/lib/mulukhiya/dynamic_features.rb
+++ b/app/lib/mulukhiya/dynamic_features.rb
@@ -8,6 +8,9 @@ module Mulukhiya
   #                        に一本化するため合流 (#4343)
   #   - program_editable : 番組表エディタ (livecure かつ auto_update 無効) で書き込み
   #                        API が利用可能か。WebUI の UI 出し分けに使う (#4272)
+  #   - word_suggest     : 読み付き単語サジェスト (#4397)。word_suggest/urls が設定
+  #                        されているか。capsicum の UI 出し分けに使う。フラグの正本を
+  #                        URL 設定の有無に一本化し二重管理を避ける
   #
   # 新しい動的フラグ (例: spotify_linked) を増やす際は REGISTRY に 1 行追加する。
   class DynamicFeatures
@@ -19,6 +22,7 @@ module Mulukhiya
       'program_editable' => lambda {|_sns|
         Environment.controller_class.livecure? && !Program.instance.auto_update?
       },
+      'word_suggest' => ->(_sns) {PronunciationDictionary.new.enabled?},
     }.freeze
 
     def initialize(sns)

--- a/app/lib/mulukhiya/pronunciation_dictionary.rb
+++ b/app/lib/mulukhiya/pronunciation_dictionary.rb
@@ -51,10 +51,8 @@ module Mulukhiya
         next unless rank
         [rank, entry['reading'].to_s.length, entry]
       end
-      return scored
-        .sort_by {|rank, length, entry| [rank, length, entry['reading'].to_s]}
-        .first(limit)
-        .map {|_, _, entry| present(entry)}
+      ranked = scored.sort_by {|rank, length, entry| [rank, length, entry['reading'].to_s]}
+      return ranked.first(limit).map {|_, _, entry| present(entry)}
     end
 
     def update

--- a/app/lib/mulukhiya/pronunciation_dictionary.rb
+++ b/app/lib/mulukhiya/pronunciation_dictionary.rb
@@ -1,0 +1,220 @@
+module Mulukhiya
+  # capsicum 投稿サジェスト (#4397 / capsicum#614) 向けの読み付き単語辞書。
+  #
+  # サーバー固有の GAS エンドポイント (precure.ml /api/dic/v1/pron.json /
+  # mstdn.delmulin.com /api/dic/v1/pronunciations.json 等) が出力する
+  # [{word, pronunciation, category?}] を取り込み、読み (カタカナ) で引ける
+  # 候補リストとして Redis にキャッシュする。更新は
+  # PronunciationDictionaryUpdateWorker が定期実行する。
+  #
+  # データの正本は各サーバー 1 枚のスプレッドシート (GAS が dic.json と
+  # pron.json を同一シートから投影している)。モロヘイヤは揮発キャッシュのみを
+  # 持ち、辞書の写しを永続化しない (二重管理の回避)。
+  class PronunciationDictionary
+    include Package
+
+    REDIS_KEY = 'pronunciation_dictionary'.freeze
+    DEFAULT_FETCH_MAX_BYTES = 1_048_576
+    DEFAULT_FETCH_TIMEOUT = 30
+    DEFAULT_LIMIT = 20
+    MAX_LIMIT = 100
+
+    def initialize
+      @http = HTTP.new
+    end
+
+    def enabled?
+      return uris.any?
+    end
+
+    def uris
+      return config['/word_suggest/urls'].filter_map {|v| Ginseng::URI.parse(v)} rescue []
+    end
+
+    def entries
+      @entries ||= cached_entries || (update && cached_entries) || []
+    end
+
+    def size
+      return entries.size
+    end
+
+    # 読み (主にひらがな) で前方一致 → 表層前方一致 → 部分一致の順に候補を返す。
+    # surface / reading は固定で返し、category はソースにあれば添える (任意)。
+    def suggest(query, limit: DEFAULT_LIMIT)
+      surface_query = query.to_s.strip
+      reading_query = normalize_reading(surface_query)
+      return [] if reading_query.empty?
+      limit = clamp_limit(limit)
+      scored = entries.filter_map do |entry|
+        rank = match_rank(entry, reading_query, surface_query)
+        next unless rank
+        [rank, entry['reading'].to_s.length, entry]
+      end
+      return scored
+        .sort_by {|rank, length, entry| [rank, length, entry['reading'].to_s]}
+        .first(limit)
+        .map {|_, _, entry| present(entry)}
+    end
+
+    def update
+      entries = fetch_remote
+      return nil unless entries
+      return save(entries)
+    end
+
+    def invalidate_cache
+      @entries = nil
+      return redis.unlink(REDIS_KEY)
+    end
+
+    def redis
+      @redis ||= Redis.new
+      return @redis
+    end
+
+    private
+
+    # 候補マッチの優先度。小さいほど上位。マッチしなければ nil。
+    def match_rank(entry, reading_query, surface_query)
+      reading = entry['reading'].to_s
+      surface = entry['surface'].to_s
+      return 0 if reading.start_with?(reading_query)
+      return 1 if surface_query.present? && surface.start_with?(surface_query)
+      return 2 if reading.include?(reading_query)
+      return nil
+    end
+
+    def present(entry)
+      result = {surface: entry['surface'], reading: entry['reading']}
+      result[:category] = entry['category'] if entry['category'].present?
+      return result
+    end
+
+    # ひらがな↔カタカナ・全半角の揺れを吸収しカタカナへ正規化する。ユーザーが
+    # 打鍵できるのはひらがな読みなので、検索キーと辞書側 pronunciation を同じ
+    # カタカナ空間に寄せて突き合わせる (proxy 哲学に従い正規化はモロヘイヤ側で
+    # 吸収する)。
+    def normalize_reading(value)
+      return value.to_s.nfkc.tr('ぁ-ゖ', 'ァ-ヶ').strip
+    end
+
+    def clamp_limit(limit)
+      limit = limit.to_i
+      return DEFAULT_LIMIT unless limit.positive?
+      return [limit, MAX_LIMIT].min
+    end
+
+    def fetch_remote
+      entries = []
+      success = 0
+      uris.each do |uri|
+        rows = fetch_one(uri)
+        next unless rows
+        entries.concat(rows)
+        success += 1
+      rescue => e
+        # 単一 URL の取得失敗で update 全体が落ちるのを防ぐ。失敗 URL のみ skip。
+        e.log(url: uri.to_s)
+      end
+      # 全 URL が失敗した場合は last-known-good を保持するため nil を返し、上位の
+      # update() で save をスキップする (GAS の一過性障害で候補が全消失するのを防ぐ)。
+      return nil if success.zero?
+      return dedup(entries)
+    end
+
+    def fetch_one(uri)
+      return nil unless valid_content_length?(uri)
+      response = @http.get(uri, timeout: fetch_timeout)
+      return nil unless valid_response_size?(response, uri)
+      parsed = response.parsed_response
+      return nil unless valid_schema?(parsed, uri)
+      return normalize_entries(parsed)
+    end
+
+    # 複数サーバーで同一の表層形+読みが重複した場合は先勝ちで 1 件に畳む。
+    def dedup(entries)
+      seen = Set.new
+      return entries.select {|entry| seen.add?([entry['surface'], entry['reading']])}
+    end
+
+    def normalize_entries(parsed)
+      return parsed.filter_map do |row|
+        next unless row.is_a?(Hash)
+        surface = row['word'].to_s.strip
+        reading = normalize_reading(row['pronunciation'])
+        next if surface.empty? || reading.empty?
+        entry = {'surface' => surface, 'reading' => reading}
+        category = row['category'].to_s.strip
+        entry['category'] = category unless category.empty?
+        entry
+      end
+    end
+
+    # HTTParty が本文を丸ごとメモリへ読み込む前に、相手が申告した Content-Length が
+    # max を超えていれば GET せず弾く。Content-Length 不在・HEAD 非対応の場合は判定
+    # 不能としてそのまま GET へ進み、受信後の valid_response_size? を最終防衛線とする。
+    def valid_content_length?(uri)
+      length = @http.head(uri, timeout: fetch_timeout).headers['content-length']
+      return true if length.nil? || length.to_i <= fetch_max_bytes
+      log_oversize(uri, length.to_i, 'word_suggest fetch content-length exceeded max bytes')
+      return false
+    rescue => e
+      e.log(url: uri.to_s)
+      return true
+    end
+
+    def valid_response_size?(response, uri)
+      bytes = response.body.to_s.bytesize
+      return true if bytes <= fetch_max_bytes
+      log_oversize(uri, bytes, 'word_suggest fetch exceeded max bytes')
+      return false
+    end
+
+    def log_oversize(uri, bytes, message)
+      logger.error(message:, url: uri.to_s, bytes:, max_bytes: fetch_max_bytes)
+    end
+
+    def valid_schema?(parsed, uri)
+      valid = parsed.is_a?(Array) && parsed.all? do |row|
+        row.is_a?(Hash) && row.key?('word') && row.key?('pronunciation')
+      end
+      return true if valid
+      logger.error(
+        message: 'word_suggest fetch schema invalid',
+        url: uri.to_s,
+        type: parsed.class.name,
+      )
+      return false
+    end
+
+    def fetch_max_bytes
+      return config['/word_suggest/fetch/max_bytes'] || DEFAULT_FETCH_MAX_BYTES
+    end
+
+    def fetch_timeout
+      return config['/word_suggest/fetch/timeout'] || DEFAULT_FETCH_TIMEOUT
+    end
+
+    def cached_entries
+      raw = redis[REDIS_KEY]
+      return nil unless raw
+      parsed = JSON.parse(raw)
+      return parsed.is_a?(Array) ? parsed : nil
+    rescue => e
+      e.alert
+      return nil
+    end
+
+    def save(entries)
+      @entries = nil
+      redis[REDIS_KEY] = entries.to_json
+      return entries
+    rescue => e
+      # 中途半端なキャッシュを除去し以降の read を fetch フォールバックへ倒す保険。
+      invalidate_cache rescue nil
+      e.alert(entries_size: entries.size)
+      return nil
+    end
+  end
+end

--- a/app/lib/mulukhiya/pronunciation_dictionary.rb
+++ b/app/lib/mulukhiya/pronunciation_dictionary.rb
@@ -98,6 +98,9 @@ module Mulukhiya
     end
 
     def clamp_limit(limit)
+      # limit[]=1 のように配列/ハッシュで渡されると to_i が無く 500 になるため、
+      # スカラー以外・非正値は既定値に倒す (公開クエリを 500 にしない)。
+      return DEFAULT_LIMIT unless limit.respond_to?(:to_i)
       limit = limit.to_i
       return DEFAULT_LIMIT unless limit.positive?
       return [limit, MAX_LIMIT].min

--- a/app/lib/mulukhiya/worker/pronunciation_dictionary_update_worker.rb
+++ b/app/lib/mulukhiya/worker/pronunciation_dictionary_update_worker.rb
@@ -1,0 +1,20 @@
+module Mulukhiya
+  class PronunciationDictionaryUpdateWorker < Worker
+    sidekiq_options retry: false
+
+    def disable?
+      return true unless PronunciationDictionary.new.enabled?
+      return super
+    end
+
+    def perform(params = {})
+      # sidekiq-scheduler は perform_async を介さず Sidekiq::Client.push 直叩きで
+      # enqueue するため、disable? を perform 側でも評価する。
+      return if disable?
+      dictionary = PronunciationDictionary.new
+      dictionary.update
+      log(entries: dictionary.size)
+      return dictionary
+    end
+  end
+end

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -482,6 +482,11 @@ program:
   fetch:
     max_bytes: 1048576
     timeout: 30
+word_suggest:
+  urls: []
+  fetch:
+    max_bytes: 1048576
+    timeout: 30
 remote_host:
   dns:
     timeout: 3
@@ -635,6 +640,9 @@ sidekiq:
     program_update:
       class: Mulukhiya::ProgramUpdateWorker
       every: 1m
+    pronunciation_dictionary_update:
+      class: Mulukhiya::PronunciationDictionaryUpdateWorker
+      every: 10m
     startup_notification:
       class: Mulukhiya::StartupNotificationWorker
       every: 5m

--- a/config/schema/base.yaml
+++ b/config/schema/base.yaml
@@ -270,6 +270,25 @@ properties:
     required:
       - urls
     type: object
+  word_suggest:
+    properties:
+      urls:
+        items:
+          format: uri
+          type: string
+        type: array
+      fetch:
+        properties:
+          max_bytes:
+            minimum: 1
+            type: integer
+          timeout:
+            minimum: 1
+            type: integer
+        type: object
+    required:
+      - urls
+    type: object
   remote_host:
     properties:
       dns:

--- a/docs/api.md
+++ b/docs/api.md
@@ -92,6 +92,7 @@ SNS 本体への転送が失敗した場合、SNS が返したステータスコ
 | `/{controller}/features/feed` | `/feed/list` |
 | `/{controller}/features/announcement` | `/announcement/update` |
 | `/{controller}/features/annict` | `/annict/oauth_uri`, `/annict/auth`, `/tagging/dic/annict/episodes`, `/program/works`, `/program/works/:id/episodes` |
+| `/word_suggest/urls`（features.word_suggest に合流） | `/word/suggest` |
 
 ## モロヘイヤ検出プロトコル
 
@@ -634,6 +635,38 @@ Web Push サブスクリプションを解除する。
   }
 }
 ```
+
+#### GET /mulukhiya/api/word/suggest
+
+読み付き単語サジェスト（劇中ワード補完）。ユーザーが入力したひらがな/カタカナの読みから、辞書登録済みの表層形を引く。IME に変換候補が出ない専門ワード（例: `閃華裂光拳`）を capsicum の投稿サジェスト UI（capsicum#614）から補うための API（#4397）。
+
+`tagging/tag/search` がタグ検索目的で「読み」を返さないのに対し、本 API は読みで引けることが目的。辞書の正本は各サーバー 1 枚のスプレッドシート（GAS が dic.json と pron.json を同一シートから投影）で、モロヘイヤは GAS の出力を Redis に揮発キャッシュするだけ（`PronunciationDictionaryUpdateWorker` が 10 分毎更新）。読み取り専用（DB 書き込みなし）。
+
+- **認証**: 不要
+- **前提条件**: `features.word_suggest` が `true`（= `word_suggest/urls` が設定済み）。未設定サーバーは 404
+- **パラメータ**（クエリ文字列）:
+
+| 名前 | 型 | 必須 | 説明 |
+|------|-----|------|------|
+| `q` | string | 必須 | 入力（主にひらがな読み。表層の前方一致も拾う） |
+| `limit` | integer | 任意 | 最大件数（既定 20、上限 100） |
+
+- **読み正規化**: ひらがな↔カタカナ・全半角の揺れはモロヘイヤ側で吸収（NFKC + ひらがな→カタカナ）。クライアントは素の読みを渡せばよい。
+- **並び順**: 読みの前方一致 → 表層の前方一致 → 読みの部分一致の順、同点は読みが短い順。
+
+**レスポンス例**:
+
+```json
+{
+  "candidates": [
+    { "surface": "愛崎えみる", "reading": "アイサキエミル", "category": "人名" }
+  ]
+}
+```
+
+- `surface`: 挿入する表層形
+- `reading`: 並べ替え・ハイライト用（カタカナ）
+- `category`: 品詞細分類（人名 / 技名 / 作品名 / 一般 等）。スプレッドシートに列がある場合のみ付く**任意**フィールド。capsicum 側のカテゴリ別ブラウズ用。空欄・未整備のサーバーでは省略される
 
 #### GET /mulukhiya/api/announcement/list
 

--- a/docs/capsicum-requirements.md
+++ b/docs/capsicum-requirements.md
@@ -348,6 +348,19 @@ enrich の `prefer` パラメータの供給元として、capsicum 側に **「
 
 ## 9. 読み付き単語サジェスト API（劇中ワード補完）
 
+### 実装方針（5.26.0 確定・#4397）
+
+設計相談の結果、以下で確定し実装した。詳細仕様は [api.md](api.md) の `GET /mulukhiya/api/word/suggest` を正本とする。
+
+- **エンドポイント**: 新設 `GET /mulukhiya/api/word/suggest`（`tagging/tag/search` 拡張ではなく、読み専用・read-only で別系統）。
+- **v1 出力**: `surface` + `reading`（カタカナ）。`category` は**ソースにあれば付く任意フィールド**。`tags`（挿入時タグ自動付与）は別レイヤとして見送り。
+- **読み正規化**: **モロヘイヤ側**で吸収（NFKC + ひらがな→カタカナ）。capsicum は素の読みを送ればよい。
+- **データソース**: dic.json（MeCab 形式）を再パースせず、**サーバー固有の専用エンドポイント**（precure.ml `/api/dic/v1/pron.json` / mstdn.delmulin.com `/api/dic/v1/pronunciations.json`）の `[{word, pronunciation, category?}]` を取り込む。各サーバーの正本は**1 枚のスプレッドシート**で、GAS が dic.json と pron.json を同一シートから投影（**二重管理を作らない**ことを設計の不変条件とする）。モロヘイヤは Redis の揮発キャッシュのみ保持（`PronunciationDictionaryUpdateWorker` が 10 分毎更新、全 URL 失敗時は last-known-good 保持）。
+- **features フラグ**: `features.word_suggest` を `word_suggest/urls` 設定の有無から動的導出（`DynamicFeatures`）。フラグの正本を URL 設定に一本化し二重管理を回避。
+- **category の語彙**: スプレッドシートに**プルダウン列を 1 本追加**する運用（寄稿者がメンバーに広がるため複雑なルールを避ける）。値は `人名 / 技名 / 作品名 / 一般`、**空欄=一般**。MeCab の品詞列からは `技名`/`作品名` を判別できない（MeCab 体系に無い）ため、category は**シートに直接入力**し MeCab からの自動導出はしない。
+- **辞書整備状況**: デルムリン丼 `pronunciations.json` は 997 語整備済み（当初「~1,000 語が必要」だった前提作業は完了）。
+- **将来フェーズ（別 Issue）**: タグ付けパイプライン（`MecabRemoteDictionary`）を同じ簡易スプレッドシート＋category へ寄せ、サーバーごとの MeCab 形式辞書を廃止する。本節の範囲外。
+
 ### 背景
 
 capsicum v1.35（[capsicum#614](https://github.com/pooza/capsicum/issues/614)）で、投稿フォームに**劇中ワード・キャラ名・必殺技名のサジェスト**を実装する。実況用途で、辞書登録のない環境だと専門ワード（例: `閃華裂光拳`）が IME の変換候補に出ず入力できないため、capsicum 側のアプリ独立サジェスト UI で補う。

--- a/test/contract/word_suggest_contract.rb
+++ b/test/contract/word_suggest_contract.rb
@@ -1,0 +1,15 @@
+module Mulukhiya
+  class WordSuggestContractTest < TestCase
+    def setup
+      @contract = WordSuggestContract.new
+    end
+
+    def test_call
+      assert_empty(@contract.call(q: 'あい').errors)
+      assert_empty(@contract.call(q: 'あい', limit: '10').errors)
+
+      assert_false(@contract.call(q: nil).errors.empty?)
+      assert_false(@contract.call({}).errors.empty?)
+    end
+  end
+end

--- a/test/unit/lib/dynamic_features.rb
+++ b/test/unit/lib/dynamic_features.rb
@@ -2,7 +2,7 @@ module Mulukhiya
   class DynamicFeaturesTest < TestCase
     def test_registry_keys
       assert_equal(
-        ['annict_linked', 'media_catalog', 'program_editable'].to_set,
+        ['annict_linked', 'media_catalog', 'program_editable', 'word_suggest'].to_set,
         DynamicFeatures::REGISTRY.keys.to_set,
       )
     end

--- a/test/unit/lib/pronunciation_dictionary.rb
+++ b/test/unit/lib/pronunciation_dictionary.rb
@@ -1,0 +1,60 @@
+module Mulukhiya
+  class PronunciationDictionaryTest < TestCase
+    ENTRIES = [
+      {'surface' => '愛崎えみる', 'reading' => 'アイサキエミル', 'category' => '人名'},
+      {'surface' => '閃華裂光拳', 'reading' => 'センカレッコウケン', 'category' => '技名'},
+      {'surface' => 'アイス', 'reading' => 'アイス'},
+    ].freeze
+
+    def disable?
+      PronunciationDictionary.new.redis.get('1')
+      return super
+    rescue
+      return true
+    end
+
+    def setup
+      return if disable?
+      @dic = PronunciationDictionary.new
+      @dic.redis[PronunciationDictionary::REDIS_KEY] = ENTRIES.to_json
+    end
+
+    def teardown
+      @dic&.invalidate_cache
+    end
+
+    def test_suggest_by_hiragana_reading
+      results = @dic.suggest('あいさき')
+
+      assert_equal('愛崎えみる', results.first[:surface])
+      assert_equal('アイサキエミル', results.first[:reading])
+      assert_equal('人名', results.first[:category])
+    end
+
+    def test_suggest_passes_category_only_when_present
+      entry = @dic.suggest('あいす').find {|r| r[:surface] == 'アイス'}
+
+      assert_not_nil(entry)
+      assert_false(entry.key?(:category))
+    end
+
+    def test_suggest_reading_prefix_match
+      surfaces = @dic.suggest('あい').map {|r| r[:surface]}
+
+      assert_includes(surfaces, '愛崎えみる')
+      assert_includes(surfaces, 'アイス')
+    end
+
+    def test_suggest_empty_query_returns_empty
+      assert_empty(@dic.suggest(''))
+    end
+
+    def test_suggest_respects_limit
+      assert_operator(@dic.suggest('あい', limit: 1).size, :<=, 1)
+    end
+
+    def test_suggest_no_match_returns_empty
+      assert_empty(@dic.suggest('ぞんざいしないよみ'))
+    end
+  end
+end

--- a/test/unit/lib/pronunciation_dictionary.rb
+++ b/test/unit/lib/pronunciation_dictionary.rb
@@ -53,6 +53,14 @@ module Mulukhiya
       assert_operator(@dic.suggest('あい', limit: 1).size, :<=, 1)
     end
 
+    def test_suggest_tolerates_non_scalar_limit
+      # limit[]=1 のような配列・非数値でも 500 にせず既定動作へ倒す。
+      assert_nothing_raised do
+        @dic.suggest('あい', limit: ['1'])
+        @dic.suggest('あい', limit: 'abc')
+      end
+    end
+
     def test_suggest_no_match_returns_empty
       assert_empty(@dic.suggest('ぞんざいしないよみ'))
     end

--- a/test/unit/worker/pronunciation_dictionary_update_worker.rb
+++ b/test/unit/worker/pronunciation_dictionary_update_worker.rb
@@ -1,0 +1,17 @@
+module Mulukhiya
+  class PronunciationDictionaryUpdateWorkerTest < TestCase
+    def setup
+      @worker = Worker.create(:pronunciation_dictionary_update)
+    end
+
+    def test_disable
+      assert_boolean(@worker.disable?)
+    end
+
+    def test_perform_when_disabled
+      # word_suggest/urls 未設定 (テスト既定) では disable? が true で no-op。
+      return unless @worker.disable?
+      assert_nil(@worker.perform)
+    end
+  end
+end

--- a/test/unit/worker/pronunciation_dictionary_update_worker.rb
+++ b/test/unit/worker/pronunciation_dictionary_update_worker.rb
@@ -11,6 +11,7 @@ module Mulukhiya
     def test_perform_when_disabled
       # word_suggest/urls 未設定 (テスト既定) では disable? が true で no-op。
       return unless @worker.disable?
+
       assert_nil(@worker.perform)
     end
   end


### PR DESCRIPTION
## 概要

capsicum 投稿サジェスト ([capsicum#614](https://github.com/pooza/capsicum/issues/614)) 向けに、ひらがな読みから劇中ワードの表層形を引く `GET /mulukhiya/api/word/suggest` を新設する。closes #4397

IME に変換候補が出ない専門ワード（例: `閃華裂光拳`）を、ユーザーが打鍵できるひらがな読みから補完できるようにする。

## 実装

- **`PronunciationDictionary`** — サーバー固有 GAS (`pron.json` / `pronunciations.json`) の `{word, pronunciation, category?}` を取り込み、読み(カタカナ)正規化して Redis に揮発キャッシュ。全 URL 失敗時は last-known-good 保持。表層形+読みで先勝ち dedup。
- **`PronunciationDictionaryUpdateWorker`** — 10 分毎更新（sidekiq-scheduler 直 push 対策で `perform` 側でも `disable?` 評価）。
- **`features.word_suggest`** を `word_suggest/urls` 設定の有無から動的導出（`DynamicFeatures`）。フラグの正本を URL 設定に一本化。
- 読み正規化（ひら→カナ・全半角）は**モロヘイヤ側**で吸収。
- v1 出力は `surface` + `reading`、`category` はソースにあれば付く**任意**フィールド。
- ドキュメント: [api.md](docs/api.md) に endpoint 仕様、[capsicum-requirements.md](docs/capsicum-requirements.md) §9 を実装確定で更新。

## 設計上の合意（相談の結論）

- **二重管理ゼロ**: 辞書の正本は各サーバー 1 スプレッドシートのみ（GAS が dic.json と pron.json を同一シートから投影）。モロヘイヤは揮発キャッシュだけで写しを永続化しない。
- `category` の語彙は `人名 / 技名 / 作品名 / 一般`（空欄=一般）をスプレッドシートのプルダウンで運用。MeCab 品詞からの自動導出はしない（`技名`/`作品名` を判別できないため）。
- タグ付けパイプラインの MeCab 廃止は別フェーズ（別 Issue）。

## テスト

- 追加: `test/unit/lib/pronunciation_dictionary.rb` / `test/unit/worker/...` / `test/contract/word_suggest_contract.rb`
- ローカルは git-source gem 未 bundle / libvips 不在のためスイート実行不可。構文・kana 正規化・ランキングロジックは Ruby 4.0.4 で確認済み。残りは CI に委ねる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)