### PR TITLE
リリース前レビュー hotfix: word/suggest alert 抑制・入力ログスクラブ (#4397 #4394)

### DIFF
--- a/app/lib/mulukhiya/controller.rb
+++ b/app/lib/mulukhiya/controller.rb
@@ -9,7 +9,10 @@ module Mulukhiya
 
     # 投稿本文系フィールドを info ログに平文で残さない (#4394)。処理には素の
     # @params を使うため、ログ用の複製だけ top-level の該当キーをマスクする。
-    SCRUBBED_LOG_PARAMS = ['status', 'text', 'body', 'comment', 'spoiler_text', 'cw'].freeze
+    SCRUBBED_LOG_PARAMS = [
+      'status', 'text', 'body', 'comment', 'spoiler_text', 'cw',
+      'q', 'title', 'artist', 'album' # word/suggest・nowplaying のユーザー入力 (#4394)
+    ].freeze
 
     set :root, Environment.dir
     enable :method_override

--- a/app/lib/mulukhiya/nowplaying_resolver.rb
+++ b/app/lib/mulukhiya/nowplaying_resolver.rb
@@ -69,7 +69,8 @@ module Mulukhiya
         }.compact,
       }
     rescue => e
-      e.log(provider: 'apple_music', keyword:)
+      # keyword は曲名・アーティスト等のユーザー入力なのでログに残さない (#4394)。
+      e.log(provider: 'apple_music')
       return nil
     end
 
@@ -87,7 +88,8 @@ module Mulukhiya
         }.compact,
       }
     rescue => e
-      e.log(provider: 'spotify', keyword:)
+      # keyword は曲名・アーティスト等のユーザー入力なのでログに残さない (#4394)。
+      e.log(provider: 'spotify')
       return nil
     end
 

--- a/app/lib/mulukhiya/pronunciation_dictionary.rb
+++ b/app/lib/mulukhiya/pronunciation_dictionary.rb
@@ -206,9 +206,22 @@ module Mulukhiya
     def cached_entries
       raw = redis[REDIS_KEY]
       return nil unless raw
+      return parse_cached_entries(raw)
+    rescue => e
+      # Redis 接続障害などの読み取り失敗。公開 /word/suggest から per-request で
+      # 呼ばれるため alert すると Redis 全断時に Sentry スパム化する。ログのみに
+      # 留め、上位 (entries) を update → fetch フォールバックへ倒す (#4397)。
+      e.log
+      return nil
+    end
+
+    def parse_cached_entries(raw)
       parsed = JSON.parse(raw)
       return parsed.is_a?(Array) ? parsed : nil
     rescue => e
+      # キャッシュ本体の破損 (不正 JSON / 非配列)。一過性ではなく要対処なので
+      # alert し、壊れたキャッシュを除去して以降の read を fetch へ倒す。
+      invalidate_cache rescue nil
       e.alert
       return nil
     end


### PR DESCRIPTION
## 概要

5.26.0 リリース前 5観点レビューで **赤近い黄** と判定した2系統をインライン修正。真の赤は 0 件で、残り黄・緑は別途まとめ Issue で 5.27.0 送り。

## 変更

### (a) word/suggest: Redis 障害時の Sentry スパム抑制
`PronunciationDictionary#cached_entries` の rescue を分離。
- **破損 (JSON.parse 失敗 / 非配列)** → `alert` + `invalidate_cache`（要対処・一過性でない）
- **Redis 接続障害** → `log` のみ（公開 `/word/suggest` から per-request で呼ばれるため、Redis 全断時に alert すると Sentry がスパム化する）

`ProgramFetcher#cached_data`（読みは alert しない）との非対称を解消。

### (b) ユーザー入力の平文ログ除去 (#4394 スクラブ方針)
- `NowplayingResolver`: fault 時 `e.log` から `keyword`（曲名・アーティスト等）を除去
- `Controller#scrub_log_params`: `SCRUBBED_LOG_PARAMS` に `q` / `title` / `artist` / `album` を追加（リクエストログにユーザー入力が平文で残らないように）

## テスト
`pronunciation_dictionary` / `nowplaying_resolver` 全 20 tests green、rubocop clean。

## 残タスク（このPR対象外・5.27.0 まとめ Issue 送り）
- リダイレクト経由 SSRF（fetch が `RemoteHost.public?` を通らない非対称）
- cold-cache 時の同期 remote fetch（Puma スレッドが GAS fetch を直列ブロック）
- docs/api.md features 表記揺れ・capsicum-requirements.md reading 例タイポ 等

🤖 Generated with [Claude Code](https://claude.com/claude-code)