### PR TITLE
fix: #4397 HEAD 非対応ホスト(GAS)の事前チェック 403 ログ抑止

### DIFF
--- a/app/lib/mulukhiya/program.rb
+++ b/app/lib/mulukhiya/program.rb
@@ -208,8 +208,11 @@ module Mulukhiya
       log_oversize(uri, length.to_i, 'program fetch content-length exceeded max bytes')
       return false
     rescue => e
-      # HEAD 非対応・一過性障害は判定不能。GET 側で再評価する
-      e.log(url: uri.to_s)
+      # HEAD 非対応・一過性障害は判定不能。GET 側で再評価する。GAS など HEAD を
+      # 受け付けないホストは 403/405 を返すが、これは想定内なので黙ってフォール
+      # バックし、timeout・5xx 等の異常のみログする (#4397)。
+      status = e.respond_to?(:source_status) ? e.source_status : nil
+      e.log(url: uri.to_s) unless [403, 405].include?(status)
       return true
     end
 

--- a/app/lib/mulukhiya/pronunciation_dictionary.rb
+++ b/app/lib/mulukhiya/pronunciation_dictionary.rb
@@ -161,7 +161,11 @@ module Mulukhiya
       log_oversize(uri, length.to_i, 'word_suggest fetch content-length exceeded max bytes')
       return false
     rescue => e
-      e.log(url: uri.to_s)
+      # GAS など HEAD 非対応のホストは 403/405 を返す。これは想定内なので黙って GET へ
+      # フォールバックし (GET 側 valid_response_size? が最終防衛線)、timeout・5xx 等の
+      # 異常のみログする。GAS は Content-Length も返さず事前チェックは効かない (#4397)。
+      status = e.respond_to?(:source_status) ? e.source_status : nil
+      e.log(url: uri.to_s) unless [403, 405].include?(status)
       return true
     end
 


### PR DESCRIPTION
## 背景

dev04/dev23 に `PronunciationDictionaryUpdateWorker` を設定したところ、フェッチログに `Bad response 403` が毎サイクル出る現象を確認。データ自体は正常に読めている。

切り分けた結果:
- 読み辞書のソース（GAS = script.google.com）は **HEAD を受け付けず 403** を返す（GET は 200・217KB）。
- 403 は `valid_content_length?`（GET 前に Content-Length を HEAD で先読みする事前チェック）が出していた。設計上 HEAD 失敗は握り潰して GET にフォールバックするため**機能は正常**だが、`e.log` で毎サイクル（10分ごと×台数）ノイズが出ていた。
- GAS は Content-Length も返さないため、このソースで事前チェックは元々効かない。

## 変更

`valid_content_length?` の rescue で、`source_status` が **403/405（HEAD 非対応の想定内シグナル）なら黙ってフォールバック**し、timeout・5xx 等の異常のみ `e.log` する。

- `PronunciationDictionary`（#4397、GAS ソース）
- `Program`（現状ソースは Mastodon で HEAD 対応のため 403 は出ていないが、将来 GAS URL を挿しても無害になるよう同じ防御を適用）

GET 後の `valid_response_size?` が引き続き本当のサイズ上限を担保する（保護効果は不変）。

## テスト

ログ出力の分岐のみで挙動・戻り値は不変（HEAD 失敗時は従来どおり `return true`）。`source_status` を持たない例外は従来どおりログする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)