### PR TITLE
fix(word-suggest): 同ランク内候補を読みの五十音順に並べる (#4397)

### DIFF
--- a/app/lib/mulukhiya/pronunciation_dictionary.rb
+++ b/app/lib/mulukhiya/pronunciation_dictionary.rb
@@ -49,9 +49,11 @@ module Mulukhiya
       scored = entries.filter_map do |entry|
         rank = match_rank(entry, reading_query, surface_query)
         next unless rank
-        [rank, entry['reading'].to_s.length, entry]
+        [rank, entry['reading'].to_s, entry]
       end
-      ranked = scored.sort_by {|rank, length, entry| [rank, length, entry['reading'].to_s]}
+      # 同ランク内は読み (カタカナ) の五十音順 → 短い順。前方一致優先 (rank) は
+      # 維持しつつ、同ランクではふりがな辞書順で安定して並べる (#4397)。
+      ranked = scored.sort_by {|rank, reading, _entry| [rank, reading, reading.length]}
       return ranked.first(limit).map {|_, _, entry| present(entry)}
     end
 

--- a/test/unit/lib/pronunciation_dictionary.rb
+++ b/test/unit/lib/pronunciation_dictionary.rb
@@ -45,6 +45,13 @@ module Mulukhiya
       assert_includes(surfaces, 'アイス')
     end
 
+    def test_suggest_orders_same_rank_by_reading
+      # 同ランク (読み前方一致) 内は読みの五十音順で並ぶ。アイサ... < アイス。
+      surfaces = @dic.suggest('あい').map {|r| r[:surface]}
+
+      assert_equal(['愛崎えみる', 'アイス'], surfaces)
+    end
+
     def test_suggest_empty_query_returns_empty
       assert_empty(@dic.suggest(''))
     end


### PR DESCRIPTION
## 概要

`word/suggest` の候補ソートで、同ランク内のタイブレーカーを「読みの文字数 → 読み」から **「読み (五十音順) → 文字数」** へ入れ替える (#4397, capsicum #614 連携)。

利用者 (pooza) より「ふりがなの辞書順だと良い」との要望。前方一致優先の `rank` は維持し、同ランク内のみ五十音順で安定して並ぶようにする。完全な純辞書順 (rank 無視) は前方一致の優位が崩れるため採らない。

## 変更

- `PronunciationDictionary#suggest` のソートキー: `[rank, reading.length, reading]` → `[rank, reading, reading.length]`
- 例: `あい` で `アイス`(短い順で先) → `愛崎えみる` だったのが、`愛崎えみる`(アイサ) → `アイス`(アイス) に (サ < ス)
- 同挙動をロックするテスト `test_suggest_orders_same_rank_by_reading` を追加

## 確認

- `ruby -c` 構文 OK / rubocop オフェンス 0
- ローカルは Redis 不在のためテスト self-disable (CI で実行)

🤖 Generated with [Claude Code](https://claude.com/claude-code)