### PR TITLE
refactor(program): I/O 層を ProgramFetcher に分離 (#4347)

### DIFF
--- a/app/lib/mulukhiya/program.rb
+++ b/app/lib/mulukhiya/program.rb
@@ -1,17 +1,16 @@
 module Mulukhiya
-  class Program # rubocop:disable Metrics/ClassLength
+  # 番組表データの参照・編集 (ドメインロジック) を担う。HTTP 取得・YAML/Redis
+  # 永続化といった I/O は ProgramFetcher へ委譲する (#4347)。
+  class Program
     include Singleton
     include Package
 
-    YAML_PATH = File.join(Environment.dir, 'var/program.yaml').freeze
-    REDIS_KEY = 'program'.freeze
-    DEFAULT_FETCH_MAX_BYTES = 1_048_576
-    DEFAULT_FETCH_TIMEOUT = 30
+    # 後方互換: rake task / テストが参照するため委譲先の定数を再公開する。
+    YAML_PATH = ProgramFetcher::YAML_PATH
 
     def update
       return nil unless auto_update?
-      return nil unless uris.any?
-      programs = fetch_remote
+      programs = fetcher.fetch
       return nil unless programs
       return save(programs)
     end
@@ -21,13 +20,11 @@ module Mulukhiya
     end
 
     def save(programs)
-      write_yaml(programs)
-      return update_cache(programs)
+      return fetcher.save(programs)
     end
 
     def data
-      raw = cached_data || load_from_yaml
-      return raw.each_with_object({}) do |(key, entry), result|
+      return fetcher.load.each_with_object({}) do |(key, entry), result|
         next unless entry.is_a?(Hash)
         result[key] = entry.merge('extra_tags' => entry['extra_tags'] || [])
       end
@@ -105,11 +102,6 @@ module Mulukhiya
       return entry
     end
 
-    def redis
-      @redis ||= Redis.new
-      return @redis
-    end
-
     def count
       return data.count
     end
@@ -119,23 +111,23 @@ module Mulukhiya
     end
 
     def uris
-      return config['/program/urls'].filter_map {|v| Ginseng::URI.parse(v)}.to_set rescue []
+      return fetcher.uris
     end
 
     def yaml_exist?
-      return File.exist?(YAML_PATH)
+      return fetcher.yaml_exist?
     end
 
     def invalidate_cache
-      return redis.unlink(REDIS_KEY)
+      return fetcher.invalidate_cache
     end
 
     alias to_s to_yaml
 
     private
 
-    def initialize
-      @http = HTTP.new
+    def fetcher
+      @fetcher ||= ProgramFetcher.new
     end
 
     # nil または空白のみの文字列は「未設定」として扱い、保存対象から除く。
@@ -174,118 +166,6 @@ module Mulukhiya
     rescue => e
       e.alert
       return nil
-    end
-
-    def fetch_remote
-      programs = {}
-      success = 0
-      uris.each do |v|
-        next unless valid_content_length?(v)
-        response = @http.get(v, timeout: fetch_timeout)
-        next unless valid_response_size?(response, v)
-        parsed = response.parsed_response
-        next unless valid_program_schema?(parsed, v)
-        programs.merge!(parsed)
-        success += 1
-      rescue => e
-        # 単一 URL の取得失敗 (HTTP error / parse error 等) で update 全体が落ちる
-        # のを防ぐ。失敗した URL のみ skip し、他の URL の取り込みは続ける
-        e.log(url: v.to_s)
-      end
-      # 全 URL が失敗した場合は last-known-good を保持するため nil を返し
-      # 上位の update() で save をスキップする (一過性障害で YAML 全消失を防ぐ)
-      return nil if success.zero?
-      return programs
-    end
-
-    # HTTParty がレスポンス本文を丸ごとメモリへ読み込む前に、相手が申告した
-    # Content-Length が max を超えていれば GET せず弾く。Content-Length 不在や
-    # HEAD 非対応 (GatewayError) の場合は判定不能としてそのまま GET へ進み、
-    # 受信後の valid_response_size? を最終防衛線とする。
-    def valid_content_length?(uri)
-      length = @http.head(uri, timeout: fetch_timeout).headers['content-length']
-      return true if length.nil? || length.to_i <= fetch_max_bytes
-      log_oversize(uri, length.to_i, 'program fetch content-length exceeded max bytes')
-      return false
-    rescue => e
-      # HEAD 非対応・一過性障害は判定不能。GET 側で再評価する。GAS など HEAD を
-      # 受け付けないホストは 403/405 を返すが、これは想定内なので黙ってフォール
-      # バックし、timeout・5xx 等の異常のみログする (#4397)。
-      status = e.respond_to?(:source_status) ? e.source_status : nil
-      e.log(url: uri.to_s) unless [403, 405].include?(status)
-      return true
-    end
-
-    def valid_response_size?(response, uri)
-      bytes = response.body.to_s.bytesize
-      return true if bytes <= fetch_max_bytes
-      log_oversize(uri, bytes, 'program fetch exceeded max bytes')
-      return false
-    end
-
-    def log_oversize(uri, bytes, message)
-      logger.error(message:, url: uri.to_s, bytes:, max_bytes: fetch_max_bytes)
-    end
-
-    def valid_program_schema?(parsed, uri)
-      return true if parsed.is_a?(Hash) && parsed.values.all?(Hash)
-      logger.error(
-        message: 'program fetch schema invalid',
-        url: uri.to_s,
-        type: parsed.class.name,
-      )
-      return false
-    end
-
-    def fetch_max_bytes
-      return config['/program/fetch/max_bytes'] || DEFAULT_FETCH_MAX_BYTES
-    end
-
-    def fetch_timeout
-      return config['/program/fetch/timeout'] || DEFAULT_FETCH_TIMEOUT
-    end
-
-    def cached_data
-      raw = redis[REDIS_KEY]
-      return nil unless raw
-      return JSON.parse(raw)
-    end
-
-    def load_from_yaml
-      return {} unless yaml_exist?
-      programs = YAML.safe_load_file(YAML_PATH, permitted_classes: [Symbol]) || {}
-      update_cache(programs)
-      return programs
-    end
-
-    def update_cache(programs)
-      return redis[REDIS_KEY] = programs.to_json
-    rescue => e
-      # SET が中途半端に値を残したまま例外になった場合に備え、不整合な
-      # キャッシュを除去して以降の read を YAML フォールバックへ倒す保険。
-      # Redis 全断なら UNLINK も失敗するが、その場合は実質キャッシュ無しと
-      # 等価なので無害 (best-effort、例外は握り潰す)。
-      invalidate_cache rescue nil
-      # Redis 書込失敗の根因 (件数・JSON サイズ) を Sentry に残す。
-      e.alert(**cache_failure_context(programs))
-      return nil
-    end
-
-    # alert に添える文脈。programs.to_json が失敗要因だった場合に
-    # ここで再 raise すると alert 自体が落ちるため握り潰して空で返す。
-    def cache_failure_context(programs)
-      return {programs_size: programs.size, json_bytes: programs.to_json.bytesize}
-    rescue => e
-      e.log
-      return {}
-    end
-
-    def write_yaml(programs)
-      dir = File.dirname(YAML_PATH)
-      FileUtils.mkdir_p(dir)
-      tmp = File.join(dir, ".program.yaml.#{Process.pid}.#{Thread.current.object_id}")
-      File.write(tmp, programs.to_yaml)
-      return File.rename(tmp, YAML_PATH)
     end
   end
 end

--- a/app/lib/mulukhiya/program_fetcher.rb
+++ b/app/lib/mulukhiya/program_fetcher.rb
@@ -1,0 +1,166 @@
+module Mulukhiya
+  # 番組表 (Program) の取得・永続化 (I/O) 層 (#4347)。HTTP 取得・サイズ/スキーマ
+  # 検証・YAML 永続化・Redis キャッシュを担い、Program 本体は番組表データの参照・
+  # 編集 (ドメインロジック) に専念する。Program がメモ化した本クラスのインスタンスへ
+  # I/O を委譲する。
+  class ProgramFetcher
+    include Package
+
+    YAML_PATH = File.join(Environment.dir, 'var/program.yaml').freeze
+    REDIS_KEY = 'program'.freeze
+    DEFAULT_FETCH_MAX_BYTES = 1_048_576
+    DEFAULT_FETCH_TIMEOUT = 30
+
+    def initialize
+      @http = HTTP.new
+    end
+
+    def uris
+      return config['/program/urls'].filter_map {|v| Ginseng::URI.parse(v)}.to_set rescue []
+    end
+
+    # 全 URL を取得・検証し、マージした番組表ハッシュを返す。取得対象が無い、または
+    # 全 URL 失敗時は nil (呼び出し側で last-known-good を保持する)。
+    def fetch
+      return nil unless uris.any?
+      return fetch_remote
+    end
+
+    def save(programs)
+      write_yaml(programs)
+      return update_cache(programs)
+    end
+
+    # キャッシュ (Redis) → YAML の順に番組表データを読む。
+    def load
+      return cached_data || load_from_yaml
+    end
+
+    def yaml_exist?
+      return File.exist?(YAML_PATH)
+    end
+
+    def invalidate_cache
+      return redis.unlink(REDIS_KEY)
+    end
+
+    def redis
+      @redis ||= Redis.new
+      return @redis
+    end
+
+    private
+
+    def fetch_remote
+      programs = {}
+      success = 0
+      uris.each do |v|
+        next unless valid_content_length?(v)
+        response = @http.get(v, timeout: fetch_timeout)
+        next unless valid_response_size?(response, v)
+        parsed = response.parsed_response
+        next unless valid_program_schema?(parsed, v)
+        programs.merge!(parsed)
+        success += 1
+      rescue => e
+        # 単一 URL の取得失敗 (HTTP error / parse error 等) で update 全体が落ちる
+        # のを防ぐ。失敗した URL のみ skip し、他の URL の取り込みは続ける
+        e.log(url: v.to_s)
+      end
+      # 全 URL が失敗した場合は last-known-good を保持するため nil を返し
+      # 上位の update() で save をスキップする (一過性障害で YAML 全消失を防ぐ)
+      return nil if success.zero?
+      return programs
+    end
+
+    # HTTParty がレスポンス本文を丸ごとメモリへ読み込む前に、相手が申告した
+    # Content-Length が max を超えていれば GET せず弾く。Content-Length 不在や
+    # HEAD 非対応 (GatewayError) の場合は判定不能としてそのまま GET へ進み、
+    # 受信後の valid_response_size? を最終防衛線とする。
+    def valid_content_length?(uri)
+      length = @http.head(uri, timeout: fetch_timeout).headers['content-length']
+      return true if length.nil? || length.to_i <= fetch_max_bytes
+      log_oversize(uri, length.to_i, 'program fetch content-length exceeded max bytes')
+      return false
+    rescue => e
+      # HEAD 非対応・一過性障害は判定不能。GET 側で再評価する。GAS など HEAD を
+      # 受け付けないホストは 403/405 を返すが、これは想定内なので黙ってフォール
+      # バックし、timeout・5xx 等の異常のみログする (#4397)。
+      status = e.respond_to?(:source_status) ? e.source_status : nil
+      e.log(url: uri.to_s) unless [403, 405].include?(status)
+      return true
+    end
+
+    def valid_response_size?(response, uri)
+      bytes = response.body.to_s.bytesize
+      return true if bytes <= fetch_max_bytes
+      log_oversize(uri, bytes, 'program fetch exceeded max bytes')
+      return false
+    end
+
+    def log_oversize(uri, bytes, message)
+      logger.error(message:, url: uri.to_s, bytes:, max_bytes: fetch_max_bytes)
+    end
+
+    def valid_program_schema?(parsed, uri)
+      return true if parsed.is_a?(Hash) && parsed.values.all?(Hash)
+      logger.error(
+        message: 'program fetch schema invalid',
+        url: uri.to_s,
+        type: parsed.class.name,
+      )
+      return false
+    end
+
+    def fetch_max_bytes
+      return config['/program/fetch/max_bytes'] || DEFAULT_FETCH_MAX_BYTES
+    end
+
+    def fetch_timeout
+      return config['/program/fetch/timeout'] || DEFAULT_FETCH_TIMEOUT
+    end
+
+    def cached_data
+      raw = redis[REDIS_KEY]
+      return nil unless raw
+      return JSON.parse(raw)
+    end
+
+    def load_from_yaml
+      return {} unless yaml_exist?
+      programs = YAML.safe_load_file(YAML_PATH, permitted_classes: [Symbol]) || {}
+      update_cache(programs)
+      return programs
+    end
+
+    def update_cache(programs)
+      return redis[REDIS_KEY] = programs.to_json
+    rescue => e
+      # SET が中途半端に値を残したまま例外になった場合に備え、不整合な
+      # キャッシュを除去して以降の read を YAML フォールバックへ倒す保険。
+      # Redis 全断なら UNLINK も失敗するが、その場合は実質キャッシュ無しと
+      # 等価なので無害 (best-effort、例外は握り潰す)。
+      invalidate_cache rescue nil
+      # Redis 書込失敗の根因 (件数・JSON サイズ) を Sentry に残す。
+      e.alert(**cache_failure_context(programs))
+      return nil
+    end
+
+    # alert に添える文脈。programs.to_json が失敗要因だった場合に
+    # ここで再 raise すると alert 自体が落ちるため握り潰して空で返す。
+    def cache_failure_context(programs)
+      return {programs_size: programs.size, json_bytes: programs.to_json.bytesize}
+    rescue => e
+      e.log
+      return {}
+    end
+
+    def write_yaml(programs)
+      dir = File.dirname(YAML_PATH)
+      FileUtils.mkdir_p(dir)
+      tmp = File.join(dir, ".program.yaml.#{Process.pid}.#{Thread.current.object_id}")
+      File.write(tmp, programs.to_yaml)
+      return File.rename(tmp, YAML_PATH)
+    end
+  end
+end

--- a/test/unit/lib/program_fetcher.rb
+++ b/test/unit/lib/program_fetcher.rb
@@ -1,0 +1,212 @@
+module Mulukhiya
+  class ProgramFetcherTest < TestCase
+    def disable?
+      return true unless controller_class.livecure?
+      return super
+    end
+
+    def setup
+      return if disable?
+      @fetcher = ProgramFetcher.new
+    end
+
+    def test_uris
+      assert_kind_of(Set, @fetcher.uris)
+      @fetcher.uris.each do |uri|
+        assert_kind_of(Addressable::URI, uri)
+        assert_predicate(uri, :absolute?)
+      end
+    end
+
+    def test_fetch_merges_valid_payload
+      return if disable?
+      url = 'http://example.com/programs.json'
+      payload = {'remote_a' => {'series' => 'Remote A'}}
+      stub_remote_program(url, payload.to_json)
+      with_program_urls([url]) do
+        result = @fetcher.fetch
+
+        assert_equal(payload, result)
+      end
+    end
+
+    def test_fetch_returns_nil_without_urls
+      return if disable?
+      with_program_urls([]) do
+        assert_nil(@fetcher.fetch)
+      end
+    end
+
+    def test_fetch_skips_oversize_body
+      return if disable?
+      url = 'http://example.com/oversize.json'
+      stub_remote_program(url, 'x' * (ProgramFetcher::DEFAULT_FETCH_MAX_BYTES + 1))
+      with_program_urls([url]) do
+        result = @fetcher.fetch
+
+        assert_nil(result)
+      end
+    end
+
+    def test_fetch_skips_non_hash_payload
+      return if disable?
+      url = 'http://example.com/array.json'
+      stub_remote_program(url, [{'series' => 'A'}].to_json)
+      with_program_urls([url]) do
+        result = @fetcher.fetch
+
+        assert_nil(result)
+      end
+    end
+
+    def test_fetch_skips_hash_with_non_hash_values
+      return if disable?
+      url = 'http://example.com/scalar_values.json'
+      stub_remote_program(url, {'key' => 'not_a_hash'}.to_json)
+      with_program_urls([url]) do
+        result = @fetcher.fetch
+
+        assert_nil(result)
+      end
+    end
+
+    def test_fetch_honors_configured_max_bytes
+      original_max = config['/program/fetch/max_bytes']
+      return if disable?
+      url = 'http://example.com/configured.json'
+      payload = {'remote_b' => {'series' => 'Remote B'}}
+      body = payload.to_json
+      stub_remote_program(url, body)
+      config['/program/fetch/max_bytes'] = body.bytesize - 1
+      with_program_urls([url]) do
+        result = @fetcher.fetch
+
+        assert_nil(result)
+      end
+    ensure
+      config['/program/fetch/max_bytes'] = original_max if defined?(original_max)
+    end
+
+    def test_fetch_skips_before_get_when_content_length_exceeds_max
+      return if disable?
+      url = 'http://example.com/huge.json'
+      payload = {'remote_c' => {'series' => 'Remote C'}}
+      stub_remote_program(
+        url, payload.to_json, content_length: ProgramFetcher::DEFAULT_FETCH_MAX_BYTES + 1
+      )
+      with_program_urls([url]) do
+        result = @fetcher.fetch
+
+        assert_nil(result)
+        assert_not_requested(:get, url)
+      end
+    end
+
+    def test_fetch_proceeds_when_head_unsupported
+      return if disable?
+      url = 'http://example.com/no_head.json'
+      payload = {'remote_d' => {'series' => 'Remote D'}}
+      stub_request(:head, url).to_return(status: 405)
+      stub_request(:get, url)
+        .to_return(body: payload.to_json, headers: {'Content-Type' => 'application/json'})
+      with_program_urls([url]) do
+        result = @fetcher.fetch
+
+        assert_equal(payload, result)
+      end
+    end
+
+    def test_fetch_returns_nil_when_all_urls_fail
+      return if disable?
+      url = 'http://example.com/fail.json'
+      stub_request(:head, url).to_raise(StandardError.new('upstream down'))
+      stub_request(:get, url).to_raise(StandardError.new('upstream down'))
+      with_program_urls([url]) do
+        result = @fetcher.fetch
+
+        assert_nil(result)
+      end
+    end
+
+    def test_fetch_timeout_returns_configured_value
+      assert_kind_of(Integer, @fetcher.send(:fetch_timeout))
+      assert_equal(config['/program/fetch/timeout'], @fetcher.send(:fetch_timeout))
+    end
+
+    def test_fetch_timeout_honors_config
+      original = config['/program/fetch/timeout']
+      config['/program/fetch/timeout'] = 7
+
+      assert_equal(7, @fetcher.send(:fetch_timeout))
+    ensure
+      config['/program/fetch/timeout'] = original
+    end
+
+    def test_save_writes_yaml
+      original = @fetcher.load
+      data = {'test_program' => {'series' => 'TestSeries', 'enable' => true}}
+      @fetcher.save(data)
+
+      assert_predicate(@fetcher, :yaml_exist?)
+      loaded = YAML.safe_load_file(ProgramFetcher::YAML_PATH, permitted_classes: [Symbol])
+
+      assert_equal('TestSeries', loaded['test_program']['series'])
+    ensure
+      @fetcher.save(original) if defined?(original) && original
+    end
+
+    def test_invalidate_cache
+      @fetcher.invalidate_cache
+
+      assert_kind_of(Hash, @fetcher.load)
+    end
+
+    def test_cache_failure_context
+      ctx = @fetcher.send(:cache_failure_context, {'k1' => {}, 'k2' => {}})
+
+      assert_equal(2, ctx[:programs_size])
+      assert_kind_of(Integer, ctx[:json_bytes])
+      assert_operator(ctx[:json_bytes], :>, 0)
+    end
+
+    def test_update_cache_invalidates_on_redis_write_failure
+      original = @fetcher.load
+      @fetcher.save({'sentinel' => {'series' => 'sentinel'}})
+
+      failing_redis = Object.new
+      unlinks = []
+      failing_redis.define_singleton_method(:[]=) {|_k, _v| raise 'simulated redis failure'}
+      failing_redis.define_singleton_method(:unlink) do |k|
+        unlinks << k
+        1
+      end
+      original_redis = @fetcher.instance_variable_get(:@redis)
+      @fetcher.instance_variable_set(:@redis, failing_redis)
+
+      result = @fetcher.send(:update_cache, {'after' => {'series' => 'after'}})
+
+      assert_nil(result)
+      assert_equal([ProgramFetcher::REDIS_KEY], unlinks)
+    ensure
+      @fetcher.instance_variable_set(:@redis, original_redis)
+      @fetcher.save(original) if defined?(original) && original
+    end
+
+    private
+
+    def stub_remote_program(url, body, content_length: body.bytesize)
+      stub_request(:head, url)
+        .to_return(headers: {'Content-Length' => content_length.to_s})
+      stub_request(:get, url)
+        .to_return(body:, headers: {'Content-Type' => 'application/json'})
+    end
+
+    def with_program_urls(urls)
+      original = config['/program/urls']
+      config['/program/urls'] = urls
+      yield
+    ensure
+      config['/program/urls'] = original
+    end
+  end
+end

--- a/test/unit/lib/program_fetcher.rb
+++ b/test/unit/lib/program_fetcher.rb
@@ -32,7 +32,7 @@ module Mulukhiya
 
     def test_fetch_returns_nil_without_urls
       return if disable?
-      result = with_program_urls([]) { @fetcher.fetch }
+      result = with_program_urls([]) {@fetcher.fetch}
 
       assert_nil(result)
     end

--- a/test/unit/lib/program_fetcher.rb
+++ b/test/unit/lib/program_fetcher.rb
@@ -32,9 +32,9 @@ module Mulukhiya
 
     def test_fetch_returns_nil_without_urls
       return if disable?
-      with_program_urls([]) do
-        assert_nil(@fetcher.fetch)
-      end
+      result = with_program_urls([]) { @fetcher.fetch }
+
+      assert_nil(result)
     end
 
     def test_fetch_skips_oversize_body

--- a/test/unit/model/program.rb
+++ b/test/unit/model/program.rb
@@ -100,14 +100,6 @@ module Mulukhiya
       assert_kind_of(Hash, @program.data)
     end
 
-    def test_cache_failure_context
-      ctx = @program.send(:cache_failure_context, {'k1' => {}, 'k2' => {}})
-
-      assert_equal(2, ctx[:programs_size])
-      assert_kind_of(Integer, ctx[:json_bytes])
-      assert_operator(ctx[:json_bytes], :>, 0)
-    end
-
     def test_add_entry_creates_new_entry
       key = "test_add_#{Time.now.to_i}"
       original = @program.data
@@ -343,121 +335,6 @@ module Mulukhiya
       end
     end
 
-    def test_fetch_remote_merges_valid_payload
-      return if disable?
-      url = 'http://example.com/programs.json'
-      payload = {'remote_a' => {'series' => 'Remote A'}}
-      stub_remote_program(url, payload.to_json)
-      with_program_urls([url]) do
-        result = @program.send(:fetch_remote)
-
-        assert_equal(payload, result)
-      end
-    end
-
-    def test_fetch_remote_skips_oversize_body
-      return if disable?
-      url = 'http://example.com/oversize.json'
-      stub_remote_program(url, 'x' * (Program::DEFAULT_FETCH_MAX_BYTES + 1))
-      with_program_urls([url]) do
-        result = @program.send(:fetch_remote)
-
-        assert_nil(result)
-      end
-    end
-
-    def test_fetch_remote_skips_non_hash_payload
-      return if disable?
-      url = 'http://example.com/array.json'
-      stub_remote_program(url, [{'series' => 'A'}].to_json)
-      with_program_urls([url]) do
-        result = @program.send(:fetch_remote)
-
-        assert_nil(result)
-      end
-    end
-
-    def test_fetch_remote_skips_hash_with_non_hash_values
-      return if disable?
-      url = 'http://example.com/scalar_values.json'
-      stub_remote_program(url, {'key' => 'not_a_hash'}.to_json)
-      with_program_urls([url]) do
-        result = @program.send(:fetch_remote)
-
-        assert_nil(result)
-      end
-    end
-
-    def test_fetch_remote_honors_configured_max_bytes
-      original_max = config['/program/fetch/max_bytes']
-      return if disable?
-      url = 'http://example.com/configured.json'
-      payload = {'remote_b' => {'series' => 'Remote B'}}
-      body = payload.to_json
-      stub_remote_program(url, body)
-      config['/program/fetch/max_bytes'] = body.bytesize - 1
-      with_program_urls([url]) do
-        result = @program.send(:fetch_remote)
-
-        assert_nil(result)
-      end
-    ensure
-      config['/program/fetch/max_bytes'] = original_max if defined?(original_max)
-    end
-
-    def test_fetch_remote_skips_before_get_when_content_length_exceeds_max
-      return if disable?
-      url = 'http://example.com/huge.json'
-      payload = {'remote_c' => {'series' => 'Remote C'}}
-      stub_remote_program(url, payload.to_json, content_length: Program::DEFAULT_FETCH_MAX_BYTES + 1)
-      with_program_urls([url]) do
-        result = @program.send(:fetch_remote)
-
-        assert_nil(result)
-        assert_not_requested(:get, url)
-      end
-    end
-
-    def test_fetch_remote_proceeds_when_head_unsupported
-      return if disable?
-      url = 'http://example.com/no_head.json'
-      payload = {'remote_d' => {'series' => 'Remote D'}}
-      stub_request(:head, url).to_return(status: 405)
-      stub_request(:get, url)
-        .to_return(body: payload.to_json, headers: {'Content-Type' => 'application/json'})
-      with_program_urls([url]) do
-        result = @program.send(:fetch_remote)
-
-        assert_equal(payload, result)
-      end
-    end
-
-    def test_fetch_timeout_returns_configured_value
-      assert_kind_of(Integer, @program.send(:fetch_timeout))
-      assert_equal(config['/program/fetch/timeout'], @program.send(:fetch_timeout))
-    end
-
-    def test_fetch_timeout_honors_config
-      original = config['/program/fetch/timeout']
-      config['/program/fetch/timeout'] = 7
-
-      assert_equal(7, @program.send(:fetch_timeout))
-    ensure
-      config['/program/fetch/timeout'] = original
-    end
-
-    def test_fetch_remote_returns_nil_when_all_urls_fail
-      return if disable?
-      url = 'http://example.com/fail.json'
-      stub_request(:head, url).to_raise(StandardError.new('upstream down'))
-      stub_request(:get, url).to_raise(StandardError.new('upstream down'))
-      with_program_urls([url]) do
-        result = @program.send(:fetch_remote)
-
-        assert_nil(result)
-      end
-    end
-
     def test_update_preserves_existing_data_when_all_urls_fail
       return if disable?
       original = @program.data
@@ -472,29 +349,6 @@ module Mulukhiya
         assert_includes(@program.data.keys, sentinel_key)
       end
     ensure
-      @program.save(original) if original
-    end
-
-    def test_update_cache_invalidates_on_redis_write_failure
-      original = @program.data
-      @program.save({'sentinel' => {'series' => 'sentinel'}})
-
-      failing_redis = Object.new
-      unlinks = []
-      failing_redis.define_singleton_method(:[]=) {|_k, _v| raise 'simulated redis failure'}
-      failing_redis.define_singleton_method(:unlink) do |k|
-        unlinks << k
-        1
-      end
-      original_redis = @program.instance_variable_get(:@redis)
-      @program.instance_variable_set(:@redis, failing_redis)
-
-      result = @program.send(:update_cache, {'after' => {'series' => 'after'}})
-
-      assert_nil(result)
-      assert_equal([Program::REDIS_KEY], unlinks)
-    ensure
-      @program.instance_variable_set(:@redis, original_redis)
       @program.save(original) if original
     end
 


### PR DESCRIPTION
## 概要

`Program` クラスの取得・キャッシュ系 (I/O) を `ProgramFetcher` に切り出し、`Metrics/ClassLength` の `# rubocop:disable` を解除する (#4347)。

## 変更点

- **`ProgramFetcher`** (新規): HTTP 取得・サイズ/スキーマ検証・YAML 永続化・Redis キャッシュを担う I/O 層。
  - public: `uris` / `fetch` / `save` / `load` / `yaml_exist?` / `invalidate_cache` / `redis`
  - private: `fetch_remote` / `valid_content_length?` / `valid_response_size?` / `valid_program_schema?` / `update_cache` / `cached_data` / `load_from_yaml` / `write_yaml` / `cache_failure_context` 等
- **`Program`**: 番組表データの参照・編集 (CRUD entry / generate_key / normalize) に専念。I/O はメモ化した `ProgramFetcher` へ委譲。
  - `# rubocop:disable Metrics/ClassLength` を解除（クラス本体 225 → 134 行）
  - `YAML_PATH` は rake task / テストの後方互換のため再公開
- **テスト追従**: fetch・cache 系を `ProgramFetcherTest` (test/unit/lib) へ移設。`ProgramTest` には参照・編集系と `update` 統合テスト（全 URL 失敗時の last-known-good 保持）を残す。

## 確認

- 外部呼び出し元 (`ProgramUpdateWorker` / `api_controller` / `program_calendar` / `controller_methods` / rake task) はすべて `Program.instance` の公開 API 経由で、シグネチャ非変更のため影響なし。
- ローカルは git-source gem 未 bundle のためテスト/rubocop 実行不可。CI (test mastodon / test misskey) で検証。

🤖 Generated with [Claude Code](https://claude.com/claude-code)