### PR TITLE
fix(misskey): sw/register の dedup を (userId, endpoint) 単位にし重複行蓄積を防ぐ (#4408)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-core.git
-  revision: b2e3d06d7702c6c1e743dd3b4168dda5d74b553e
+  revision: 98a72b02e5c560e7bf9914fe5b13e89bfbff51b6
   branch: main
   specs:
-    ginseng-core (1.15.25)
+    ginseng-core (1.15.26)
       activesupport (>= 7.0.7.1)
       addressable (>= 2.9.0)
       cgi (>= 0.4.2)
@@ -268,7 +268,7 @@ GEM
     mustermann (3.1.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.4)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)
@@ -356,7 +356,7 @@ GEM
       netrc (~> 0.8)
     rexml (3.4.4)
     ricecream (0.2.1)
-    rss (0.3.2)
+    rss (0.3.3)
       rexml
     rubocop (1.87.0)
       json (~> 2.3)
@@ -398,12 +398,12 @@ GEM
     sassc (2.4.0)
       ffi (~> 1.9)
     securerandom (0.4.1)
-    sentry-ruby (6.6.1)
+    sentry-ruby (6.6.2)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
       logger
-    sentry-sidekiq (6.6.1)
-      sentry-ruby (~> 6.6.1)
+    sentry-sidekiq (6.6.2)
+      sentry-ruby (~> 6.6.2)
       sidekiq (>= 5.0)
     sequel (5.105.0)
       bigdecimal
@@ -513,4 +513,4 @@ RUBY VERSION
   ruby 4.0.5
 
 BUNDLED WITH
-  4.0.13
+  4.0.14

--- a/app/lib/mulukhiya/service/misskey_service.rb
+++ b/app/lib/mulukhiya/service/misskey_service.rb
@@ -151,21 +151,21 @@ module Mulukhiya
     end
 
     def register_sw_subscription(account, params)
-      key = {
+      # endpoint は配信先を一意に指すアドレスなので (userId, endpoint) で dedup する。
+      # auth / publickey は端末側で再生成され得る（再インストール・鍵ローテ等）ため
+      # キーに含めず、再登録時は既存行を UPDATE で置換して行を増やさない (#4408)。
+      send_read_message = params[:sendReadMessage] == true
+      existing = Misskey::SwSubscription.first(
         userId: account.id,
         endpoint: params[:endpoint],
-        auth: params[:auth],
-        publickey: params[:publickey],
-      }
-      send_read_message = params[:sendReadMessage] == true
-      existing = Misskey::SwSubscription.first(key)
-      state = existing ? :already_subscribed : :subscribed
-      subscription = existing || Misskey::SwSubscription.create(key.merge(
-        id: self.class.create_aid,
-        sendReadMessage: send_read_message,
-      ))
-      if existing && existing.sendReadMessage != send_read_message
-        subscription.update(sendReadMessage: send_read_message)
+      )
+      if existing
+        replace_sw_subscription(existing, params, send_read_message)
+        subscription = existing
+        state = :already_subscribed
+      else
+        subscription = create_sw_subscription(account, params, send_read_message)
+        state = :subscribed
       end
       invalidate_sw_subscription_cache(account.id)
       return {subscription:, state:}
@@ -175,8 +175,6 @@ module Mulukhiya
       row = Misskey::SwSubscription.first(
         userId: account.id,
         endpoint: params[:endpoint],
-        auth: params[:auth],
-        publickey: params[:publickey],
       )
       return nil unless row
       row.delete
@@ -215,6 +213,30 @@ module Mulukhiya
     end
 
     private
+
+    def create_sw_subscription(account, params, send_read_message)
+      return Misskey::SwSubscription.create(
+        id: self.class.create_aid,
+        userId: account.id,
+        endpoint: params[:endpoint],
+        auth: params[:auth],
+        publickey: params[:publickey],
+        sendReadMessage: send_read_message,
+      )
+    end
+
+    def replace_sw_subscription(row, params, send_read_message)
+      changed =
+        row.auth != params[:auth] ||
+        row.publickey != params[:publickey] ||
+        row.sendReadMessage != send_read_message
+      return unless changed
+      row.update(
+        auth: params[:auth],
+        publickey: params[:publickey],
+        sendReadMessage: send_read_message,
+      )
+    end
 
     def invalidate_sw_subscription_cache(user_id)
       key = "kvcache:userSwSubscriptions:#{user_id}"

--- a/app/lib/mulukhiya/service/misskey_service.rb
+++ b/app/lib/mulukhiya/service/misskey_service.rb
@@ -155,13 +155,9 @@ module Mulukhiya
       # auth / publickey は端末側で再生成され得る（再インストール・鍵ローテ等）ため
       # キーに含めず、再登録時は既存行を UPDATE で置換して行を増やさない (#4408)。
       send_read_message = params[:sendReadMessage] == true
-      existing = Misskey::SwSubscription.first(
-        userId: account.id,
-        endpoint: params[:endpoint],
-      )
-      if existing
-        replace_sw_subscription(existing, params, send_read_message)
-        subscription = existing
+      rows = sw_subscriptions(account, params).all
+      if rows.any?
+        subscription = consolidate_sw_subscriptions(rows, params, send_read_message)
         state = :already_subscribed
       else
         subscription = create_sw_subscription(account, params, send_read_message)
@@ -172,14 +168,12 @@ module Mulukhiya
     end
 
     def unregister_sw_subscription(account, params)
-      row = Misskey::SwSubscription.first(
-        userId: account.id,
-        endpoint: params[:endpoint],
-      )
-      return nil unless row
-      row.delete
+      rows = sw_subscriptions(account, params).all
+      return nil if rows.empty?
+      # pre-fix の鍵ローテ蓄積で複数行残り得るため、endpoint 単位で全行削除する。
+      rows.each(&:delete)
       invalidate_sw_subscription_cache(account.id)
-      return row
+      return rows.first
     end
 
     def self.parse_aid(aid)
@@ -213,6 +207,24 @@ module Mulukhiya
     end
 
     private
+
+    def sw_subscriptions(account, params)
+      return Misskey::SwSubscription.where(
+        userId: account.id,
+        endpoint: params[:endpoint],
+      )
+    end
+
+    # pre-fix の鍵ローテ蓄積で同一 (userId, endpoint) に複数行ある場合、先頭を
+    # canonical として残し他を削除する。1 行しか更新しないと残った重複行が
+    # Misskey の購読キャッシュ再構築後も配信され、再登録後も重複プッシュが
+    # 続くため、再登録経路で必ず全行を 1 行へ集約する (#4408 Codex P1)。
+    def consolidate_sw_subscriptions(rows, params, send_read_message)
+      canonical, *stale = rows
+      stale.each(&:delete)
+      replace_sw_subscription(canonical, params, send_read_message)
+      return canonical
+    end
 
     def create_sw_subscription(account, params, send_read_message)
       return Misskey::SwSubscription.create(

--- a/test/unit/service/misskey_service.rb
+++ b/test/unit/service/misskey_service.rb
@@ -153,6 +153,35 @@ module Mulukhiya
       end
     end
 
+    def test_register_sw_subscription_consolidates_preexisting_duplicates
+      return unless Environment.misskey? && account
+
+      endpoint = "https://push.test/#{SecureRandom.hex(8)}"
+      cleanup = -> {Misskey::SwSubscription.where(userId: account.id, endpoint:).delete}
+      cleanup.call
+      begin
+        # pre-fix の鍵ローテ蓄積を模し、同一 (userId, endpoint) に複数行を直接作る。
+        2.times do |i|
+          Misskey::SwSubscription.create(
+            id: MisskeyService.create_aid, userId: account.id, endpoint:,
+            auth: "old_#{i}", publickey: "oldkey_#{i}", sendReadMessage: true
+          )
+        end
+        result = @service.register_sw_subscription(account, {
+          endpoint:, auth: 'auth_new', publickey: 'key_new', sendReadMessage: false
+        })
+
+        assert_equal(:already_subscribed, result[:state])
+        rows = Misskey::SwSubscription.where(userId: account.id, endpoint:).all
+
+        assert_equal(1, rows.size)
+        assert_equal('auth_new', rows.first.auth)
+        assert_equal('key_new', rows.first.publickey)
+      ensure
+        cleanup.call
+      end
+    end
+
     def test_parse_emoji_palette_entries_with_nil
       assert_equal([], @service.send(:parse_emoji_palette_entries, nil))
     end

--- a/test/unit/service/misskey_service.rb
+++ b/test/unit/service/misskey_service.rb
@@ -126,6 +126,33 @@ module Mulukhiya
       assert_equal({id: 'p2', name: 'パレ2', emojis: []}, entries[1])
     end
 
+    def test_register_sw_subscription_dedup_on_key_rotation
+      return unless Environment.misskey? && account
+
+      endpoint = "https://push.test/#{SecureRandom.hex(8)}"
+      cleanup = -> {Misskey::SwSubscription.where(userId: account.id, endpoint:).delete}
+      cleanup.call
+      begin
+        first = @service.register_sw_subscription(account, {
+          endpoint:, auth: 'auth_a', publickey: 'key_a', sendReadMessage: true
+        })
+        second = @service.register_sw_subscription(account, {
+          endpoint:, auth: 'auth_b', publickey: 'key_b', sendReadMessage: false
+        })
+
+        assert_equal(:subscribed, first[:state])
+        assert_equal(:already_subscribed, second[:state])
+        rows = Misskey::SwSubscription.where(userId: account.id, endpoint:).all
+
+        assert_equal(1, rows.size)
+        assert_equal('auth_b', rows.first.auth)
+        assert_equal('key_b', rows.first.publickey)
+        refute(rows.first.sendReadMessage)
+      ensure
+        cleanup.call
+      end
+    end
+
     def test_parse_emoji_palette_entries_with_nil
       assert_equal([], @service.send(:parse_emoji_palette_entries, nil))
     end


### PR DESCRIPTION
## 概要

`/mulukhiya/api/sw/register` 経由で登録した Misskey の `sw_subscription` が、同一 (userId, endpoint) に対して複数行蓄積する不具合 (#4408) を修正。

## 原因

[register_sw_subscription](../blob/develop/app/lib/mulukhiya/service/misskey_service.rb) の dedup キーが auth / publickey まで含んでいた。capsicum 側は端末の ECDH 鍵（auth / publickey）を再生成することがあり（再インストール・鍵ローテ等）、鍵が変わると同一 endpoint でも `first(key)` が既存にヒットせず新規行を CREATE していた。1 endpoint に N 行あると Misskey が 1 通知で N 回 Web Push を送り、端末に重複プッシュ通知（pooza/capsicum#692）が出る。

## 変更

- **register**: dedup を `(userId, endpoint)` 単位に変更。再登録時は既存行の `auth` / `publickey` / `sendReadMessage` を UPDATE で置換し、行を増やさない。
- **unregister**: 同じく `(userId, endpoint)` を一意キーに。鍵ローテ後でも対象行へ確実に到達できるよう register と対称化。
- `create_sw_subscription` / `replace_sw_subscription` を private ヘルパーに抽出。
- **test**: Misskey CI で実 DB に対し、鍵をローテして再登録しても 1 行のみ残り auth/publickey/sendReadMessage が置換されることを検証（`Environment.misskey?` ガード・テスト後にクリーンアップ）。

## エッジケース

1 endpoint に複数デバイスがぶら下がることは無い（capsicum の endpoint は push_token を URL に埋め込み端末ごとに一意）ため、(userId, endpoint) 一意化で多デバイスを壊さない。

Closes #4408

🤖 Generated with [Claude Code](https://claude.com/claude-code)