### PR TITLE
fix(word-suggest): Redis 書き込み失敗の per-request alert を log に倒す (#4404 Codex P2)

### DIFF
--- a/app/lib/mulukhiya/pronunciation_dictionary.rb
+++ b/app/lib/mulukhiya/pronunciation_dictionary.rb
@@ -231,9 +231,15 @@ module Mulukhiya
       redis[REDIS_KEY] = entries.to_json
       return entries
     rescue => e
-      # 中途半端なキャッシュを除去し以降の read を fetch フォールバックへ倒す保険。
+      # Redis 書き込み失敗。公開 /word/suggest の cold-cache fallthrough
+      # (entries → update → save) からも到達するため、alert すると read 側の
+      # 抑制と同様に Redis 全断時に per-request で Sentry スパム化する。
+      # Ginseng::Redis::Service が接続障害を一律ラップして型で切り分けられない
+      # うえ、save の失敗は実質的に Redis インフラ障害なので log に倒す。
+      # 定期ワーカーが次サイクルで再書き込みする (#4404 Codex P2)。
+      # 中途半端なキャッシュは除去し以降の read を fetch フォールバックへ倒す。
       invalidate_cache rescue nil
-      e.alert(entries_size: entries.size)
+      e.log(entries_size: entries.size)
       return nil
     end
   end


### PR DESCRIPTION
## 背景
#4404 で `cached_entries`（read 側）の alert を破損限定にし、Redis 接続障害は log のみに抑制した。しかし Codex が #4404 で P2 を指摘:

> When Redis is unavailable on a `/word/suggest` request, this rescue logs the failed read but then returns `nil`, so `entries` continues into `update`; if the remote dictionary fetch succeeds, `save` immediately writes to the same unavailable Redis and still calls `e.alert(entries_size: entries.size)`.

cold-cache 時は `entries → cached_entries(nil) → update → save` と落ちるため、Redis 全断時に **save の rescue が公開 /word/suggest から per-request で alert** し、read 側の抑制意図が write 側で破れていた。

## 修正
`save` の rescue を `e.alert` → `e.log` に変更。

- `Ginseng::Redis::Service` が接続障害を一律 `Ginseng::Redis::Error` にラップするため、接続障害と他障害を型で切り分けられない
- save の失敗は実質的に Redis インフラ障害であり、per-request での alert はスパム
- 定期ワーカー（`PronunciationDictionaryUpdateWorker`、10 分毎）が次サイクルで再書き込みするため恒久的なキャッシュ欠落にはならない
- read 側（#4404）の log-only 抑制と対称化

cold-start での同期 update 自体は維持（外すと最大 10 分 /word/suggest が空になるため）。

## テスト
ローカル Redis 起動で `pronunciation_dictionary` 10 tests / 12 assertions green、rubocop clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)