### PR TITLE
5.27.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ dist
 tmp/
 var/*.yaml
 2
+
+# ローカル Redis ダンプ
+dump.rdb

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-core.git
-  revision: b2e3d06d7702c6c1e743dd3b4168dda5d74b553e
+  revision: 98a72b02e5c560e7bf9914fe5b13e89bfbff51b6
   branch: main
   specs:
-    ginseng-core (1.15.25)
+    ginseng-core (1.15.26)
       activesupport (>= 7.0.7.1)
       addressable (>= 2.9.0)
       cgi (>= 0.4.2)
@@ -268,7 +268,7 @@ GEM
     mustermann (3.1.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.4)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)
@@ -356,7 +356,7 @@ GEM
       netrc (~> 0.8)
     rexml (3.4.4)
     ricecream (0.2.1)
-    rss (0.3.2)
+    rss (0.3.3)
       rexml
     rubocop (1.87.0)
       json (~> 2.3)
@@ -398,12 +398,12 @@ GEM
     sassc (2.4.0)
       ffi (~> 1.9)
     securerandom (0.4.1)
-    sentry-ruby (6.6.1)
+    sentry-ruby (6.6.2)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
       logger
-    sentry-sidekiq (6.6.1)
-      sentry-ruby (~> 6.6.1)
+    sentry-sidekiq (6.6.2)
+      sentry-ruby (~> 6.6.2)
       sidekiq (>= 5.0)
     sequel (5.105.0)
       bigdecimal
@@ -513,4 +513,4 @@ RUBY VERSION
   ruby 4.0.5
 
 BUNDLED WITH
-  4.0.13
+  4.0.14

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,7 @@ GEM
       bundler (>= 1.2.0)
       thor (~> 1.0)
     cgi (0.5.1)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     crack (1.0.1)
       bigdecimal
@@ -199,8 +199,8 @@ GEM
       tzinfo
     etc (1.4.6)
     eventmachine (1.2.7)
-    facets (3.2.0)
-    faraday (2.14.2)
+    facets (3.2.2)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -226,7 +226,7 @@ GEM
       csv
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
-    i18n (1.14.8)
+    i18n (1.15.1)
       concurrent-ruby (~> 1.0)
     icalendar (2.12.3)
       base64
@@ -234,7 +234,7 @@ GEM
       logger
       ostruct
     ice_cube (0.17.0)
-    json (2.19.8)
+    json (2.19.9)
     json-schema (6.2.0)
       addressable (~> 2.8)
       bigdecimal (>= 3.1, < 5)
@@ -288,14 +288,14 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
-    oauth2 (2.0.22)
+    oauth2 (2.0.23)
       auth-sanitizer (~> 0.2, >= 0.2.1)
       faraday (>= 0.17.3, < 4.0)
       jwt (>= 1.0, < 4.0)
       logger (~> 1.2)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 4)
-      snaky_hash (~> 2.0, >= 2.0.5)
+      snaky_hash (~> 2.0, >= 2.0.6)
       version_gem (~> 1.1, >= 1.1.11)
     omniauth (2.1.4)
       hashie (>= 3.4.6)
@@ -346,7 +346,7 @@ GEM
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rainbow (3.1.1)
     rake (13.3.1)
-    redis-client (0.29.0)
+    redis-client (0.30.0)
       connection_pool
     regexp_parser (2.12.0)
     rest-client (2.1.0)
@@ -358,7 +358,7 @@ GEM
     ricecream (0.2.1)
     rss (0.3.3)
       rexml
-    rubocop (1.87.0)
+    rubocop (1.88.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -431,7 +431,7 @@ GEM
       rexml (~> 3.2)
       rubocop (>= 1.0, < 2.0)
       slim (>= 3.0, < 6.0)
-    snaky_hash (2.0.5)
+    snaky_hash (2.0.6)
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
     syslog (0.4.0)
@@ -452,7 +452,7 @@ GEM
     unicode-emoji (4.2.0)
     uri (1.1.1)
     useragent (0.16.11)
-    version_gem (1.1.11)
+    version_gem (1.1.12)
     webmock (3.26.2)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)

--- a/app/lib/mulukhiya/contract/nowplaying_resolve_url_contract.rb
+++ b/app/lib/mulukhiya/contract/nowplaying_resolve_url_contract.rb
@@ -1,0 +1,14 @@
+module Mulukhiya
+  class NowplayingResolveUrlContract < Contract
+    MAX_URL_SIZE = 2048
+    URL_FORMAT = %r{\Ahttps?://}
+
+    params do
+      required(:url).filled(:string, max_size?: MAX_URL_SIZE)
+    end
+
+    rule(:url) do
+      key.failure('URL は http(s):// で始まる URL を指定してください。') unless URL_FORMAT.match?(value.to_s)
+    end
+  end
+end

--- a/app/lib/mulukhiya/contract/spotify_auth_contract.rb
+++ b/app/lib/mulukhiya/contract/spotify_auth_contract.rb
@@ -1,0 +1,8 @@
+module Mulukhiya
+  class SpotifyAuthContract < Contract
+    params do
+      required(:token).value(:string)
+      required(:code).value(:string)
+    end
+  end
+end

--- a/app/lib/mulukhiya/contract/spotify_auth_contract.rb
+++ b/app/lib/mulukhiya/contract/spotify_auth_contract.rb
@@ -1,7 +1,8 @@
 module Mulukhiya
   class SpotifyAuthContract < Contract
     params do
-      required(:token).value(:string)
+      # ユーザー特定は APIController の bearer 認証 (sns.account) で行うため、
+      # body への token 重複は要求しない。検証するのは認可 code のみ。
       required(:code).value(:string)
     end
   end

--- a/app/lib/mulukhiya/contract/word_suggest_contract.rb
+++ b/app/lib/mulukhiya/contract/word_suggest_contract.rb
@@ -2,6 +2,10 @@ module Mulukhiya
   class WordSuggestContract < Contract
     params do
       required(:q).value(:string)
+      # limit はあえて型を付けない。query string 由来で配列 (limit[]=1) 等の不正値も
+      # 届くが、ここで型検証して 400 にせず PronunciationDictionary#clamp_limit が
+      # 非スカラー・非正値を既定値へ倒す方針 (#4397)。型を付けると clamp の防御が
+      # 殺され、公開エンドポイントが malformed limit で 400 を返すようになる。
       optional(:limit)
     end
   end

--- a/app/lib/mulukhiya/controller.rb
+++ b/app/lib/mulukhiya/controller.rb
@@ -11,7 +11,8 @@ module Mulukhiya
     # @params を使うため、ログ用の複製だけ top-level の該当キーをマスクする。
     SCRUBBED_LOG_PARAMS = [
       'status', 'text', 'body', 'comment', 'spoiler_text', 'cw',
-      'q', 'title', 'artist', 'album' # word/suggest・nowplaying のユーザー入力 (#4394)
+      'q', 'title', 'artist', 'album', # word/suggest・nowplaying のユーザー入力 (#4394)
+      'code' # OAuth 認可コード (spotify/auth・annict/auth)。短命だが資格情報なので伏せる
     ].freeze
 
     set :root, Environment.dir

--- a/app/lib/mulukhiya/controller/api_controller.rb
+++ b/app/lib/mulukhiya/controller/api_controller.rb
@@ -456,6 +456,23 @@ module Mulukhiya
       return @renderer.to_s
     end
 
+    post '/nowplaying/resolve-url' do
+      raise Ginseng::AuthError, 'Unauthorized' unless sns.account
+      errors = NowplayingResolveUrlContract.new.exec(params)
+      if errors.present?
+        @renderer.status = 422
+        @renderer.message = {errors:}
+        return @renderer.to_s
+      end
+      @renderer.message = NowplayingUrlResolver.new(url: params[:url]).resolve
+      return @renderer.to_s
+    rescue => e
+      e.log
+      @renderer.status = e.status
+      @renderer.message = {error: e.message}
+      return @renderer.to_s
+    end
+
     get '/annict/oauth_uri' do
       raise Ginseng::NotFoundError, 'Not Found' unless controller_class.annict?
       @renderer.message = {oauth_uri: AnnictService.new.oauth_uri.to_s}

--- a/app/lib/mulukhiya/controller/api_controller.rb
+++ b/app/lib/mulukhiya/controller/api_controller.rb
@@ -490,6 +490,75 @@ module Mulukhiya
       return @renderer.to_s
     end
 
+    get '/spotify/oauth_uri' do
+      raise Ginseng::NotFoundError, 'Not Found' unless SpotifyUserService.config?
+      @renderer.message = {oauth_uri: SpotifyUserService.new.oauth_uri.to_s}
+      return @renderer.to_s
+    rescue => e
+      e.alert
+      @renderer.status = e.status
+      @renderer.message = {error: e.message}
+      return @renderer.to_s
+    end
+
+    post '/spotify/auth' do
+      raise Ginseng::NotFoundError, 'Not Found' unless SpotifyUserService.config?
+      raise Ginseng::AuthError, 'Unauthorized' unless sns.account
+      errors = SpotifyAuthContract.new.exec(params)
+      if errors.present?
+        @renderer.status = 422
+        @renderer.message = {errors:}
+      else
+        SpotifyUserService.new(sns.account).auth(params[:code])
+        @renderer.message = {config: sns.account.user_config.to_h}
+      end
+      return @renderer.to_s
+    rescue => e
+      e.alert
+      @renderer.status = e.status
+      @renderer.message = {error: e.message}
+      return @renderer.to_s
+    end
+
+    get '/spotify/currently_playing' do
+      raise Ginseng::NotFoundError, 'Not Found' unless SpotifyUserService.config?
+      raise Ginseng::AuthError, 'Unauthorized' unless sns.account
+      spotify = sns.account.spotify
+      raise Ginseng::AuthError, 'Spotify authentication required' unless spotify
+      @renderer.message = {url: spotify.currently_playing}
+      return @renderer.to_s
+    rescue Ginseng::GatewayError => e
+      e.log
+      @renderer.status = e.respond_to?(:source_status) ? e.source_status : 502
+      @renderer.message = {error: e.message}
+      return @renderer.to_s
+    rescue Ginseng::AuthError => e
+      # 未連携・refresh_token 失効は想定内のユーザー状態。capsicum が定期ポーリング
+      # するため alert すると Sentry スパム化する。log に留め 403 で返す。
+      e.log
+      @renderer.status = e.status
+      @renderer.message = {error: e.message}
+      return @renderer.to_s
+    rescue => e
+      e.alert
+      @renderer.status = e.status
+      @renderer.message = {error: e.message}
+      return @renderer.to_s
+    end
+
+    delete '/spotify/auth' do
+      raise Ginseng::NotFoundError, 'Not Found' unless SpotifyUserService.config?
+      raise Ginseng::AuthError, 'Unauthorized' unless sns.account
+      sns.account.spotify&.unlink
+      @renderer.message = {config: sns.account.user_config.to_h}
+      return @renderer.to_s
+    rescue => e
+      e.alert
+      @renderer.status = e.status
+      @renderer.message = {error: e.message}
+      return @renderer.to_s
+    end
+
     post '/annict/record' do
       raise Ginseng::NotFoundError, 'Not Found' unless controller_class.annict?
       raise Ginseng::AuthError, 'Unauthorized' unless sns.account

--- a/app/lib/mulukhiya/dynamic_features.rb
+++ b/app/lib/mulukhiya/dynamic_features.rb
@@ -13,6 +13,8 @@ module Mulukhiya
   #                        URL 設定の有無に一本化し二重管理を避ける
   #   - nowplaying_resolver : ナウプレ enrich (#4382)。メタデータ → 共有 URL 解決
   #                        エンドポイントの可否。capsicum が enrich を試みるか判定に使う
+  #   - nowplaying_url_resolver : ナウプレ enrich の逆方向 (#4415)。共有 URL → メタ解決
+  #                        エンドポイントの可否。capsicum の Share 経路 enrich 判定に使う
   #
   # 新しい動的フラグ (例: spotify_linked) を増やす際は REGISTRY に 1 行追加する。
   class DynamicFeatures
@@ -26,6 +28,7 @@ module Mulukhiya
       },
       'word_suggest' => ->(_sns) {PronunciationDictionary.new.enabled?},
       'nowplaying_resolver' => ->(_sns) {NowplayingResolver.enabled?},
+      'nowplaying_url_resolver' => ->(_sns) {NowplayingUrlResolver.enabled?},
     }.freeze
 
     def initialize(sns)

--- a/app/lib/mulukhiya/dynamic_features.rb
+++ b/app/lib/mulukhiya/dynamic_features.rb
@@ -13,8 +13,12 @@ module Mulukhiya
   #                        URL 設定の有無に一本化し二重管理を避ける
   #   - nowplaying_resolver : ナウプレ enrich (#4382)。メタデータ → 共有 URL 解決
   #                        エンドポイントの可否。capsicum が enrich を試みるか判定に使う
+  #   - spotify_enabled  : Spotify user OAuth (#4337) がサーバーで有効か。Developer
+  #                        Dashboard 登録 + user_oauth_enabled を満たすか。capsicum が
+  #                        連携導線を出すか判定に使う
+  #   - spotify_linked   : リクエストの SNS アカウント単位の Spotify 連携状態 (#4337)
   #
-  # 新しい動的フラグ (例: spotify_linked) を増やす際は REGISTRY に 1 行追加する。
+  # 新しい動的フラグを増やす際は REGISTRY に 1 行追加する。
   class DynamicFeatures
     include Package
 
@@ -26,6 +30,8 @@ module Mulukhiya
       },
       'word_suggest' => ->(_sns) {PronunciationDictionary.new.enabled?},
       'nowplaying_resolver' => ->(_sns) {NowplayingResolver.enabled?},
+      'spotify_enabled' => ->(_sns) {SpotifyUserService.config?},
+      'spotify_linked' => ->(sns) {sns.account&.spotify_linked? || false},
     }.freeze
 
     def initialize(sns)

--- a/app/lib/mulukhiya/model/account_methods.rb
+++ b/app/lib/mulukhiya/model/account_methods.rb
@@ -81,6 +81,23 @@ module Mulukhiya
       return false
     end
 
+    def spotify
+      return nil unless user_config['/service/spotify/refresh_token']
+      @spotify ||= SpotifyUserService.new(self)
+      return @spotify
+    end
+
+    # 当該ユーザーに Spotify refresh_token が保管済みか (#4337)。
+    # capsicum が features.spotify_linked でナウプレ取得導線の出し分けに使う。
+    # access_token は失効するため refresh_token の有無で「連携済み」を表す
+    # (liveness/refresh 確認は about を重くするため範囲外)。
+    def spotify_linked?
+      return user_config['/service/spotify/refresh_token'].present?
+    rescue => e
+      e.log(acct: acct.to_s)
+      return false
+    end
+
     def featured_tags
       return TagContainer.new
     end

--- a/app/lib/mulukhiya/nowplaying_url_resolver.rb
+++ b/app/lib/mulukhiya/nowplaying_url_resolver.rb
@@ -1,0 +1,78 @@
+module Mulukhiya
+  # ナウプレ URL→メタ解決プロキシ (#4415 / capsicum#729)。共有 (Share) 経路は
+  # ShareExtension から URL しか受け取らず title/artist/album を持たないため、
+  # capsicum が in-app と同じ formatter で整形できるよう URL からメタを逆引きする。
+  #
+  # メタデータ → 共有 URL を解決する NowplayingResolver (#4382) と対になる、逆方向
+  # (URL → メタデータ) の読み取り専用 enrich。テキスト整形は行わず (整形は capsicum
+  # 側)、外部 API が返す正規化済みメタデータと URL のみを返す。
+  class NowplayingUrlResolver
+    include Package
+
+    # iTunes 経路は資格情報不要で常時利用可能なため resolver は常に有効。
+    # /about の features.nowplaying_url_resolver の正本 (capsicum の enrich 試行判定)。
+    def self.enabled?
+      return true
+    end
+
+    def initialize(url:)
+      @url = url.to_s.strip
+    end
+
+    # host でプロバイダを振り分け、URL からメタを抽出した
+    # {url:, provider:, normalized: {title, artist, album}} を返す (resolve と同形)。
+    # 解決不可 (未対応 host / track・album とも nil) は {url: nil} (404 ではなく 200 + null)。
+    def resolve
+      return {url: nil} if @url.empty?
+      uri = parse
+      return {url: nil} unless uri
+      title = uri.track_name
+      album = uri.album_name
+      return {url: nil} if title.nil? && album.nil?
+      return {
+        url: uri.to_s,
+        provider:,
+        normalized: {
+          title:,
+          artist: Array(uri.artists).join(', ').presence,
+          album:,
+        }.compact,
+      }
+    rescue => e
+      # url はユーザー入力なのでログに残さない (#4394 と同方針)。
+      e.log(provider: provider)
+      return {url: nil}
+    end
+
+    private
+
+    # host から振り分けた URI クラスでパースする。Spotify は資格情報必須なので
+    # 未設定なら nil (apple_music は資格情報不要)。未対応 host も nil。
+    def parse
+      case provider
+      when 'spotify'
+        return nil unless SpotifyService.config?
+        return SpotifyURI.parse(@url)
+      when 'apple_music'
+        return ItunesURI.create(@url)
+      end
+    end
+
+    def provider
+      @provider ||= detect_provider
+    end
+
+    def detect_provider
+      host = base_uri&.host.to_s.downcase
+      return 'spotify' if host.split('.').member?('spotify')
+      return 'apple_music' if config['/service/itunes/hosts'].member?(host)
+      return nil
+    end
+
+    def base_uri
+      @base_uri ||= Ginseng::URI.parse(@url)
+    rescue
+      return nil
+    end
+  end
+end

--- a/app/lib/mulukhiya/pronunciation_dictionary.rb
+++ b/app/lib/mulukhiya/pronunciation_dictionary.rb
@@ -32,7 +32,7 @@ module Mulukhiya
     end
 
     def entries
-      @entries ||= cached_entries || (update && cached_entries) || []
+      @entries ||= cached_entries || enqueue_update_and_empty
     end
 
     def size
@@ -74,6 +74,22 @@ module Mulukhiya
     end
 
     private
+
+    # cold-cache (Redis 未充填) 時のフォールバック。同期 remote fetch すると公開
+    # /word/suggest のリクエストスレッド (Puma) を GAS 取得の間ブロックするため、
+    # 充填は非同期ワーカーへ委ね、当該リクエストは空候補で即返す。cold-window は
+    # Redis flush / 再起動直後等に限られ、数秒後にはワーカーが充填する (#4405)。
+    # 短時間に複数リクエストが来ると enqueue が重複し得るが、update は冪等
+    # (再 fetch して SET するだけ) かつ retry:false なので実害はない。
+    def enqueue_update_and_empty
+      PronunciationDictionaryUpdateWorker.perform_async
+      return []
+    rescue => e
+      # enqueue 先 (Sidekiq Redis) 障害等。public エンドポイントから per-request で
+      # 呼ばれるため alert せず log に留め、空候補で返す。
+      e.log
+      return []
+    end
 
     # 候補マッチの優先度。小さいほど上位。マッチしなければ nil。
     def match_rank(entry, reading_query, surface_query)

--- a/app/lib/mulukhiya/service/misskey_service.rb
+++ b/app/lib/mulukhiya/service/misskey_service.rb
@@ -151,21 +151,21 @@ module Mulukhiya
     end
 
     def register_sw_subscription(account, params)
-      key = {
+      # endpoint は配信先を一意に指すアドレスなので (userId, endpoint) で dedup する。
+      # auth / publickey は端末側で再生成され得る（再インストール・鍵ローテ等）ため
+      # キーに含めず、再登録時は既存行を UPDATE で置換して行を増やさない (#4408)。
+      send_read_message = params[:sendReadMessage] == true
+      existing = Misskey::SwSubscription.first(
         userId: account.id,
         endpoint: params[:endpoint],
-        auth: params[:auth],
-        publickey: params[:publickey],
-      }
-      send_read_message = params[:sendReadMessage] == true
-      existing = Misskey::SwSubscription.first(key)
-      state = existing ? :already_subscribed : :subscribed
-      subscription = existing || Misskey::SwSubscription.create(key.merge(
-        id: self.class.create_aid,
-        sendReadMessage: send_read_message,
-      ))
-      if existing && existing.sendReadMessage != send_read_message
-        subscription.update(sendReadMessage: send_read_message)
+      )
+      if existing
+        replace_sw_subscription(existing, params, send_read_message)
+        subscription = existing
+        state = :already_subscribed
+      else
+        subscription = create_sw_subscription(account, params, send_read_message)
+        state = :subscribed
       end
       invalidate_sw_subscription_cache(account.id)
       return {subscription:, state:}
@@ -175,8 +175,6 @@ module Mulukhiya
       row = Misskey::SwSubscription.first(
         userId: account.id,
         endpoint: params[:endpoint],
-        auth: params[:auth],
-        publickey: params[:publickey],
       )
       return nil unless row
       row.delete
@@ -215,6 +213,30 @@ module Mulukhiya
     end
 
     private
+
+    def create_sw_subscription(account, params, send_read_message)
+      return Misskey::SwSubscription.create(
+        id: self.class.create_aid,
+        userId: account.id,
+        endpoint: params[:endpoint],
+        auth: params[:auth],
+        publickey: params[:publickey],
+        sendReadMessage: send_read_message,
+      )
+    end
+
+    def replace_sw_subscription(row, params, send_read_message)
+      changed =
+        row.auth != params[:auth] ||
+        row.publickey != params[:publickey] ||
+        row.sendReadMessage != send_read_message
+      return unless changed
+      row.update(
+        auth: params[:auth],
+        publickey: params[:publickey],
+        sendReadMessage: send_read_message,
+      )
+    end
 
     def invalidate_sw_subscription_cache(user_id)
       key = "kvcache:userSwSubscriptions:#{user_id}"

--- a/app/lib/mulukhiya/service/misskey_service.rb
+++ b/app/lib/mulukhiya/service/misskey_service.rb
@@ -155,13 +155,9 @@ module Mulukhiya
       # auth / publickey は端末側で再生成され得る（再インストール・鍵ローテ等）ため
       # キーに含めず、再登録時は既存行を UPDATE で置換して行を増やさない (#4408)。
       send_read_message = params[:sendReadMessage] == true
-      existing = Misskey::SwSubscription.first(
-        userId: account.id,
-        endpoint: params[:endpoint],
-      )
-      if existing
-        replace_sw_subscription(existing, params, send_read_message)
-        subscription = existing
+      rows = sw_subscriptions(account, params).all
+      if rows.any?
+        subscription = consolidate_sw_subscriptions(rows, params, send_read_message)
         state = :already_subscribed
       else
         subscription = create_sw_subscription(account, params, send_read_message)
@@ -172,14 +168,12 @@ module Mulukhiya
     end
 
     def unregister_sw_subscription(account, params)
-      row = Misskey::SwSubscription.first(
-        userId: account.id,
-        endpoint: params[:endpoint],
-      )
-      return nil unless row
-      row.delete
+      rows = sw_subscriptions(account, params).all
+      return nil if rows.empty?
+      # pre-fix の鍵ローテ蓄積で複数行残り得るため、endpoint 単位で全行削除する。
+      rows.each(&:delete)
       invalidate_sw_subscription_cache(account.id)
-      return row
+      return rows.first
     end
 
     def self.parse_aid(aid)
@@ -213,6 +207,24 @@ module Mulukhiya
     end
 
     private
+
+    def sw_subscriptions(account, params)
+      return Misskey::SwSubscription.where(
+        userId: account.id,
+        endpoint: params[:endpoint],
+      )
+    end
+
+    # pre-fix の鍵ローテ蓄積で同一 (userId, endpoint) に複数行ある場合、先頭を
+    # canonical として残し他を削除する。1 行しか更新しないと残った重複行が
+    # Misskey の購読キャッシュ再構築後も配信され、再登録後も重複プッシュが
+    # 続くため、再登録経路で必ず全行を 1 行へ集約する (#4408 Codex P1)。
+    def consolidate_sw_subscriptions(rows, params, send_read_message)
+      canonical, *stale = rows
+      stale.each(&:delete)
+      replace_sw_subscription(canonical, params, send_read_message)
+      return canonical
+    end
 
     def create_sw_subscription(account, params, send_read_message)
       return Misskey::SwSubscription.create(

--- a/app/lib/mulukhiya/service/spotify_user_service.rb
+++ b/app/lib/mulukhiya/service/spotify_user_service.rb
@@ -13,9 +13,9 @@ module Mulukhiya
   class SpotifyUserService
     include Package
 
-    AUTHORIZE_PATH = '/authorize'
-    TOKEN_PATH = '/api/token'
-    CURRENTLY_PLAYING_PATH = '/v1/me/player/currently-playing'
+    AUTHORIZE_PATH = '/authorize'.freeze
+    TOKEN_PATH = '/api/token'.freeze
+    CURRENTLY_PLAYING_PATH = '/v1/me/player/currently-playing'.freeze
 
     # account は currently_playing / auth / unlink で必要 (refresh したトークンを
     # UserConfig へ書き戻すため)。oauth_uri のみ account なしでも使える。
@@ -67,8 +67,8 @@ module Mulukhiya
     # 連携解除。保管した access/refresh/expires_at を除去する (deep_compact で nil は
     # 削除されるため、これで未連携状態に戻る)。
     def unlink
-      @account.user_config.update(service: {spotify: {token: nil, refresh_token: nil, expires_at: nil}})
-      return true
+      cleared = {token: nil, refresh_token: nil, expires_at: nil}
+      return @account.user_config.update(service: {spotify: cleared})
     end
 
     def self.client_id

--- a/app/lib/mulukhiya/service/spotify_user_service.rb
+++ b/app/lib/mulukhiya/service/spotify_user_service.rb
@@ -1,0 +1,196 @@
+module Mulukhiya
+  # capsicum のナウプレ投稿 (capsicum #465) 向けの user-level OAuth サービス (#4337)。
+  #
+  # 既存の SpotifyService (Client Credentials Flow / app-level、track 検索・lookup 用)
+  # とは別系統で、Authorization Code Flow により当該ユーザーの
+  # GET /v1/me/player/currently-playing を呼ぶ。capsicum に client_secret を置かず
+  # サーバー (モロヘイヤ) がトークンを保管する点は Annict 連携 (#4338) と同方針。
+  #
+  # トークンは UserConfig (Redis、暗号化) に保管する。Spotify の access_token は
+  # 3600s で失効するため refresh_token も保管し、失効時/401 時に自動更新する。
+  # capsicum 側は code-post 方式で、ブラウザ認可後の code を POST /api/spotify/auth に
+  # 渡すだけでよい (ユーザー特定は SNS トークンで行うため state は不要)。
+  class SpotifyUserService
+    include Package
+
+    AUTHORIZE_PATH = '/authorize'
+    TOKEN_PATH = '/api/token'
+    CURRENTLY_PLAYING_PATH = '/v1/me/player/currently-playing'
+
+    # account は currently_playing / auth / unlink で必要 (refresh したトークンを
+    # UserConfig へ書き戻すため)。oauth_uri のみ account なしでも使える。
+    def initialize(account = nil)
+      @account = account
+    end
+
+    def oauth_uri
+      uri = accounts_service.create_uri(AUTHORIZE_PATH)
+      uri.query_values = {
+        client_id: self.class.client_id,
+        response_type: 'code',
+        redirect_uri: redirect_uri,
+        scope: scopes.join(' '),
+      }
+      return uri
+    end
+
+    # authorization code を access_token + refresh_token に交換し保管する。
+    def auth(code)
+      response = token_request(
+        'grant_type' => 'authorization_code',
+        'code' => code,
+        'redirect_uri' => redirect_uri,
+      )
+      store_tokens(response.parsed_response)
+      return response
+    end
+
+    # 現在再生中トラックの共有 URL を返す。無再生・広告・プライベートセッション
+    # (204 / item なし) は nil。access_token 失効は事前 refresh で、保管値が古い等の
+    # 401 は事後 refresh + 1 回リトライで吸収する。
+    def currently_playing
+      refresh! if expired?
+      attempts = 0
+      begin
+        response = api_service.get(CURRENTLY_PLAYING_PATH, headers: bearer_headers)
+        return nil if response.code == 204
+        return extract_track_url(response.parsed_response)
+      rescue Ginseng::GatewayError => e
+        raise unless e.source_status == 401
+        attempts += 1
+        raise if attempts > 1
+        refresh!
+        retry
+      end
+    end
+
+    # 連携解除。保管した access/refresh/expires_at を除去する (deep_compact で nil は
+    # 削除されるため、これで未連携状態に戻る)。
+    def unlink
+      @account.user_config.update(service: {spotify: {token: nil, refresh_token: nil, expires_at: nil}})
+      return true
+    end
+
+    def self.client_id
+      return config['/service/spotify/client/id'] rescue nil
+    end
+
+    def self.client_secret
+      return config['/service/spotify/client/secret'].decrypt
+    rescue Ginseng::ConfigError
+      return nil
+    rescue
+      return config['/service/spotify/client/secret']
+    end
+
+    # user OAuth が利用可能か (features.spotify_enabled の正本)。Spotify Developer
+    # Dashboard 側で Redirect URI / Scope 登録が済むまでは user_oauth_enabled を false に
+    # しておき、capsicum に連携導線を出させない。
+    def self.config?
+      return false unless config['/service/spotify/oauth/user_oauth_enabled']
+      return false unless client_id
+      return false unless client_secret
+      return true
+    rescue => e
+      e.log
+      return false
+    end
+
+    private
+
+    def redirect_uri
+      return config['/service/spotify/oauth/redirect_uri']
+    end
+
+    def scopes
+      return Array(config['/service/spotify/oauth/scopes'])
+    end
+
+    def access_token
+      return decrypt(@account.user_config['/service/spotify/token'])
+    end
+
+    def refresh_token
+      return decrypt(@account.user_config['/service/spotify/refresh_token'])
+    end
+
+    def expired?
+      expires_at = @account.user_config['/service/spotify/expires_at']
+      return true unless expires_at
+      return Time.now.to_i >= expires_at.to_i
+    end
+
+    def refresh!
+      raise Ginseng::AuthError, 'Spotify authentication required' unless refresh_token
+      response = token_request(
+        'grant_type' => 'refresh_token',
+        'refresh_token' => refresh_token,
+      )
+      store_tokens(response.parsed_response)
+      return response
+    rescue Ginseng::GatewayError => e
+      # refresh_token 失効/revoke (invalid_grant) は token endpoint が 4xx を返す。
+      # これは再認証が必要なユーザー起因エラーなので AuthError (401) に倒し、
+      # capsicum に再連携フローを誘導させる。5xx/timeout は Spotify 障害なので
+      # GatewayError (502) のまま上げる。
+      raise unless e.source_status&.between?(400, 499)
+      raise Ginseng::AuthError, 'Spotify re-authentication required'
+    end
+
+    def token_request(params)
+      return accounts_service.post(TOKEN_PATH, {
+        headers: {'Content-Type' => 'application/x-www-form-urlencoded'},
+        body: {
+          'client_id' => self.class.client_id,
+          'client_secret' => self.class.client_secret,
+        }.merge(params),
+      })
+    end
+
+    def store_tokens(body)
+      values = {
+        token: body['access_token'],
+        expires_at: Time.now.to_i + body['expires_in'].to_i,
+      }
+      # Spotify は refresh_token を毎回返すとは限らない。返らない場合は既存値を保持する
+      # (上書きで消すと以降 refresh 不能になる)。
+      values[:refresh_token] = body['refresh_token'] if body['refresh_token'].present?
+      @account.user_config.update(service: {spotify: values})
+    end
+
+    def extract_track_url(body)
+      return nil unless body.is_a?(Hash)
+      item = body['item']
+      return nil unless item.is_a?(Hash)
+      return item.dig('external_urls', 'spotify').presence
+    end
+
+    def bearer_headers
+      return {'Authorization' => "Bearer #{access_token}"}
+    end
+
+    # UserConfig は暗号化値をそのまま返す (read 時に復号しない) ため、利用側で復号する。
+    def decrypt(value)
+      return nil unless value
+      return value.decrypt
+    rescue
+      return value
+    end
+
+    def accounts_service
+      unless @accounts_service
+        @accounts_service = HTTP.new
+        @accounts_service.base_uri = config['/service/spotify/urls/accounts']
+      end
+      return @accounts_service
+    end
+
+    def api_service
+      unless @api_service
+        @api_service = HTTP.new
+        @api_service.base_uri = config['/service/spotify/urls/api']
+      end
+      return @api_service
+    end
+  end
+end

--- a/app/lib/mulukhiya/service/spotify_user_service.rb
+++ b/app/lib/mulukhiya/service/spotify_user_service.rb
@@ -1,3 +1,5 @@
+require 'base64'
+
 module Mulukhiya
   # capsicum のナウプレ投稿 (capsicum #465) 向けの user-level OAuth サービス (#4337)。
   #
@@ -138,13 +140,21 @@ module Mulukhiya
     end
 
     def token_request(params)
+      # Authorization Code Flow の /api/token は client 認証を HTTP Basic ヘッダで行う。
+      # client_id/secret を body にだけ入れると invalid_client で弾かれうるため、
+      # 認証はヘッダ、grant 固有パラメータのみ body に置く。
+      # https://developer.spotify.com/documentation/web-api/tutorials/code-flow#request-an-access-token
       return accounts_service.post(TOKEN_PATH, {
-        headers: {'Content-Type' => 'application/x-www-form-urlencoded'},
-        body: {
-          'client_id' => self.class.client_id,
-          'client_secret' => self.class.client_secret,
-        }.merge(params),
+        headers: {
+          'Content-Type' => 'application/x-www-form-urlencoded',
+          'Authorization' => "Basic #{basic_credentials}",
+        },
+        body: params,
       })
+    end
+
+    def basic_credentials
+      return Base64.strict_encode64("#{self.class.client_id}:#{self.class.client_secret}")
     end
 
     def store_tokens(body)
@@ -160,6 +170,9 @@ module Mulukhiya
 
     def extract_track_url(body)
       return nil unless body.is_a?(Hash)
+      # 一時停止中 (is_playing:false) は item が直前の選択トラックのまま 200 で返るため、
+      # ポーリング側が停止中トラックを再生中扱いしないよう再生中のみ URL を返す。
+      return nil unless body['is_playing'] == true
       item = body['item']
       return nil unless item.is_a?(Hash)
       return item.dig('external_urls', 'spotify').presence

--- a/app/lib/mulukhiya/worker/pronunciation_dictionary_update_worker.rb
+++ b/app/lib/mulukhiya/worker/pronunciation_dictionary_update_worker.rb
@@ -12,8 +12,12 @@ module Mulukhiya
       # enqueue するため、disable? を perform 側でも評価する。
       return if disable?
       dictionary = PronunciationDictionary.new
-      dictionary.update
-      log(entries: dictionary.size)
+      entries = dictionary.update
+      # 件数は update の戻り値 (保存できた entries / 失敗時 nil) から取る。
+      # dictionary.size 経由だと cold-cache 時に entries → enqueue_update_and_empty
+      # が走り、fetch / save 失敗ワーカーが次のワーカーを無限に再 enqueue する
+      # (retry:false でも防げない) (#4405 Codex P1)。
+      log(entries: entries&.size || 0)
       return dictionary
     end
   end

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -439,7 +439,7 @@ package:
     - tkoishi@b-shock.co.jp
   license: MIT
   url: https://github.com/pooza/mulukhiya-toot-proxy
-  version: 5.26.0
+  version: 5.27.0
 parser:
   note:
     fields:

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -581,6 +581,15 @@ service:
         - /videos/watch/
   spotify:
     language: ja,en-US;q=0.9,en;q=0.8
+    oauth:
+      # capsicum がブラウザ認可後の code を受け取れる Redirect URI。Spotify Developer
+      # Dashboard 側にも同値を登録する必要がある (#4337)。
+      redirect_uri: capsicum://spotify/callback
+      scopes:
+        - user-read-currently-playing
+      # Dashboard の Redirect URI / Scope 登録が済むまでは false。true で
+      # features.spotify_enabled が有効化され capsicum に連携導線が出る。
+      user_oauth_enabled: false
     patterns:
       - pattern: /track/([[:alnum:]]+)
         type: track
@@ -589,6 +598,8 @@ service:
     retry:
       seconds: 1
     urls:
+      accounts: https://accounts.spotify.com
+      api: https://api.spotify.com
       track: https://open.spotify.com/
 sharkey:
   capabilities:
@@ -655,6 +666,7 @@ spoiler:
 user_config:
   encrypt_fields:
     - token
+    - refresh_token
     - password
     - secret
   valid_keys:

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -582,9 +582,11 @@ service:
   spotify:
     language: ja,en-US;q=0.9,en;q=0.8
     oauth:
-      # capsicum がブラウザ認可後の code を受け取れる Redirect URI。Spotify Developer
-      # Dashboard 側にも同値を登録する必要がある (#4337)。
-      redirect_uri: capsicum://spotify/callback
+      # capsicum がブラウザ認可後の code を受け取る Redirect URI。デスクトップ向けに
+      # Spotify 公式推奨の loopback を採用。capsicum がクライアント機の 127.0.0.1 で
+      # 受けるためサーバー非依存の共通値。Spotify Developer Dashboard にも同値の登録が
+      # 必要 (#4337)。ポートは capsicum 側実装に合わせる (capsicum #570)。
+      redirect_uri: http://127.0.0.1:8888/spotify/callback
       scopes:
         - user-read-currently-playing
       # Dashboard の Redirect URI / Scope 登録が済むまでは false。true で

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -152,6 +152,30 @@ git diff Gemfile.lock
 # 5. 問題なければコミット
 ```
 
+## リリース済み: 5.26.0（2026-06-09）
+
+ナウプレ enrich プロキシ (#4382) と読み付き単語サジェスト API (#4397) の新設を主軸に、capsicum 連携（投稿サジェスト・ナウプレ共有 URL 解決）の土台を整えた回。あわせて Program の ProgramFetcher 分割 (#4347)、5.25.0 レビュー送り (#4394) の構造改善、本リリース前 5観点レビュー由来のログ/アラート整備を含む。
+
+- **#4382 feat: ナウプレ enrich プロキシ `POST /mulukhiya/api/nowplaying/resolve`** — Bearer 必須。構造化メタ（title/artist/album）→ Spotify/iTunes 検索 → 共有可能 URL 解決の読み取り専用 enrich。プロバイダ優先 `prefer`（capsicum トグル）> `source_app_name` ヒント > サーバー既定 `/nowplaying/resolve/default_provider`（既定 apple_music、フォールバック許可）。`features.nowplaying_resolver` 露出、整形は capsicum 側でモロヘイヤはステートレス。未使用の旧系統①（`itunes_nowplaying`/`spotify_nowplaying`）を削除し検索ロジックを resolver へ集約（capsicum #466/#484/#668/#570 連携）
+- **#4397 feat: 読み付き単語サジェスト API `GET /mulukhiya/api/word/suggest`** — capsicum #614 投稿サジェスト連携。`PronunciationDictionary` が GAS の pron.json を Redis キャッシュし、読み（ひらがな→カタカナ正規化はモロヘイヤ側で吸収）前方一致 → 表層前方一致 → 部分一致でランク付け、同ランクは五十音順タイブレーク（#4403）。`features.word_suggest` を `/word_suggest/urls` 設定有無で `DynamicFeatures::REGISTRY` から動的導出。本体 API #4398、HEAD 非対応ホスト（GAS）の content-length 事前チェック 403 ログ抑止 #4400
+- **#4347 refactor: Program クラスを ProgramFetcher へ分割** — fetch/キャッシュ責務を切り出し、rubocop Metrics/ClassLength disable 解除（5.25.0 から送り）
+- **#4394 5.25.0 リリース前 5観点レビュー 5.26.0 送り（黄・緑まとめ）** — favorites 400 ログ、program.ics alert 昇格、harness の `test?` ガード、冪等ロック storage/rescue 重複の共通化（`AnnictIdempotencyLockStorage` 抽出）、request ログ本文 scrub、start_time 二段検証、slim 記法ゆれ、api.md 補記
+- **本リリース前 5観点レビュー赤近い黄インライン (#4404/#4406)** — 公開 `/word/suggest` 由来の Sentry スパム抑止: `PronunciationDictionary` の Redis 読み/書き失敗（接続障害）を alert→log に倒し、破損（不正 JSON/非配列）のみ alert+invalidate に限定（read #4404 / write は Codex P2 を受け #4406 で対称化）。`nowplaying/resolve`・`word/suggest` のユーザー入力（曲名・検索語）ログ scrub 追加。残り黄・緑は #4405 で 5.27.0 送り
+- **bundle update** — Gemfile.lock 変更なし（既に最新、bundler-audit クリーン、Dependabot 0）
+- **運用向け設定変更**: word/suggest を有効化するサーバーは `config/local.yaml` に `/word_suggest/urls`（GAS pron.json）設定が必要。未設定なら `features.word_suggest=false` で無効（既定で無害）。`PronunciationDictionaryUpdateWorker` が 10 分毎更新
+- ステージング: dev04（FreeBSD・美食丼）/ dev23（Misskey・ダイスキー）で develop=5.26.0 を確認（dev15/dev22 はメンテ外につき対象外）
+- **本番デプロイ: pooza 実施予定**（辞書設定 `/word_suggest/urls` の書き込みを伴うため。日付・結果は後追記）
+
+### 振り返り
+
+**期間**: 5.25.0 リリース・本番デプロイ 2026-06-07 → 5.26.0 リリース 2026-06-09（2 日間）。
+
+**消化**: 5.26.0 マイルストーン Issue 全消化（#4382/#4347/#4394/#4397）。
+
+**5観点レビュー仕分け**: 真の赤 0 件。赤近い黄 2 系統（word/suggest の Redis 障害 Sentry スパム / 入力ログ scrub）をインライン (#4404)、Codex P2（save 側 write の alert スパム）を追い fix (#4406)、残り黄・緑（リダイレクト SSRF 非対称、cold-cache 同期 fetch、docs 表記揺れ・タイポ等）は #4405 にまとめて 5.27.0 送り。
+
+**Codex 仕分け**: ドラフト解除した release PR #4396 に届く Codex レビューは 5観点と重複見込み。#4404 上の P2（Redis 全断時の write 側 alert スパム）は #4406 でインライン対応しリリースに同梱。
+
 ## リリース済み: 5.25.0（2026-06-07）
 
 APIController 段階的リファクタの締め (#4285) + 5.23/5.24 レビュー送りの構造改善 + 番組表の iCalendar 出力・開始時刻欄 + Annict review API + 運用ログ整備 + 報告ベース修正を組み合わせた着地回。
@@ -226,75 +250,7 @@ APIController 段階的リファクタの締め (#4285) + 5.23/5.24 レビュー
 - `gh pr create --base develop` の指定漏れで意図しない main 起点マージが 3 件発生。CI が通っただけでマージしてしまったため気づくのが遅れた。PR 作成直後に `gh pr view <num> --json baseRefName` を確認するワークフローを徹底
 - EmojiSpacingHandler の本文ログ流出は新ハンドラ開発時のテンプレ判断 (`result.push(text:)` で text の中身をどこまで残すか) の問題。今後新ハンドラを書く際は「Reporter に乗る値が info ログへ流れる」点を意識する
 
-## リリース済み: 5.23.0（2026-05-23）
-
-5.22 リリース前 5観点並列レビューの黄送り掃き出しと、本リリース前 5観点並列レビュー対応を主とする「整理回」。あわせて本番で観測された重 SQL 病理（2026-05-19 障害、底値レイテンシ 175 秒級）を受け、メディアカタログ機能を実験的扱いとしデフォルト無効化する運用判断を反映（#4343）。
-
-- **#4343 feat: media_catalog をデフォルト無効化し disabled シグナルを返す** — `data.media_catalog` のデフォルトを `false` に反転（実験的機能扱い）。disabled 時の `/mulukhiya/api/media`・`/mulukhiya/feed/media` は **404 ではなく 503** + body `{"available": false, ...}` を返し、`/about` の `features.media_catalog` で discovery 可能にした。経緯と再開判断は [docs/media_catalog.md](media_catalog.md) を参照。capsicum 側 gate は [pooza/capsicum#606](https://github.com/pooza/capsicum/issues/606)
-- **#4338 feat: features API に `annict_linked` を追加** — ユーザー単位の Annict 連携状態を `/about` の features に動的合流（capsicum 連携）
-- **#4336 feat: 番組表エディタの各エントリにコピーボタン**（作品名・話数+サブタイトル、毎朝の挨拶投稿運用の手数削減、#4286 の代替最小実装）
-- **#4331 feat: Addrinfo.getaddrinfo にタイムアウト** — Puma スレッド枯渇防止
-- **#4330 feat: POST /annict/record に冪等性** — 重複 record 投稿を抑止
-- **#4329 feat: AnnictService の GraphQL エラーをカテゴリ別 status code で返す**
-- **#4318 feat: ProgramEntryContract のエラーメッセージにフィールド名を含める**
-- **#4316 fix: Program#update_cache の rescue 整理と失敗文脈付与**
-- **#4334 perf: RateLimitStorage を EVALSHA + NOSCRIPT フォールバックに移行**
-- **#4328 perf: HTTP fetch のサイズ検証を Content-Length 事前判定に切替え**
-- **#4335 refactor: MediaCatalogUpdateWorker の `cursor_pagination?` を Attachment 側に移譲**（#4343 の前提整理）
-- **#4333 refactor: RemoteHost.public? の bare rescue を具体例外に絞る**
-- **#4319 refactor: tagging_handler.rb / program.rb の暗黙 return を明示**
-- **#4313 refactor: ProgramEntryUpdateContract の params 抽出順序整理**
-- **#4314 docs: docs/api.md に ProgramEntryContract の上限値・null セマンティクスを補記**
-- **#4280 docs: docs/api.md の表記揺れ修正**（インスタンス→サーバー）
-- **#4332 wontfix クローズ** — SwSubscriptionContract allowed_hosts は allow-all デフォルトが妥当（endpoint がベンダー管理で allowlist 列挙不能、内部宛 SSRF は #4271 で対応済み、NOTE コメントに理由明記）
-- **リリース前 5観点レビュー赤対応** — MediaCatalogUpdateWorker の scheduler 直叩き経路で `disable?` が効かない穴（sidekiq-scheduler が `Sidekiq::Client.push` を直接呼ぶため `Worker.perform_async` 側 gate を通らない）を `perform` 先頭ガード追加で封じ込め。docs 表記揺れ追加修正、`/feed/media` の disabled 時挙動を `docs/api.md` で明確化
-- **リリース前 5観点レビュー黄インライン** — ConflictError 経路に info ログ、RateLimitStorage NoScriptError フォールバックに warn ログ、`/media`・`/feed/media` の disabled 応答にも構造化 info ログ、AnnictRecordLockStorage#ttl の memoize
-- **5観点レビュー次リリース送り** — #4345（fix: AnnictRecordLockStorage release の compare-and-delete、5.24.0）、#4346（feat: alert しきい値）、#4347（refactor: Program 分割）、#4348（refactor: /about 動的合流フック化）、#4349（refactor: MediaCatalogDisabledRenderer 切り出し）。後者 4 件は未設定
-- **Ruby 4.0.4 に更新**
-- **bundle update**
-- 本番デプロイ: 4 台（zugoga / lbock / shallu / sweep）
-
-### 振り返り
-
-**期間**: 5.22.1 リリース 2026-05-15 → 5.23.0 リリース 2026-05-23（8 日間）。本リリース 7 コミット（#4343 関連 + 5観点対応 + version bump）。
-
-**消化**: 17 Issue（5.22 レビュー送り 8 件 + 番組表エディタ補助 1 件 + media_catalog #4343 + 諸 docs/refactor 7 件）。
-
-**主軸**: #4343 が事実上の主軸として急遽組み込まれた。当初計画は「滞留した小粒の整理回」で主軸なしだったが、2026-05-19 障害（zugoga 等の DB プール枯渇で全サーバー投稿不可）と zugoga 本番ベースライン EXPLAIN で確証した 175 秒級病理を受け、当該機能の実験的扱い化に切替。本来の最適化 #4323（partial index `idx_mlkhy_statuses_local_catalog` 追加）は on-hold へ移動（ベースラインと candidate A は再開時の起点として残す）。
-
-**5観点レビュー仕分け**: 真の赤 1 件（scheduler 経路）を hotfix インライン、黄 2 件と自明赤 7 件（docs 表記等）をまとめて対応、緑容易分 2 件もインライン。残り構造改善 5 件は #4345〜#4349 で次リリース送り。誤検知 2 件（AAAA 取得・`e.alert(**hash)` kwargs）は実証で覆して対応外とした。
-
-**運用観察**:
-
-- sidekiq-scheduler は `Sidekiq::Client.push` を直叩きするため、`Worker.perform_async` 側 gate は scheduler 経由では効かない（本リリースで判明）。今後 `disable?` を持つ worker は `perform` 先頭でも評価する必要がある
-- 本番病理（重 SQL の DB プール枯渇）は本番規模特有で、ステージング dev04 等では再現不能（n_live_tup の桁が違う）。性能検証は本番で `EXPLAIN ANALYZE` を取る必要がある（#4323 で実証）
-
-**反省**:
-
-- #4343 で本番停止に駆け込んだが、scheduler 直叩き経路の穴を 5観点レビューが拾わなかったら本番で「local.yaml で false にしたつもりが止まっていない」が継続するところだった。並列レビューを規定どおり実施する価値を再確認
-
-## 次期マイルストーン: 5.26.0
-
-主軸: ナウプレ enrich プロキシ (#4382) + 旧キーワード検索ハンドラ（系統①）削除。ナウプレ基盤見直しの土台回。重み合計 9（予算 20〜25 に対し軽め＝薄く速くの方針）。2026-06-07 にスコープ・設計を確定（[[project_4382-nowplaying-redesign]] / capsicum docs/nowplaying-design.md §責務分担）。
-
-### 主軸
-
-- #4382 feat: ナウプレ enrich プロキシ `POST /mulukhiya/api/nowplaying/resolve`（Bearer 必須、メタ→共有URL、capsicum #466/#484/#668/#570/#669 連携、size:M）。**確定仕様**: 入力 title/artist/album/source_app_name/prefer、プロバイダ優先 `prefer`(capsicum トグル) > source_app_name ヒント > サーバー既定 `/nowplaying/resolve/default_provider`（**既定 apple_music**、フォールバック許可）、`features.nowplaying_resolver` 露出、嗜好は capsicum ローカル保持でモロヘイヤはステートレス。**系統①（`itunes_nowplaying`/`spotify_nowplaying`、現場未使用）を本回で削除**し検索ロジックを resolver へ集約。系統②（`*_url_nowplaying` 4本）と `NowplayingHandler.trim`/`DELETE /status/nowplaying` は据え置き。整形は capsicum 側（モロヘイヤに整形器は新設しない、capsicum#680 で doc 訂正済み）。capsicum 側プロバイダ優先トグルは capsicum#681
-
-### capsicum 連携
-
-- #4397 feat: 読み付き単語サジェスト API `GET /mulukhiya/api/word/suggest`（capsicum #614 / 投稿サジェスト連携、size:M）。`PronunciationDictionary` が GAS の pron.json を Redis キャッシュ、読み（ひらがな→カタカナ正規化はモロヘイヤ側で吸収）前方一致 → 表層前方一致 → 部分一致でランク付け。`config.features.word_suggest` を `DynamicFeatures::REGISTRY` から `word_suggest/urls` 設定有無で動的導出。本体 API は #4398、HEAD 非対応ホスト(GAS)の content-length 事前チェック 403 ログ抑止は #4400。capsicum 実測で API・フラグ・正規化すべて充足を確認（v1.35 はフラット読み検索リストで出荷可、category/tags は後追い）。利用者要望でソートの同ランク内タイブレーカーを五十音順に改善（#4403）
-
-### 構造改善 / レビュー送り
-
-- #4347 refactor: Program クラスを ProgramFetcher へ分割（rubocop Metrics/ClassLength の disable 解除、5.25 から送り、size:M）
-- #4394 5.25.0 リリース前 5観点レビュー 5.26.0 送り（黄 4 + 緑 4 まとめ: favorites 400 ログ, program.ics alert 昇格, harness test? ガード, lock storage/rescue 重複の共通化, request ログ本文 scrub, start_time 二段検証, slim 記法ゆれ, api.md 補記、size:M）
-
-### 5.26.0 では触らない（緊急性低下で据え置き）
-
-メディアカタログ再有効化（#4393 sub-second 化 / #4351 zugoga / #4352 横展開）は緊急性が下がり、5.26.0 から外して #4323 ロードマップ管理へ戻した。再開判断は #4323 / docs/media-catalog-index-plan.md 参照。
-
-## 次々期マイルストーン: 5.27.0
+## 次期マイルストーン: 5.27.0
 
 主軸: #4337 feat: Spotify user-level OAuth + currently-playing API（capsicum #465/#570 連携、size:L）。#4382 enrich とは別経路（URL を自前で返せる源）。currently-playing 取得・per-user token 暗号化保管・refresh 自動化・`SpotifyUserService`(仮) 新設。capsicum #570/#669 をアンブロック。ナウプレは番組表級の長期計画として段階的に進める（[[project_4382-nowplaying-redesign]]）。
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -869,7 +869,7 @@ Spotify 連携を解除する（保管トークンを削除）。
 ##### 設定キー
 
 - `/service/spotify/client/{id,secret}`: Spotify アプリの資格情報（app-level の `SpotifyService` と共用）
-- `/service/spotify/oauth/redirect_uri`: Redirect URI（Dashboard 登録値と一致させる。既定 `capsicum://spotify/callback`）
+- `/service/spotify/oauth/redirect_uri`: Redirect URI（Dashboard 登録値・capsicum の捕捉先と一致させる。既定 `http://127.0.0.1:8888/spotify/callback` = デスクトップ向け loopback）
 - `/service/spotify/oauth/scopes`: 要求スコープ（既定 `user-read-currently-playing`）
 - `/service/spotify/oauth/user_oauth_enabled`: user OAuth の有効化フラグ（既定 `false`。Dashboard 登録完了後に `true`）
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -806,6 +806,23 @@ NowPlaying 情報を除去して再投稿する。
   - `/nowplaying/resolve/default_provider`: 優先指定・ヒントが無いときの既定プロバイダ（`apple_music` / `spotify`、既定 `apple_music`）
 - **備考**: Spotify は `/service/spotify` の資格情報が設定済みのときのみ候補。iTunes Search API は資格情報不要のため常時利用可能。capsicum は `features.nowplaying_resolver`（下記）で enrich を試みるか判定する。
 
+#### POST /mulukhiya/api/nowplaying/resolve-url
+
+ナウプレ enrich プロキシの**逆方向**（#4415）。共有 URL を受け取り、URL からメタデータ（曲名・アーティスト名・アルバム名）を逆引きする。共有（Share）経路は ShareExtension から URL しか受け取らずメタを持たないため、capsicum が in-app と同じ formatter で整形できるようにする。`/nowplaying/resolve`（メタ → URL）と対になる読み取り専用エンドポイント。外部 API 濫用防止のため Bearer 必須。
+
+- **認証**: 必須（Bearer / SNS token）
+- **パラメータ**:
+
+| 名前 | 型 | 必須 | 説明 |
+|------|-----|------|------|
+| `url` | string | 必須 | 楽曲の共有 URL（`http(s)://` 始まり、最大 2048 文字） |
+
+- **プロバイダ振り分け（host）**: `*.spotify.com` → Spotify、`music.apple.com` / `itunes.apple.com` → iTunes、それ以外 → 解決なし。
+- **レスポンス**:
+  - 解決時: `{ "url": "https://music.apple.com/...", "provider": "apple_music", "normalized": { "title": "...", "artist": "...", "album": "..." } }`（`normalized` は外部 API が返した値のみ。欠落要素は省く）
+  - 解決なし（未対応 host / メタ取得不可）: `{ "url": null }`（404 ではなく 200）
+- **備考**: Spotify は `/service/spotify` の資格情報が設定済みのときのみ候補。iTunes は資格情報不要のため常時利用可能。capsicum は `features.nowplaying_url_resolver`（下記）で Share 経路 enrich を試みるか判定する。
+
 #### GET /mulukhiya/api/program
 
 番組情報を取得する。

--- a/docs/api.md
+++ b/docs/api.md
@@ -94,6 +94,8 @@ SNS 本体への転送が失敗した場合、SNS が返したステータスコ
 | `/{controller}/features/annict` | `/annict/oauth_uri`, `/annict/auth`, `/tagging/dic/annict/episodes`, `/program/works`, `/program/works/:id/episodes` |
 | `features.word_suggest`（`/word_suggest/urls` 設定時に有効） | `/word/suggest` |
 | `features.nowplaying_resolver`（常時 `true`） | `/nowplaying/resolve` |
+| `features.spotify_enabled`（`/service/spotify/oauth/user_oauth_enabled` + 資格情報設定時に有効） | `/spotify/oauth_uri`, `/spotify/auth`, `/spotify/currently_playing` |
+| `features.spotify_linked`（当該ユーザーが Spotify 連携済みか） | `/spotify/currently_playing` |
 
 ## モロヘイヤ検出プロトコル
 
@@ -805,6 +807,71 @@ NowPlaying 情報を除去して再投稿する。
 - **設定キー**:
   - `/nowplaying/resolve/default_provider`: 優先指定・ヒントが無いときの既定プロバイダ（`apple_music` / `spotify`、既定 `apple_music`）
 - **備考**: Spotify は `/service/spotify` の資格情報が設定済みのときのみ候補。iTunes Search API は資格情報不要のため常時利用可能。capsicum は `features.nowplaying_resolver`（下記）で enrich を試みるか判定する。
+
+#### Spotify user OAuth（現在再生中の取得）
+
+capsicum が Spotify Web API 経由で「現在再生中」を OS 非依存に取得するための user-level OAuth（#4337 / capsicum #465）。app-level の `SpotifyService`（track 検索・lookup、`/nowplaying/resolve` でも使用）とは別系統で、**Authorization Code Flow** により当該ユーザーの `GET /me/player/currently-playing` を呼ぶ。capsicum に `client_secret` を置かず、モロヘイヤがアクセストークン／リフレッシュトークンを暗号化保管する点は Annict 連携と同方針。アクセストークンは 3600 秒で失効するため、モロヘイヤが失効時・401 時に自動でリフレッシュする（capsicum は意識不要）。
+
+- **前提条件**: `features.spotify_enabled` が `true`（= `/service/spotify/client/{id,secret}` 設定済み **かつ** `/service/spotify/oauth/user_oauth_enabled` が `true`）。Spotify Developer Dashboard 側で Redirect URI と `user-read-currently-playing` スコープの登録が必要。
+- **認証フロー（code-post 方式）**:
+  1. クライアントが `GET /spotify/oauth_uri` で認可 URL を取得する
+  2. クライアントが認可 URL をブラウザで開き、ユーザーが Spotify で認可する
+  3. Spotify が Redirect URI（`/service/spotify/oauth/redirect_uri`、capsicum が捕捉できる URL／カスタムスキーム）へ認可コード付きでリダイレクトする
+  4. クライアントが捕捉した認可コードを `POST /spotify/auth` に送信（ユーザー特定は SNS トークンで行うため `state` は不要）
+  5. 以降クライアントは `GET /spotify/currently_playing` で現在再生中の URL を取得できる
+
+##### GET /mulukhiya/api/spotify/oauth_uri
+
+Spotify の OAuth 認可 URL を取得する。
+
+- **認証**: 不要
+- **前提条件**: `features.spotify_enabled` が `true`（false 時は 404）
+- **パラメータ**: なし
+- **レスポンス例**: `{ "oauth_uri": "https://accounts.spotify.com/authorize?client_id=...&response_type=code&redirect_uri=...&scope=user-read-currently-playing" }`
+
+##### POST /mulukhiya/api/spotify/auth
+
+認可コードをアクセストークン＋リフレッシュトークンに交換し、ユーザー設定に暗号化保存する。
+
+- **認証**: 必須（SNS アカウントのトークン）
+- **前提条件**: `features.spotify_enabled` が `true`
+- **パラメータ**:
+
+| 名前 | 型 | 必須 | 説明 |
+|------|-----|------|------|
+| `token` | string | 必須 | SNS アカウントのアクセストークン |
+| `code` | string | 必須 | Spotify OAuth 認可コード |
+
+- **レスポンス**: `{ "config": { ... } }`（更新後のユーザー設定）
+
+##### GET /mulukhiya/api/spotify/currently_playing
+
+現在再生中トラックの共有 URL を返す。
+
+- **認証**: 必須（SNS アカウントのトークン → モロヘイヤが保持する Spotify トークンに解決）
+- **前提条件**: `features.spotify_enabled` が `true` かつ当該ユーザーが連携済み（`features.spotify_linked`）
+- **パラメータ**: なし
+- **レスポンス**:
+  - 再生中: `{ "url": "https://open.spotify.com/track/..." }`
+  - 無再生・広告再生中・プライベートセッション: `{ "url": null }`（200）
+- **エラー**:
+  - **403**（`Ginseng::AuthError`）: 未連携、またはリフレッシュトークン失効・revoke（要再連携）
+  - **502 Bad Gateway**: Spotify API ダウン・ネットワーク失敗
+
+##### DELETE /mulukhiya/api/spotify/auth
+
+Spotify 連携を解除する（保管トークンを削除）。
+
+- **認証**: 必須（SNS アカウントのトークン）
+- **前提条件**: `features.spotify_enabled` が `true`
+- **レスポンス**: `{ "config": { ... } }`（更新後のユーザー設定）
+
+##### 設定キー
+
+- `/service/spotify/client/{id,secret}`: Spotify アプリの資格情報（app-level の `SpotifyService` と共用）
+- `/service/spotify/oauth/redirect_uri`: Redirect URI（Dashboard 登録値と一致させる。既定 `capsicum://spotify/callback`）
+- `/service/spotify/oauth/scopes`: 要求スコープ（既定 `user-read-currently-playing`）
+- `/service/spotify/oauth/user_oauth_enabled`: user OAuth の有効化フラグ（既定 `false`。Dashboard 登録完了後に `true`）
 
 #### GET /mulukhiya/api/program
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -92,7 +92,7 @@ SNS 本体への転送が失敗した場合、SNS が返したステータスコ
 | `/{controller}/features/feed` | `/feed/list` |
 | `/{controller}/features/announcement` | `/announcement/update` |
 | `/{controller}/features/annict` | `/annict/oauth_uri`, `/annict/auth`, `/tagging/dic/annict/episodes`, `/program/works`, `/program/works/:id/episodes` |
-| `/word_suggest/urls`（features.word_suggest に合流） | `/word/suggest` |
+| `features.word_suggest`（`/word_suggest/urls` 設定時に有効） | `/word/suggest` |
 | `features.nowplaying_resolver`（常時 `true`） | `/nowplaying/resolve` |
 
 ## モロヘイヤ検出プロトコル

--- a/docs/archive/release-history.md
+++ b/docs/archive/release-history.md
@@ -2,6 +2,53 @@
 
 CLAUDE.md から分離した過去のリリースノート。直近リリースは [CLAUDE.md](../CLAUDE.md) を参照。
 
+## リリース済み: 5.23.0（2026-05-23）
+
+5.22 リリース前 5観点並列レビューの黄送り掃き出しと、本リリース前 5観点並列レビュー対応を主とする「整理回」。あわせて本番で観測された重 SQL 病理（2026-05-19 障害、底値レイテンシ 175 秒級）を受け、メディアカタログ機能を実験的扱いとしデフォルト無効化する運用判断を反映（#4343）。
+
+- **#4343 feat: media_catalog をデフォルト無効化し disabled シグナルを返す** — `data.media_catalog` のデフォルトを `false` に反転（実験的機能扱い）。disabled 時の `/mulukhiya/api/media`・`/mulukhiya/feed/media` は **404 ではなく 503** + body `{"available": false, ...}` を返し、`/about` の `features.media_catalog` で discovery 可能にした。経緯と再開判断は [docs/media_catalog.md](media_catalog.md) を参照。capsicum 側 gate は [pooza/capsicum#606](https://github.com/pooza/capsicum/issues/606)
+- **#4338 feat: features API に `annict_linked` を追加** — ユーザー単位の Annict 連携状態を `/about` の features に動的合流（capsicum 連携）
+- **#4336 feat: 番組表エディタの各エントリにコピーボタン**（作品名・話数+サブタイトル、毎朝の挨拶投稿運用の手数削減、#4286 の代替最小実装）
+- **#4331 feat: Addrinfo.getaddrinfo にタイムアウト** — Puma スレッド枯渇防止
+- **#4330 feat: POST /annict/record に冪等性** — 重複 record 投稿を抑止
+- **#4329 feat: AnnictService の GraphQL エラーをカテゴリ別 status code で返す**
+- **#4318 feat: ProgramEntryContract のエラーメッセージにフィールド名を含める**
+- **#4316 fix: Program#update_cache の rescue 整理と失敗文脈付与**
+- **#4334 perf: RateLimitStorage を EVALSHA + NOSCRIPT フォールバックに移行**
+- **#4328 perf: HTTP fetch のサイズ検証を Content-Length 事前判定に切替え**
+- **#4335 refactor: MediaCatalogUpdateWorker の `cursor_pagination?` を Attachment 側に移譲**（#4343 の前提整理）
+- **#4333 refactor: RemoteHost.public? の bare rescue を具体例外に絞る**
+- **#4319 refactor: tagging_handler.rb / program.rb の暗黙 return を明示**
+- **#4313 refactor: ProgramEntryUpdateContract の params 抽出順序整理**
+- **#4314 docs: docs/api.md に ProgramEntryContract の上限値・null セマンティクスを補記**
+- **#4280 docs: docs/api.md の表記揺れ修正**（インスタンス→サーバー）
+- **#4332 wontfix クローズ** — SwSubscriptionContract allowed_hosts は allow-all デフォルトが妥当（endpoint がベンダー管理で allowlist 列挙不能、内部宛 SSRF は #4271 で対応済み、NOTE コメントに理由明記）
+- **リリース前 5観点レビュー赤対応** — MediaCatalogUpdateWorker の scheduler 直叩き経路で `disable?` が効かない穴（sidekiq-scheduler が `Sidekiq::Client.push` を直接呼ぶため `Worker.perform_async` 側 gate を通らない）を `perform` 先頭ガード追加で封じ込め。docs 表記揺れ追加修正、`/feed/media` の disabled 時挙動を `docs/api.md` で明確化
+- **リリース前 5観点レビュー黄インライン** — ConflictError 経路に info ログ、RateLimitStorage NoScriptError フォールバックに warn ログ、`/media`・`/feed/media` の disabled 応答にも構造化 info ログ、AnnictRecordLockStorage#ttl の memoize
+- **5観点レビュー次リリース送り** — #4345（fix: AnnictRecordLockStorage release の compare-and-delete、5.24.0）、#4346（feat: alert しきい値）、#4347（refactor: Program 分割）、#4348（refactor: /about 動的合流フック化）、#4349（refactor: MediaCatalogDisabledRenderer 切り出し）。後者 4 件は未設定
+- **Ruby 4.0.4 に更新**
+- **bundle update**
+- 本番デプロイ: 4 台（zugoga / lbock / shallu / sweep）
+
+### 振り返り
+
+**期間**: 5.22.1 リリース 2026-05-15 → 5.23.0 リリース 2026-05-23（8 日間）。本リリース 7 コミット（#4343 関連 + 5観点対応 + version bump）。
+
+**消化**: 17 Issue（5.22 レビュー送り 8 件 + 番組表エディタ補助 1 件 + media_catalog #4343 + 諸 docs/refactor 7 件）。
+
+**主軸**: #4343 が事実上の主軸として急遽組み込まれた。当初計画は「滞留した小粒の整理回」で主軸なしだったが、2026-05-19 障害（zugoga 等の DB プール枯渇で全サーバー投稿不可）と zugoga 本番ベースライン EXPLAIN で確証した 175 秒級病理を受け、当該機能の実験的扱い化に切替。本来の最適化 #4323（partial index `idx_mlkhy_statuses_local_catalog` 追加）は on-hold へ移動（ベースラインと candidate A は再開時の起点として残す）。
+
+**5観点レビュー仕分け**: 真の赤 1 件（scheduler 経路）を hotfix インライン、黄 2 件と自明赤 7 件（docs 表記等）をまとめて対応、緑容易分 2 件もインライン。残り構造改善 5 件は #4345〜#4349 で次リリース送り。誤検知 2 件（AAAA 取得・`e.alert(**hash)` kwargs）は実証で覆して対応外とした。
+
+**運用観察**:
+
+- sidekiq-scheduler は `Sidekiq::Client.push` を直叩きするため、`Worker.perform_async` 側 gate は scheduler 経由では効かない（本リリースで判明）。今後 `disable?` を持つ worker は `perform` 先頭でも評価する必要がある
+- 本番病理（重 SQL の DB プール枯渇）は本番規模特有で、ステージング dev04 等では再現不能（n_live_tup の桁が違う）。性能検証は本番で `EXPLAIN ANALYZE` を取る必要がある（#4323 で実証）
+
+**反省**:
+
+- #4343 で本番停止に駆け込んだが、scheduler 直叩き経路の穴を 5観点レビューが拾わなかったら本番で「local.yaml で false にしたつもりが止まっていない」が継続するところだった。並列レビューを規定どおり実施する価値を再確認
+
 ## リリース済み: 5.22.1（2026-05-15）
 
 ホットフィックス。5.22.0 #4227 で追加した `POST /mulukhiya/api/annict/record` が、capsicum エピソードブラウザの送る数値 annictId をそのまま Annict GraphQL `createRecord(episodeId: ID!)` に渡しており、Annict が要求する Relay グローバルノード ID と不一致で `Invalid input` 失敗していた回帰を修正（dev04 ステージングで観測）。capsicum 側からの直接コミット（#4339）をリリース体裁に整えて出荷。

--- a/docs/capsicum-requirements.md
+++ b/docs/capsicum-requirements.md
@@ -385,7 +385,7 @@ capsicum v1.35（[capsicum#614](https://github.com/pooza/capsicum/issues/614)）
 - **出力（案）**:
   ```json
   { "candidates": [
-    { "surface": "愛崎えみる", "reading": "アイサキメグミ",
+    { "surface": "愛崎えみる", "reading": "アイサキエミル",
       "category": "人名", "tags": ["#プリキュア"] }
   ] }
   ```

--- a/docs/capsicum-requirements.md
+++ b/docs/capsicum-requirements.md
@@ -408,7 +408,43 @@ capsicum v1.35（[capsicum#614](https://github.com/pooza/capsicum/issues/614)）
 - 本節の実装 Issue: #4397
 - capsicum 側 Issue: [capsicum#614](https://github.com/pooza/capsicum/issues/614) / 設計 doc: <https://github.com/pooza/capsicum/blob/develop/docs/compose-suggest-design.md>
 
-## 10. 今後の API 変更時の連携
+## 10. Spotify user OAuth（現在再生中の取得）
+
+### 背景・責務分担
+
+capsicum の macOS Share Extension（capsicum #422）によるナウプレ投稿は OS 共有機構依存の push 型で Linux / Windows では使えない。Spotify Web API の `GET /me/player/currently-playing` を使えば OS 非依存で同等機能を提供できる。capsicum に `client_secret` を置きたくないため、Annict と同じく**モロヘイヤ経由のサーバー保管型 OAuth**で実装する（#4337 / capsicum #465）。app-level の `SpotifyService`（§8 enrich でも使う track 検索）とは別系統の user-level（Authorization Code Flow）。
+
+### エンドポイント（5.27.0 実装・code-post 方式）
+
+| メソッド | パス | 用途 | 認証 |
+| --- | --- | --- | --- |
+| GET | `/spotify/oauth_uri` | OAuth 認可 URL 取得 | 不要 |
+| POST | `/spotify/auth` | 認可コードを token に交換・保管（body: `code`） | SNS token |
+| GET | `/spotify/currently_playing` | 現在再生中の URL（`{url}` / 無再生は `{url: null}`） | SNS token |
+| DELETE | `/spotify/auth` | 連携解除 | SNS token |
+
+- **認証フロー**: capsicum がブラウザで認可 URL を開き、Redirect URI で捕捉した認可コードを `POST /spotify/auth` に渡す。ユーザー特定は SNS トークンで行うため `state` は不要。詳細は `docs/api.md` の「Spotify user OAuth」節。
+- **トークン管理**: access_token（3600s 失効）と refresh_token をモロヘイヤが暗号化保管し、失効・401 時に自動リフレッシュ。capsicum は意識不要。refresh_token 失効時は 403（要再連携）。
+- **エラー**: 未連携・refresh 失効 → 403、Spotify API 障害 → 502、無再生／広告／プライベートセッション → `{url: null}`（200）。
+
+### features フラグ
+
+`GET /mulukhiya/api/about` の `features` に 2 つ追加（capsicum が連携導線の出し分けに使う）:
+
+- `spotify_enabled`: サーバーで user OAuth が有効か（資格情報設定 + `/service/spotify/oauth/user_oauth_enabled`）。Spotify Developer Dashboard 登録が済むまで `false`。
+- `spotify_linked`: 当該ユーザーが連携済みか。
+
+### pooza 作業（モロヘイヤ実装とは独立）
+
+Spotify Developer Dashboard で Redirect URI（`/service/spotify/oauth/redirect_uri`、capsicum が捕捉できる値）と `user-read-currently-playing` スコープを登録し、config の `user_oauth_enabled` を `true` にする。
+
+### 関連
+
+- 本節の実装 Issue: #4337（5.27.0）
+- capsicum 側 Issue: pooza/capsicum（本 API 実装後に着手予定）
+- capsicum 側設計: <https://github.com/pooza/capsicum/blob/develop/docs/spotify-nowplaying-design.md>
+
+## 11. 今後の API 変更時の連携
 
 モロヘイヤ側でエンドポイントの追加・変更・廃止がある場合:
 

--- a/docs/release-notes-template.md
+++ b/docs/release-notes-template.md
@@ -66,6 +66,8 @@
 [更新手順](https://github.com/pooza/mulukhiya-toot-proxy/wiki/%E6%9B%B4%E6%96%B0%E6%89%8B%E9%A0%86)を参照してください。
 4.x系からのアップグレードは[4.x → 5.0 アップグレードガイド](https://github.com/pooza/mulukhiya-toot-proxy/wiki/4.x-%E2%86%92-5.0-%E3%82%A2%E3%83%83%E3%83%97%E3%82%B0%E3%83%AC%E3%83%BC%E3%83%89%E3%82%AC%E3%82%A4%E3%83%89)も参照してください。
 
+**必要 Ruby: X.Y.Z**（`.ruby-version`。前リリースから据え置きでも毎回明記する）。未導入のサーバーは `rbenv install X.Y.Z` が前提（無いと puma 起動が `rbenv: version 'X.Y.Z' is not installed` で失敗する）。
+
 <起動スクリプト変更がない場合>
 本リリースに起動スクリプトの変更はありません。通常の更新手順（git pull + bundle install + サービス再起動）で適用できます。
 
@@ -77,5 +79,6 @@
 
 - セキュリティ更新（gem パッチ）は実害がなくてもリリースノートに記載する
 - 「アップグレード手順」のリンク 2 種は毎回必ず含める（4.x 系利用者向けは当面継続）
+- **「必要 Ruby」は `.ruby-version` の値を毎回明記する**（前リリースから据え置きでも）。フレッシュなサーバーは `rbenv install` が前提で、書いておかないと puma 起動失敗（`rbenv: version '...' is not installed`）の原因になる
 - ホットフィックス（5.x.1 等）でも同フォーマットを使う。「概要」は「ホットフィックス。〜の回帰を修正」程度で短く
 - 設定キーは Ginseng のスラッシュ表記（`/ruby/jit` 等）で統一

--- a/test/contract/nowplaying_resolve_url_contract.rb
+++ b/test/contract/nowplaying_resolve_url_contract.rb
@@ -1,0 +1,37 @@
+module Mulukhiya
+  class NowplayingResolveUrlContractTest < TestCase
+    def setup
+      @contract = NowplayingResolveUrlContract.new
+    end
+
+    def test_accepts_valid_url
+      errors = @contract.call(url: 'https://music.apple.com/jp/album/1299587212?i=1299587213').errors
+
+      assert_empty(errors)
+    end
+
+    def test_rejects_missing_url
+      errors = @contract.call({}).errors
+
+      assert_false(errors.empty?)
+    end
+
+    def test_rejects_blank_url
+      errors = @contract.call(url: '').errors
+
+      assert_false(errors.empty?)
+    end
+
+    def test_rejects_non_http_url
+      errors = @contract.call(url: 'spotify:track:abc').errors
+
+      assert_false(errors.empty?)
+    end
+
+    def test_rejects_oversized_url
+      errors = @contract.call(url: "https://example.com/#{'a' * NowplayingResolveUrlContract::MAX_URL_SIZE}").errors
+
+      assert_false(errors.empty?)
+    end
+  end
+end

--- a/test/contract/spotify_auth_contract.rb
+++ b/test/contract/spotify_auth_contract.rb
@@ -5,15 +5,16 @@ module Mulukhiya
     end
 
     def test_call
-      errors = @contract.call(token: 'sns-token', code: 'auth-code').errors
+      # ユーザー特定は bearer 認証で行うため code のみ必須・token は不要。
+      errors = @contract.call(code: 'auth-code').errors
 
       assert_empty(errors)
 
-      errors = @contract.call(token: 'sns-token', code: nil).errors
+      errors = @contract.call(code: nil).errors
 
       assert_false(errors.empty?)
 
-      errors = @contract.call(code: 'auth-code').errors
+      errors = @contract.call({}).errors
 
       assert_false(errors.empty?)
     end

--- a/test/contract/spotify_auth_contract.rb
+++ b/test/contract/spotify_auth_contract.rb
@@ -1,0 +1,21 @@
+module Mulukhiya
+  class SpotifyAuthContractTest < TestCase
+    def setup
+      @contract = SpotifyAuthContract.new
+    end
+
+    def test_call
+      errors = @contract.call(token: 'sns-token', code: 'auth-code').errors
+
+      assert_empty(errors)
+
+      errors = @contract.call(token: 'sns-token', code: nil).errors
+
+      assert_false(errors.empty?)
+
+      errors = @contract.call(code: 'auth-code').errors
+
+      assert_false(errors.empty?)
+    end
+  end
+end

--- a/test/unit/lib/dynamic_features.rb
+++ b/test/unit/lib/dynamic_features.rb
@@ -3,7 +3,7 @@ module Mulukhiya
     def test_registry_keys
       assert_equal(
         ['annict_linked', 'media_catalog', 'program_editable', 'word_suggest',
-          'nowplaying_resolver'].to_set,
+          'nowplaying_resolver', 'spotify_enabled', 'spotify_linked'].to_set,
         DynamicFeatures::REGISTRY.keys.to_set,
       )
     end
@@ -23,6 +23,14 @@ module Mulukhiya
       assert_true(DynamicFeatures.new(sns_double(linked_account)).to_h['annict_linked'])
     end
 
+    def test_spotify_linked_is_false_without_account
+      assert_false(DynamicFeatures.new(sns_double(nil)).to_h['spotify_linked'])
+    end
+
+    def test_spotify_linked_reflects_linked_account
+      assert_true(DynamicFeatures.new(sns_double(linked_account)).to_h['spotify_linked'])
+    end
+
     private
 
     # 実 SNS/Account モデル (DB 依存) を読み込まないための最小ダブル。
@@ -33,6 +41,7 @@ module Mulukhiya
     def linked_account
       account = Object.new
       def account.annict_linked? = true
+      def account.spotify_linked? = true
       return account
     end
   end

--- a/test/unit/lib/dynamic_features.rb
+++ b/test/unit/lib/dynamic_features.rb
@@ -3,7 +3,7 @@ module Mulukhiya
     def test_registry_keys
       assert_equal(
         ['annict_linked', 'media_catalog', 'program_editable', 'word_suggest',
-          'nowplaying_resolver'].to_set,
+          'nowplaying_resolver', 'nowplaying_url_resolver'].to_set,
         DynamicFeatures::REGISTRY.keys.to_set,
       )
     end

--- a/test/unit/lib/nowplaying_url_resolver.rb
+++ b/test/unit/lib/nowplaying_url_resolver.rb
@@ -1,0 +1,38 @@
+module Mulukhiya
+  class NowplayingUrlResolverTest < TestCase
+    def test_enabled
+      assert_true(NowplayingUrlResolver.enabled?)
+    end
+
+    # iTunes 経路は資格情報不要で実 API を叩ける (既存 itunes_url_nowplaying_handler
+    # テストと同様)。URL → メタの逆引きを確認する。
+    def test_resolve_apple_music
+      url = 'https://music.apple.com/jp/album/1299587212?i=1299587213&uo=4'
+      result = NowplayingUrlResolver.new(url: url).resolve
+
+      assert_equal('apple_music', result[:provider])
+      assert_equal('シュビドゥビ☆スイーツタイム', result[:normalized][:title])
+      assert_equal('宮本佳那子', result[:normalized][:artist])
+      assert_includes(result[:url], 'music.apple.com')
+    end
+
+    def test_resolve_returns_nil_url_for_blank
+      assert_nil(NowplayingUrlResolver.new(url: '   ').resolve[:url])
+    end
+
+    def test_resolve_returns_nil_url_for_unsupported_host
+      result = NowplayingUrlResolver.new(url: 'https://www.youtube.com/watch?v=abc').resolve
+
+      assert_nil(result[:url])
+    end
+
+    # Spotify 経路は SpotifyService.config? が前提。未設定 (CI 既定) では解決せず
+    # {url: nil} を返す (404 にはしない)。
+    def test_resolve_spotify_returns_nil_url_without_config
+      omit('Spotify configured in this environment') if SpotifyService.config?
+      result = NowplayingUrlResolver.new(url: 'https://open.spotify.com/track/2oBorZqiVTpXAD8h7DCYWZ').resolve
+
+      assert_nil(result[:url])
+    end
+  end
+end

--- a/test/unit/lib/pronunciation_dictionary.rb
+++ b/test/unit/lib/pronunciation_dictionary.rb
@@ -71,5 +71,16 @@ module Mulukhiya
     def test_suggest_no_match_returns_empty
       assert_empty(@dic.suggest('ぞんざいしないよみ'))
     end
+
+    def test_cold_cache_returns_empty_and_enqueues_worker
+      return if disable?
+      @dic.invalidate_cache
+      PronunciationDictionaryUpdateWorker.jobs.clear
+      dic = PronunciationDictionary.new
+
+      # cold-cache 時は同期 fetch せず空候補を即返し、充填はワーカーに委ねる (#4405)。
+      assert_empty(dic.suggest('あい'))
+      assert_equal(1, PronunciationDictionaryUpdateWorker.jobs.size)
+    end
   end
 end

--- a/test/unit/lib/pronunciation_dictionary.rb
+++ b/test/unit/lib/pronunciation_dictionary.rb
@@ -72,15 +72,27 @@ module Mulukhiya
       assert_empty(@dic.suggest('ぞんざいしないよみ'))
     end
 
-    def test_cold_cache_returns_empty_and_enqueues_worker
+    def test_cold_cache_returns_empty_and_defers_fill_to_worker
       return if disable?
+      url = 'https://dic.test/pron.json'
+      original_urls = config['/word_suggest/urls']
+      config['/word_suggest/urls'] = [url]
+      stub_request(:head, url).to_return(status: 200)
+      stub_request(:get, url).to_return(
+        status: 200,
+        body: [{'word' => '相生', 'pronunciation' => 'アイオイ'}].to_json,
+        headers: {'Content-Type' => 'application/json'},
+      )
       @dic.invalidate_cache
-      PronunciationDictionaryUpdateWorker.jobs.clear
-      dic = PronunciationDictionary.new
 
-      # cold-cache 時は同期 fetch せず空候補を即返し、充填はワーカーに委ねる (#4405)。
-      assert_empty(dic.suggest('あい'))
-      assert_equal(1, PronunciationDictionaryUpdateWorker.jobs.size)
+      # cold-cache の当該リクエストは同期 fetch せず空を即返す (#4405)。旧実装なら
+      # ここで同期 fetch して候補が返るが、新実装は充填をワーカーへ委ねる。test モード
+      # では perform_async が perform を同期実行するため、直後は別インスタンスから
+      # 充填済みキャッシュで引ける。
+      assert_empty(PronunciationDictionary.new.suggest('あいおい'))
+      assert_equal('相生', PronunciationDictionary.new.suggest('あいおい').first[:surface])
+    ensure
+      config['/word_suggest/urls'] = original_urls if defined?(original_urls)
     end
   end
 end

--- a/test/unit/service/misskey_service.rb
+++ b/test/unit/service/misskey_service.rb
@@ -153,6 +153,35 @@ module Mulukhiya
       end
     end
 
+    def test_register_sw_subscription_consolidates_preexisting_duplicates
+      return unless Environment.misskey? && account
+
+      endpoint = "https://push.test/#{SecureRandom.hex(8)}"
+      cleanup = -> {Misskey::SwSubscription.where(userId: account.id, endpoint:).delete}
+      cleanup.call
+      begin
+        # pre-fix の鍵ローテ蓄積を模し、同一 (userId, endpoint) に複数行を直接作る。
+        2.times do |i|
+          Misskey::SwSubscription.create(
+            id: MisskeyService.create_aid, userId: account.id, endpoint:,
+            auth: "old_#{i}", publickey: "oldkey_#{i}", sendReadMessage: true
+          )
+        end
+        result = @service.register_sw_subscription(account, {
+          endpoint:, auth: 'auth_new', publickey: 'key_new', sendReadMessage: false
+        })
+
+        assert_equal(:already_subscribed, result[:state])
+        rows = Misskey::SwSubscription.where(userId: account.id, endpoint:).all
+
+        assert_equal(1, rows.size)
+        assert_equal('auth_new', rows.first.auth)
+        assert_equal('key_new', rows.first.publickey)
+      ensure
+        cleanup.call
+      end
+    end
+
     def test_parse_emoji_palette_entries_with_nil
       assert_equal([], @service.send(:parse_emoji_palette_entries, nil))
     end

--- a/test/unit/service/misskey_service.rb
+++ b/test/unit/service/misskey_service.rb
@@ -126,6 +126,33 @@ module Mulukhiya
       assert_equal({id: 'p2', name: 'パレ2', emojis: []}, entries[1])
     end
 
+    def test_register_sw_subscription_dedup_on_key_rotation
+      return unless Environment.misskey? && account
+
+      endpoint = "https://push.test/#{SecureRandom.hex(8)}"
+      cleanup = -> {Misskey::SwSubscription.where(userId: account.id, endpoint:).delete}
+      cleanup.call
+      begin
+        first = @service.register_sw_subscription(account, {
+          endpoint:, auth: 'auth_a', publickey: 'key_a', sendReadMessage: true
+        })
+        second = @service.register_sw_subscription(account, {
+          endpoint:, auth: 'auth_b', publickey: 'key_b', sendReadMessage: false
+        })
+
+        assert_equal(:subscribed, first[:state])
+        assert_equal(:already_subscribed, second[:state])
+        rows = Misskey::SwSubscription.where(userId: account.id, endpoint:).all
+
+        assert_equal(1, rows.size)
+        assert_equal('auth_b', rows.first.auth)
+        assert_equal('key_b', rows.first.publickey)
+        refute(rows.first.sendReadMessage)
+      ensure
+        cleanup.call
+      end
+    end
+
     def test_parse_emoji_palette_entries_with_nil
       assert_equal([], @service.send(:parse_emoji_palette_entries, nil))
     end

--- a/test/unit/service/spotify_user_service.rb
+++ b/test/unit/service/spotify_user_service.rb
@@ -15,19 +15,23 @@ module Mulukhiya
 
     def test_config_false_when_user_oauth_disabled
       config['/service/spotify/oauth/user_oauth_enabled'] = false
+
       assert_false(SpotifyUserService.config?)
     end
 
     def test_config_false_without_client_id
       config['/service/spotify/client/id'] = nil
+
       assert_false(SpotifyUserService.config?)
     end
 
     def test_oauth_uri
       uri = SpotifyUserService.new.oauth_uri
+
       assert_equal('accounts.spotify.com', uri.host)
       assert_equal('/authorize', uri.path)
       query = uri.query_values
+
       assert_equal('test_client_id', query['client_id'])
       assert_equal('code', query['response_type'])
       assert_equal('user-read-currently-playing', query['scope'])
@@ -36,7 +40,7 @@ module Mulukhiya
 
     def test_auth_exchanges_code_and_stores_tokens
       stub = stub_token_endpoint(
-        access_token: 'access-1', refresh_token: 'refresh-1', expires_in: 3600
+        access_token: 'access-1', refresh_token: 'refresh-1', expires_in: 3600,
       )
       account = account_double
 
@@ -127,7 +131,7 @@ module Mulukhiya
       )
       stub_request(:post, token_url).to_return(
         status: 400, body: {error: 'invalid_grant'}.to_json,
-        headers: {'Content-Type' => 'application/json'},
+        headers: {'Content-Type' => 'application/json'}
       )
 
       assert_raises(Ginseng::AuthError) do
@@ -163,14 +167,14 @@ module Mulukhiya
       body = {access_token:, token_type: 'Bearer', expires_in:}
       body[:refresh_token] = refresh_token if refresh_token
       return stub_request(:post, token_url).to_return(
-        status: 200, body: body.to_json, headers: {'Content-Type' => 'application/json'}
+        status: 200, body: body.to_json, headers: {'Content-Type' => 'application/json'},
       )
     end
 
     def stub_currently_playing(status:, body:)
       payload = body.is_a?(String) ? body : body.to_json
       return stub_request(:get, currently_playing_url).to_return(
-        status:, body: payload, headers: {'Content-Type' => 'application/json'}
+        status:, body: payload, headers: {'Content-Type' => 'application/json'},
       )
     end
 

--- a/test/unit/service/spotify_user_service.rb
+++ b/test/unit/service/spotify_user_service.rb
@@ -1,0 +1,224 @@
+module Mulukhiya
+  class SpotifyUserServiceTest < TestCase
+    def setup
+      config['/service/spotify/client/id'] = 'test_client_id'
+      config['/service/spotify/client/secret'] = 'test_client_secret'
+      config['/service/spotify/oauth/user_oauth_enabled'] = true
+      # repeat の内部リトライ (config['/http/retry/limit']) が WebMock の逐次レスポンスを
+      # 食ってしまい 401→refresh の検証が非決定になるため、テストでは無効化する。
+      config['/http/retry/limit'] = 1
+    end
+
+    def test_config_true_when_enabled
+      assert_predicate(SpotifyUserService, :config?)
+    end
+
+    def test_config_false_when_user_oauth_disabled
+      config['/service/spotify/oauth/user_oauth_enabled'] = false
+      assert_false(SpotifyUserService.config?)
+    end
+
+    def test_config_false_without_client_id
+      config['/service/spotify/client/id'] = nil
+      assert_false(SpotifyUserService.config?)
+    end
+
+    def test_oauth_uri
+      uri = SpotifyUserService.new.oauth_uri
+      assert_equal('accounts.spotify.com', uri.host)
+      assert_equal('/authorize', uri.path)
+      query = uri.query_values
+      assert_equal('test_client_id', query['client_id'])
+      assert_equal('code', query['response_type'])
+      assert_equal('user-read-currently-playing', query['scope'])
+      assert_equal(config['/service/spotify/oauth/redirect_uri'], query['redirect_uri'])
+    end
+
+    def test_auth_exchanges_code_and_stores_tokens
+      stub = stub_token_endpoint(
+        access_token: 'access-1', refresh_token: 'refresh-1', expires_in: 3600
+      )
+      account = account_double
+
+      SpotifyUserService.new(account).auth('the-code')
+
+      assert_requested(stub.with do |req|
+        body = URI.decode_www_form(req.body).to_h
+        body['grant_type'] == 'authorization_code' && body['code'] == 'the-code'
+      end)
+      assert_equal('access-1', account.user_config['/service/spotify/token'])
+      assert_equal('refresh-1', account.user_config['/service/spotify/refresh_token'])
+      assert_operator(account.user_config['/service/spotify/expires_at'], :>, Time.now.to_i)
+    end
+
+    def test_currently_playing_returns_track_url
+      account = account_double(
+        '/service/spotify/token' => 'access-1',
+        '/service/spotify/refresh_token' => 'refresh-1',
+        '/service/spotify/expires_at' => Time.now.to_i + 3600,
+      )
+      stub_currently_playing(status: 200, body: {
+        is_playing: true,
+        item: {external_urls: {spotify: 'https://open.spotify.com/track/abc123'}},
+      })
+
+      assert_equal(
+        'https://open.spotify.com/track/abc123',
+        SpotifyUserService.new(account).currently_playing,
+      )
+    end
+
+    def test_currently_playing_returns_nil_when_nothing_playing
+      account = account_double(
+        '/service/spotify/token' => 'access-1',
+        '/service/spotify/refresh_token' => 'refresh-1',
+        '/service/spotify/expires_at' => Time.now.to_i + 3600,
+      )
+      stub_currently_playing(status: 204, body: '')
+
+      assert_nil(SpotifyUserService.new(account).currently_playing)
+    end
+
+    def test_currently_playing_refreshes_when_token_expired
+      account = account_double(
+        '/service/spotify/token' => 'stale',
+        '/service/spotify/refresh_token' => 'refresh-1',
+        '/service/spotify/expires_at' => Time.now.to_i - 1,
+      )
+      token_stub = stub_token_endpoint(access_token: 'access-2', expires_in: 3600)
+      stub_currently_playing(status: 200, body: {
+        item: {external_urls: {spotify: 'https://open.spotify.com/track/xyz'}},
+      })
+
+      url = SpotifyUserService.new(account).currently_playing
+
+      assert_equal('https://open.spotify.com/track/xyz', url)
+      assert_requested(token_stub)
+      assert_equal('access-2', account.user_config['/service/spotify/token'])
+      # Spotify が refresh_token を返さなかった場合は既存値を保持する。
+      assert_equal('refresh-1', account.user_config['/service/spotify/refresh_token'])
+    end
+
+    def test_currently_playing_refreshes_on_401_then_retries
+      account = account_double(
+        '/service/spotify/token' => 'access-1',
+        '/service/spotify/refresh_token' => 'refresh-1',
+        '/service/spotify/expires_at' => Time.now.to_i + 3600,
+      )
+      stub_token_endpoint(access_token: 'access-2', expires_in: 3600)
+      stub_request(:get, currently_playing_url).to_return(
+        {status: 401, body: '{}', headers: {'Content-Type' => 'application/json'}},
+        {status: 200, body: {item: {external_urls: {spotify: 'https://open.spotify.com/track/r'}}}.to_json,
+         headers: {'Content-Type' => 'application/json'}},
+      )
+
+      assert_equal(
+        'https://open.spotify.com/track/r',
+        SpotifyUserService.new(account).currently_playing,
+      )
+      assert_equal('access-2', account.user_config['/service/spotify/token'])
+    end
+
+    def test_currently_playing_raises_auth_error_when_refresh_token_revoked
+      account = account_double(
+        '/service/spotify/token' => 'access-1',
+        '/service/spotify/refresh_token' => 'revoked',
+        '/service/spotify/expires_at' => Time.now.to_i - 1,
+      )
+      stub_request(:post, token_url).to_return(
+        status: 400, body: {error: 'invalid_grant'}.to_json,
+        headers: {'Content-Type' => 'application/json'},
+      )
+
+      assert_raises(Ginseng::AuthError) do
+        SpotifyUserService.new(account).currently_playing
+      end
+    end
+
+    def test_unlink_clears_tokens
+      account = account_double(
+        '/service/spotify/token' => 'access-1',
+        '/service/spotify/refresh_token' => 'refresh-1',
+        '/service/spotify/expires_at' => Time.now.to_i + 3600,
+      )
+
+      SpotifyUserService.new(account).unlink
+
+      assert_nil(account.user_config['/service/spotify/token'])
+      assert_nil(account.user_config['/service/spotify/refresh_token'])
+      assert_nil(account.user_config['/service/spotify/expires_at'])
+    end
+
+    private
+
+    def token_url
+      return "#{config['/service/spotify/urls/accounts']}/api/token"
+    end
+
+    def currently_playing_url
+      return "#{config['/service/spotify/urls/api']}/v1/me/player/currently-playing"
+    end
+
+    def stub_token_endpoint(access_token:, expires_in:, refresh_token: nil)
+      body = {access_token:, token_type: 'Bearer', expires_in:}
+      body[:refresh_token] = refresh_token if refresh_token
+      return stub_request(:post, token_url).to_return(
+        status: 200, body: body.to_json, headers: {'Content-Type' => 'application/json'}
+      )
+    end
+
+    def stub_currently_playing(status:, body:)
+      payload = body.is_a?(String) ? body : body.to_json
+      return stub_request(:get, currently_playing_url).to_return(
+        status:, body: payload, headers: {'Content-Type' => 'application/json'}
+      )
+    end
+
+    # 実 Account/UserConfig (DB・Redis 依存) を避けるための最小ダブル。
+    # UserConfig は暗号化値をそのまま保持し read 時に復号しない仕様だが、本ダブルは
+    # 平文を保持する (service 側 decrypt は復号失敗時に値をそのまま返すため整合する)。
+    def account_double(store = {})
+      user_config = FakeUserConfig.new(store)
+      return Struct.new(:user_config).new(user_config)
+    end
+
+    class FakeUserConfig
+      def initialize(store = {})
+        @store = store.dup
+      end
+
+      def [](key)
+        return @store[key]
+      end
+
+      def update(values)
+        flatten(values.deep_stringify_keys).each do |key, value|
+          if value.nil?
+            @store.delete(key)
+          else
+            @store[key] = value
+          end
+        end
+      end
+
+      def to_h
+        return @store.dup
+      end
+
+      private
+
+      def flatten(hash, prefix = '')
+        result = {}
+        hash.each do |key, value|
+          path = "#{prefix}/#{key}"
+          if value.is_a?(Hash)
+            result.merge!(flatten(value, path))
+          else
+            result[path] = value
+          end
+        end
+        return result
+      end
+    end
+  end
+end

--- a/test/unit/service/spotify_user_service.rb
+++ b/test/unit/service/spotify_user_service.rb
@@ -83,6 +83,33 @@ module Mulukhiya
       assert_nil(SpotifyUserService.new(account).currently_playing)
     end
 
+    def test_currently_playing_returns_nil_when_paused
+      account = account_double(
+        '/service/spotify/token' => 'access-1',
+        '/service/spotify/refresh_token' => 'refresh-1',
+        '/service/spotify/expires_at' => Time.now.to_i + 3600,
+      )
+      # 一時停止中は item が直前トラックのまま 200 で返るが is_playing:false。
+      stub_currently_playing(status: 200, body: {
+        is_playing: false,
+        item: {external_urls: {spotify: 'https://open.spotify.com/track/paused'}},
+      })
+
+      assert_nil(SpotifyUserService.new(account).currently_playing)
+    end
+
+    def test_auth_sends_client_credentials_via_basic_header
+      stub = stub_token_endpoint(access_token: 'a', refresh_token: 'r', expires_in: 3600)
+      expected = Base64.strict_encode64('test_client_id:test_client_secret')
+
+      SpotifyUserService.new(account_double).auth('the-code')
+
+      assert_requested(stub.with do |req|
+        req.headers['Authorization'] == "Basic #{expected}" &&
+          !URI.decode_www_form(req.body).to_h.key?('client_secret')
+      end)
+    end
+
     def test_currently_playing_refreshes_when_token_expired
       account = account_double(
         '/service/spotify/token' => 'stale',
@@ -91,6 +118,7 @@ module Mulukhiya
       )
       token_stub = stub_token_endpoint(access_token: 'access-2', expires_in: 3600)
       stub_currently_playing(status: 200, body: {
+        is_playing: true,
         item: {external_urls: {spotify: 'https://open.spotify.com/track/xyz'}},
       })
 
@@ -112,7 +140,7 @@ module Mulukhiya
       stub_token_endpoint(access_token: 'access-2', expires_in: 3600)
       stub_request(:get, currently_playing_url).to_return(
         {status: 401, body: '{}', headers: {'Content-Type' => 'application/json'}},
-        {status: 200, body: {item: {external_urls: {spotify: 'https://open.spotify.com/track/r'}}}.to_json,
+        {status: 200, body: {is_playing: true, item: {external_urls: {spotify: 'https://open.spotify.com/track/r'}}}.to_json,
          headers: {'Content-Type' => 'application/json'}},
       )
 


### PR DESCRIPTION
5.27.0 リリース。

## 概要

capsicum ナウプレ連携の源泉拡張を主軸にした回。Spotify user-level OAuth + currently-playing API (#4337) と URL→メタ逆引き `/nowplaying/resolve-url` (#4415) を新設。あわせて Misskey プッシュ購読の重複蓄積修正 (#4408)、5.26.0 レビュー繰越 (#4405)、本リリース前 5観点レビュー由来のログ scrub (#4418)。

## 主な変更
- #4337 Spotify user-level OAuth + currently-playing API（features.spotify_enabled、既定 OFF＝capsicum #570 塩漬けのため）
- #4415 ナウプレ resolve-by-URL `POST /nowplaying/resolve-url`（features.nowplaying_url_resolver）
- #4408 sw/register の重複 subscription 蓄積修正（(userId, endpoint) 単位 dedup + 既存重複集約）
- #4405 5.26.0 レビュー繰越（cold-cache 非同期化・無限 enqueue 防止）
- #4418 5観点レビュー赤近い黄インライン（OAuth code の info ログ scrub）

5観点レビュー: 真の赤は Spotify 機能が全台 OFF のため非ブロックと判断し #4414 へ繰越。bundler-audit 脆弱性なし・Dependabot 0。

[5.27.0 マイルストーン](https://github.com/pooza/mulukhiya-toot-proxy/milestone/623?closed=1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)