### PR TITLE
feat(spotify): user-level OAuth + currently-playing API を新設 (#4337)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ dist
 tmp/
 var/*.yaml
 2
+
+# ローカル Redis ダンプ
+dump.rdb

--- a/app/lib/mulukhiya/contract/spotify_auth_contract.rb
+++ b/app/lib/mulukhiya/contract/spotify_auth_contract.rb
@@ -1,0 +1,8 @@
+module Mulukhiya
+  class SpotifyAuthContract < Contract
+    params do
+      required(:token).value(:string)
+      required(:code).value(:string)
+    end
+  end
+end

--- a/app/lib/mulukhiya/contract/spotify_auth_contract.rb
+++ b/app/lib/mulukhiya/contract/spotify_auth_contract.rb
@@ -1,7 +1,8 @@
 module Mulukhiya
   class SpotifyAuthContract < Contract
     params do
-      required(:token).value(:string)
+      # ユーザー特定は APIController の bearer 認証 (sns.account) で行うため、
+      # body への token 重複は要求しない。検証するのは認可 code のみ。
       required(:code).value(:string)
     end
   end

--- a/app/lib/mulukhiya/controller/api_controller.rb
+++ b/app/lib/mulukhiya/controller/api_controller.rb
@@ -490,6 +490,75 @@ module Mulukhiya
       return @renderer.to_s
     end
 
+    get '/spotify/oauth_uri' do
+      raise Ginseng::NotFoundError, 'Not Found' unless SpotifyUserService.config?
+      @renderer.message = {oauth_uri: SpotifyUserService.new.oauth_uri.to_s}
+      return @renderer.to_s
+    rescue => e
+      e.alert
+      @renderer.status = e.status
+      @renderer.message = {error: e.message}
+      return @renderer.to_s
+    end
+
+    post '/spotify/auth' do
+      raise Ginseng::NotFoundError, 'Not Found' unless SpotifyUserService.config?
+      raise Ginseng::AuthError, 'Unauthorized' unless sns.account
+      errors = SpotifyAuthContract.new.exec(params)
+      if errors.present?
+        @renderer.status = 422
+        @renderer.message = {errors:}
+      else
+        SpotifyUserService.new(sns.account).auth(params[:code])
+        @renderer.message = {config: sns.account.user_config.to_h}
+      end
+      return @renderer.to_s
+    rescue => e
+      e.alert
+      @renderer.status = e.status
+      @renderer.message = {error: e.message}
+      return @renderer.to_s
+    end
+
+    get '/spotify/currently_playing' do
+      raise Ginseng::NotFoundError, 'Not Found' unless SpotifyUserService.config?
+      raise Ginseng::AuthError, 'Unauthorized' unless sns.account
+      spotify = sns.account.spotify
+      raise Ginseng::AuthError, 'Spotify authentication required' unless spotify
+      @renderer.message = {url: spotify.currently_playing}
+      return @renderer.to_s
+    rescue Ginseng::GatewayError => e
+      e.log
+      @renderer.status = e.respond_to?(:source_status) ? e.source_status : 502
+      @renderer.message = {error: e.message}
+      return @renderer.to_s
+    rescue Ginseng::AuthError => e
+      # 未連携・refresh_token 失効は想定内のユーザー状態。capsicum が定期ポーリング
+      # するため alert すると Sentry スパム化する。log に留め 403 で返す。
+      e.log
+      @renderer.status = e.status
+      @renderer.message = {error: e.message}
+      return @renderer.to_s
+    rescue => e
+      e.alert
+      @renderer.status = e.status
+      @renderer.message = {error: e.message}
+      return @renderer.to_s
+    end
+
+    delete '/spotify/auth' do
+      raise Ginseng::NotFoundError, 'Not Found' unless SpotifyUserService.config?
+      raise Ginseng::AuthError, 'Unauthorized' unless sns.account
+      sns.account.spotify&.unlink
+      @renderer.message = {config: sns.account.user_config.to_h}
+      return @renderer.to_s
+    rescue => e
+      e.alert
+      @renderer.status = e.status
+      @renderer.message = {error: e.message}
+      return @renderer.to_s
+    end
+
     post '/annict/record' do
       raise Ginseng::NotFoundError, 'Not Found' unless controller_class.annict?
       raise Ginseng::AuthError, 'Unauthorized' unless sns.account

--- a/app/lib/mulukhiya/dynamic_features.rb
+++ b/app/lib/mulukhiya/dynamic_features.rb
@@ -13,8 +13,12 @@ module Mulukhiya
   #                        URL 設定の有無に一本化し二重管理を避ける
   #   - nowplaying_resolver : ナウプレ enrich (#4382)。メタデータ → 共有 URL 解決
   #                        エンドポイントの可否。capsicum が enrich を試みるか判定に使う
+  #   - spotify_enabled  : Spotify user OAuth (#4337) がサーバーで有効か。Developer
+  #                        Dashboard 登録 + user_oauth_enabled を満たすか。capsicum が
+  #                        連携導線を出すか判定に使う
+  #   - spotify_linked   : リクエストの SNS アカウント単位の Spotify 連携状態 (#4337)
   #
-  # 新しい動的フラグ (例: spotify_linked) を増やす際は REGISTRY に 1 行追加する。
+  # 新しい動的フラグを増やす際は REGISTRY に 1 行追加する。
   class DynamicFeatures
     include Package
 
@@ -26,6 +30,8 @@ module Mulukhiya
       },
       'word_suggest' => ->(_sns) {PronunciationDictionary.new.enabled?},
       'nowplaying_resolver' => ->(_sns) {NowplayingResolver.enabled?},
+      'spotify_enabled' => ->(_sns) {SpotifyUserService.config?},
+      'spotify_linked' => ->(sns) {sns.account&.spotify_linked? || false},
     }.freeze
 
     def initialize(sns)

--- a/app/lib/mulukhiya/model/account_methods.rb
+++ b/app/lib/mulukhiya/model/account_methods.rb
@@ -81,6 +81,23 @@ module Mulukhiya
       return false
     end
 
+    def spotify
+      return nil unless user_config['/service/spotify/refresh_token']
+      @spotify ||= SpotifyUserService.new(self)
+      return @spotify
+    end
+
+    # 当該ユーザーに Spotify refresh_token が保管済みか (#4337)。
+    # capsicum が features.spotify_linked でナウプレ取得導線の出し分けに使う。
+    # access_token は失効するため refresh_token の有無で「連携済み」を表す
+    # (liveness/refresh 確認は about を重くするため範囲外)。
+    def spotify_linked?
+      return user_config['/service/spotify/refresh_token'].present?
+    rescue => e
+      e.log(acct: acct.to_s)
+      return false
+    end
+
     def featured_tags
       return TagContainer.new
     end

--- a/app/lib/mulukhiya/service/spotify_user_service.rb
+++ b/app/lib/mulukhiya/service/spotify_user_service.rb
@@ -13,9 +13,9 @@ module Mulukhiya
   class SpotifyUserService
     include Package
 
-    AUTHORIZE_PATH = '/authorize'
-    TOKEN_PATH = '/api/token'
-    CURRENTLY_PLAYING_PATH = '/v1/me/player/currently-playing'
+    AUTHORIZE_PATH = '/authorize'.freeze
+    TOKEN_PATH = '/api/token'.freeze
+    CURRENTLY_PLAYING_PATH = '/v1/me/player/currently-playing'.freeze
 
     # account は currently_playing / auth / unlink で必要 (refresh したトークンを
     # UserConfig へ書き戻すため)。oauth_uri のみ account なしでも使える。
@@ -67,8 +67,8 @@ module Mulukhiya
     # 連携解除。保管した access/refresh/expires_at を除去する (deep_compact で nil は
     # 削除されるため、これで未連携状態に戻る)。
     def unlink
-      @account.user_config.update(service: {spotify: {token: nil, refresh_token: nil, expires_at: nil}})
-      return true
+      cleared = {token: nil, refresh_token: nil, expires_at: nil}
+      return @account.user_config.update(service: {spotify: cleared})
     end
 
     def self.client_id

--- a/app/lib/mulukhiya/service/spotify_user_service.rb
+++ b/app/lib/mulukhiya/service/spotify_user_service.rb
@@ -1,0 +1,196 @@
+module Mulukhiya
+  # capsicum のナウプレ投稿 (capsicum #465) 向けの user-level OAuth サービス (#4337)。
+  #
+  # 既存の SpotifyService (Client Credentials Flow / app-level、track 検索・lookup 用)
+  # とは別系統で、Authorization Code Flow により当該ユーザーの
+  # GET /v1/me/player/currently-playing を呼ぶ。capsicum に client_secret を置かず
+  # サーバー (モロヘイヤ) がトークンを保管する点は Annict 連携 (#4338) と同方針。
+  #
+  # トークンは UserConfig (Redis、暗号化) に保管する。Spotify の access_token は
+  # 3600s で失効するため refresh_token も保管し、失効時/401 時に自動更新する。
+  # capsicum 側は code-post 方式で、ブラウザ認可後の code を POST /api/spotify/auth に
+  # 渡すだけでよい (ユーザー特定は SNS トークンで行うため state は不要)。
+  class SpotifyUserService
+    include Package
+
+    AUTHORIZE_PATH = '/authorize'
+    TOKEN_PATH = '/api/token'
+    CURRENTLY_PLAYING_PATH = '/v1/me/player/currently-playing'
+
+    # account は currently_playing / auth / unlink で必要 (refresh したトークンを
+    # UserConfig へ書き戻すため)。oauth_uri のみ account なしでも使える。
+    def initialize(account = nil)
+      @account = account
+    end
+
+    def oauth_uri
+      uri = accounts_service.create_uri(AUTHORIZE_PATH)
+      uri.query_values = {
+        client_id: self.class.client_id,
+        response_type: 'code',
+        redirect_uri: redirect_uri,
+        scope: scopes.join(' '),
+      }
+      return uri
+    end
+
+    # authorization code を access_token + refresh_token に交換し保管する。
+    def auth(code)
+      response = token_request(
+        'grant_type' => 'authorization_code',
+        'code' => code,
+        'redirect_uri' => redirect_uri,
+      )
+      store_tokens(response.parsed_response)
+      return response
+    end
+
+    # 現在再生中トラックの共有 URL を返す。無再生・広告・プライベートセッション
+    # (204 / item なし) は nil。access_token 失効は事前 refresh で、保管値が古い等の
+    # 401 は事後 refresh + 1 回リトライで吸収する。
+    def currently_playing
+      refresh! if expired?
+      attempts = 0
+      begin
+        response = api_service.get(CURRENTLY_PLAYING_PATH, headers: bearer_headers)
+        return nil if response.code == 204
+        return extract_track_url(response.parsed_response)
+      rescue Ginseng::GatewayError => e
+        raise unless e.source_status == 401
+        attempts += 1
+        raise if attempts > 1
+        refresh!
+        retry
+      end
+    end
+
+    # 連携解除。保管した access/refresh/expires_at を除去する (deep_compact で nil は
+    # 削除されるため、これで未連携状態に戻る)。
+    def unlink
+      @account.user_config.update(service: {spotify: {token: nil, refresh_token: nil, expires_at: nil}})
+      return true
+    end
+
+    def self.client_id
+      return config['/service/spotify/client/id'] rescue nil
+    end
+
+    def self.client_secret
+      return config['/service/spotify/client/secret'].decrypt
+    rescue Ginseng::ConfigError
+      return nil
+    rescue
+      return config['/service/spotify/client/secret']
+    end
+
+    # user OAuth が利用可能か (features.spotify_enabled の正本)。Spotify Developer
+    # Dashboard 側で Redirect URI / Scope 登録が済むまでは user_oauth_enabled を false に
+    # しておき、capsicum に連携導線を出させない。
+    def self.config?
+      return false unless config['/service/spotify/oauth/user_oauth_enabled']
+      return false unless client_id
+      return false unless client_secret
+      return true
+    rescue => e
+      e.log
+      return false
+    end
+
+    private
+
+    def redirect_uri
+      return config['/service/spotify/oauth/redirect_uri']
+    end
+
+    def scopes
+      return Array(config['/service/spotify/oauth/scopes'])
+    end
+
+    def access_token
+      return decrypt(@account.user_config['/service/spotify/token'])
+    end
+
+    def refresh_token
+      return decrypt(@account.user_config['/service/spotify/refresh_token'])
+    end
+
+    def expired?
+      expires_at = @account.user_config['/service/spotify/expires_at']
+      return true unless expires_at
+      return Time.now.to_i >= expires_at.to_i
+    end
+
+    def refresh!
+      raise Ginseng::AuthError, 'Spotify authentication required' unless refresh_token
+      response = token_request(
+        'grant_type' => 'refresh_token',
+        'refresh_token' => refresh_token,
+      )
+      store_tokens(response.parsed_response)
+      return response
+    rescue Ginseng::GatewayError => e
+      # refresh_token 失効/revoke (invalid_grant) は token endpoint が 4xx を返す。
+      # これは再認証が必要なユーザー起因エラーなので AuthError (401) に倒し、
+      # capsicum に再連携フローを誘導させる。5xx/timeout は Spotify 障害なので
+      # GatewayError (502) のまま上げる。
+      raise unless e.source_status&.between?(400, 499)
+      raise Ginseng::AuthError, 'Spotify re-authentication required'
+    end
+
+    def token_request(params)
+      return accounts_service.post(TOKEN_PATH, {
+        headers: {'Content-Type' => 'application/x-www-form-urlencoded'},
+        body: {
+          'client_id' => self.class.client_id,
+          'client_secret' => self.class.client_secret,
+        }.merge(params),
+      })
+    end
+
+    def store_tokens(body)
+      values = {
+        token: body['access_token'],
+        expires_at: Time.now.to_i + body['expires_in'].to_i,
+      }
+      # Spotify は refresh_token を毎回返すとは限らない。返らない場合は既存値を保持する
+      # (上書きで消すと以降 refresh 不能になる)。
+      values[:refresh_token] = body['refresh_token'] if body['refresh_token'].present?
+      @account.user_config.update(service: {spotify: values})
+    end
+
+    def extract_track_url(body)
+      return nil unless body.is_a?(Hash)
+      item = body['item']
+      return nil unless item.is_a?(Hash)
+      return item.dig('external_urls', 'spotify').presence
+    end
+
+    def bearer_headers
+      return {'Authorization' => "Bearer #{access_token}"}
+    end
+
+    # UserConfig は暗号化値をそのまま返す (read 時に復号しない) ため、利用側で復号する。
+    def decrypt(value)
+      return nil unless value
+      return value.decrypt
+    rescue
+      return value
+    end
+
+    def accounts_service
+      unless @accounts_service
+        @accounts_service = HTTP.new
+        @accounts_service.base_uri = config['/service/spotify/urls/accounts']
+      end
+      return @accounts_service
+    end
+
+    def api_service
+      unless @api_service
+        @api_service = HTTP.new
+        @api_service.base_uri = config['/service/spotify/urls/api']
+      end
+      return @api_service
+    end
+  end
+end

--- a/app/lib/mulukhiya/service/spotify_user_service.rb
+++ b/app/lib/mulukhiya/service/spotify_user_service.rb
@@ -1,3 +1,5 @@
+require 'base64'
+
 module Mulukhiya
   # capsicum のナウプレ投稿 (capsicum #465) 向けの user-level OAuth サービス (#4337)。
   #
@@ -138,13 +140,21 @@ module Mulukhiya
     end
 
     def token_request(params)
+      # Authorization Code Flow の /api/token は client 認証を HTTP Basic ヘッダで行う。
+      # client_id/secret を body にだけ入れると invalid_client で弾かれうるため、
+      # 認証はヘッダ、grant 固有パラメータのみ body に置く。
+      # https://developer.spotify.com/documentation/web-api/tutorials/code-flow#request-an-access-token
       return accounts_service.post(TOKEN_PATH, {
-        headers: {'Content-Type' => 'application/x-www-form-urlencoded'},
-        body: {
-          'client_id' => self.class.client_id,
-          'client_secret' => self.class.client_secret,
-        }.merge(params),
+        headers: {
+          'Content-Type' => 'application/x-www-form-urlencoded',
+          'Authorization' => "Basic #{basic_credentials}",
+        },
+        body: params,
       })
+    end
+
+    def basic_credentials
+      return Base64.strict_encode64("#{self.class.client_id}:#{self.class.client_secret}")
     end
 
     def store_tokens(body)
@@ -160,6 +170,9 @@ module Mulukhiya
 
     def extract_track_url(body)
       return nil unless body.is_a?(Hash)
+      # 一時停止中 (is_playing:false) は item が直前の選択トラックのまま 200 で返るため、
+      # ポーリング側が停止中トラックを再生中扱いしないよう再生中のみ URL を返す。
+      return nil unless body['is_playing'] == true
       item = body['item']
       return nil unless item.is_a?(Hash)
       return item.dig('external_urls', 'spotify').presence

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -581,6 +581,15 @@ service:
         - /videos/watch/
   spotify:
     language: ja,en-US;q=0.9,en;q=0.8
+    oauth:
+      # capsicum がブラウザ認可後の code を受け取れる Redirect URI。Spotify Developer
+      # Dashboard 側にも同値を登録する必要がある (#4337)。
+      redirect_uri: capsicum://spotify/callback
+      scopes:
+        - user-read-currently-playing
+      # Dashboard の Redirect URI / Scope 登録が済むまでは false。true で
+      # features.spotify_enabled が有効化され capsicum に連携導線が出る。
+      user_oauth_enabled: false
     patterns:
       - pattern: /track/([[:alnum:]]+)
         type: track
@@ -589,6 +598,8 @@ service:
     retry:
       seconds: 1
     urls:
+      accounts: https://accounts.spotify.com
+      api: https://api.spotify.com
       track: https://open.spotify.com/
 sharkey:
   capabilities:
@@ -655,6 +666,7 @@ spoiler:
 user_config:
   encrypt_fields:
     - token
+    - refresh_token
     - password
     - secret
   valid_keys:

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -582,9 +582,11 @@ service:
   spotify:
     language: ja,en-US;q=0.9,en;q=0.8
     oauth:
-      # capsicum がブラウザ認可後の code を受け取れる Redirect URI。Spotify Developer
-      # Dashboard 側にも同値を登録する必要がある (#4337)。
-      redirect_uri: capsicum://spotify/callback
+      # capsicum がブラウザ認可後の code を受け取る Redirect URI。デスクトップ向けに
+      # Spotify 公式推奨の loopback を採用。capsicum がクライアント機の 127.0.0.1 で
+      # 受けるためサーバー非依存の共通値。Spotify Developer Dashboard にも同値の登録が
+      # 必要 (#4337)。ポートは capsicum 側実装に合わせる (capsicum #570)。
+      redirect_uri: http://127.0.0.1:8888/spotify/callback
       scopes:
         - user-read-currently-playing
       # Dashboard の Redirect URI / Scope 登録が済むまでは false。true で

--- a/docs/api.md
+++ b/docs/api.md
@@ -869,7 +869,7 @@ Spotify 連携を解除する（保管トークンを削除）。
 ##### 設定キー
 
 - `/service/spotify/client/{id,secret}`: Spotify アプリの資格情報（app-level の `SpotifyService` と共用）
-- `/service/spotify/oauth/redirect_uri`: Redirect URI（Dashboard 登録値と一致させる。既定 `capsicum://spotify/callback`）
+- `/service/spotify/oauth/redirect_uri`: Redirect URI（Dashboard 登録値・capsicum の捕捉先と一致させる。既定 `http://127.0.0.1:8888/spotify/callback` = デスクトップ向け loopback）
 - `/service/spotify/oauth/scopes`: 要求スコープ（既定 `user-read-currently-playing`）
 - `/service/spotify/oauth/user_oauth_enabled`: user OAuth の有効化フラグ（既定 `false`。Dashboard 登録完了後に `true`）
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -94,6 +94,8 @@ SNS 本体への転送が失敗した場合、SNS が返したステータスコ
 | `/{controller}/features/annict` | `/annict/oauth_uri`, `/annict/auth`, `/tagging/dic/annict/episodes`, `/program/works`, `/program/works/:id/episodes` |
 | `features.word_suggest`（`/word_suggest/urls` 設定時に有効） | `/word/suggest` |
 | `features.nowplaying_resolver`（常時 `true`） | `/nowplaying/resolve` |
+| `features.spotify_enabled`（`/service/spotify/oauth/user_oauth_enabled` + 資格情報設定時に有効） | `/spotify/oauth_uri`, `/spotify/auth`, `/spotify/currently_playing` |
+| `features.spotify_linked`（当該ユーザーが Spotify 連携済みか） | `/spotify/currently_playing` |
 
 ## モロヘイヤ検出プロトコル
 
@@ -805,6 +807,71 @@ NowPlaying 情報を除去して再投稿する。
 - **設定キー**:
   - `/nowplaying/resolve/default_provider`: 優先指定・ヒントが無いときの既定プロバイダ（`apple_music` / `spotify`、既定 `apple_music`）
 - **備考**: Spotify は `/service/spotify` の資格情報が設定済みのときのみ候補。iTunes Search API は資格情報不要のため常時利用可能。capsicum は `features.nowplaying_resolver`（下記）で enrich を試みるか判定する。
+
+#### Spotify user OAuth（現在再生中の取得）
+
+capsicum が Spotify Web API 経由で「現在再生中」を OS 非依存に取得するための user-level OAuth（#4337 / capsicum #465）。app-level の `SpotifyService`（track 検索・lookup、`/nowplaying/resolve` でも使用）とは別系統で、**Authorization Code Flow** により当該ユーザーの `GET /me/player/currently-playing` を呼ぶ。capsicum に `client_secret` を置かず、モロヘイヤがアクセストークン／リフレッシュトークンを暗号化保管する点は Annict 連携と同方針。アクセストークンは 3600 秒で失効するため、モロヘイヤが失効時・401 時に自動でリフレッシュする（capsicum は意識不要）。
+
+- **前提条件**: `features.spotify_enabled` が `true`（= `/service/spotify/client/{id,secret}` 設定済み **かつ** `/service/spotify/oauth/user_oauth_enabled` が `true`）。Spotify Developer Dashboard 側で Redirect URI と `user-read-currently-playing` スコープの登録が必要。
+- **認証フロー（code-post 方式）**:
+  1. クライアントが `GET /spotify/oauth_uri` で認可 URL を取得する
+  2. クライアントが認可 URL をブラウザで開き、ユーザーが Spotify で認可する
+  3. Spotify が Redirect URI（`/service/spotify/oauth/redirect_uri`、capsicum が捕捉できる URL／カスタムスキーム）へ認可コード付きでリダイレクトする
+  4. クライアントが捕捉した認可コードを `POST /spotify/auth` に送信（ユーザー特定は SNS トークンで行うため `state` は不要）
+  5. 以降クライアントは `GET /spotify/currently_playing` で現在再生中の URL を取得できる
+
+##### GET /mulukhiya/api/spotify/oauth_uri
+
+Spotify の OAuth 認可 URL を取得する。
+
+- **認証**: 不要
+- **前提条件**: `features.spotify_enabled` が `true`（false 時は 404）
+- **パラメータ**: なし
+- **レスポンス例**: `{ "oauth_uri": "https://accounts.spotify.com/authorize?client_id=...&response_type=code&redirect_uri=...&scope=user-read-currently-playing" }`
+
+##### POST /mulukhiya/api/spotify/auth
+
+認可コードをアクセストークン＋リフレッシュトークンに交換し、ユーザー設定に暗号化保存する。
+
+- **認証**: 必須（SNS アカウントのトークン）
+- **前提条件**: `features.spotify_enabled` が `true`
+- **パラメータ**:
+
+| 名前 | 型 | 必須 | 説明 |
+|------|-----|------|------|
+| `token` | string | 必須 | SNS アカウントのアクセストークン |
+| `code` | string | 必須 | Spotify OAuth 認可コード |
+
+- **レスポンス**: `{ "config": { ... } }`（更新後のユーザー設定）
+
+##### GET /mulukhiya/api/spotify/currently_playing
+
+現在再生中トラックの共有 URL を返す。
+
+- **認証**: 必須（SNS アカウントのトークン → モロヘイヤが保持する Spotify トークンに解決）
+- **前提条件**: `features.spotify_enabled` が `true` かつ当該ユーザーが連携済み（`features.spotify_linked`）
+- **パラメータ**: なし
+- **レスポンス**:
+  - 再生中: `{ "url": "https://open.spotify.com/track/..." }`
+  - 無再生・広告再生中・プライベートセッション: `{ "url": null }`（200）
+- **エラー**:
+  - **403**（`Ginseng::AuthError`）: 未連携、またはリフレッシュトークン失効・revoke（要再連携）
+  - **502 Bad Gateway**: Spotify API ダウン・ネットワーク失敗
+
+##### DELETE /mulukhiya/api/spotify/auth
+
+Spotify 連携を解除する（保管トークンを削除）。
+
+- **認証**: 必須（SNS アカウントのトークン）
+- **前提条件**: `features.spotify_enabled` が `true`
+- **レスポンス**: `{ "config": { ... } }`（更新後のユーザー設定）
+
+##### 設定キー
+
+- `/service/spotify/client/{id,secret}`: Spotify アプリの資格情報（app-level の `SpotifyService` と共用）
+- `/service/spotify/oauth/redirect_uri`: Redirect URI（Dashboard 登録値と一致させる。既定 `capsicum://spotify/callback`）
+- `/service/spotify/oauth/scopes`: 要求スコープ（既定 `user-read-currently-playing`）
+- `/service/spotify/oauth/user_oauth_enabled`: user OAuth の有効化フラグ（既定 `false`。Dashboard 登録完了後に `true`）
 
 #### GET /mulukhiya/api/program
 

--- a/docs/capsicum-requirements.md
+++ b/docs/capsicum-requirements.md
@@ -408,7 +408,43 @@ capsicum v1.35（[capsicum#614](https://github.com/pooza/capsicum/issues/614)）
 - 本節の実装 Issue: #4397
 - capsicum 側 Issue: [capsicum#614](https://github.com/pooza/capsicum/issues/614) / 設計 doc: <https://github.com/pooza/capsicum/blob/develop/docs/compose-suggest-design.md>
 
-## 10. 今後の API 変更時の連携
+## 10. Spotify user OAuth（現在再生中の取得）
+
+### 背景・責務分担
+
+capsicum の macOS Share Extension（capsicum #422）によるナウプレ投稿は OS 共有機構依存の push 型で Linux / Windows では使えない。Spotify Web API の `GET /me/player/currently-playing` を使えば OS 非依存で同等機能を提供できる。capsicum に `client_secret` を置きたくないため、Annict と同じく**モロヘイヤ経由のサーバー保管型 OAuth**で実装する（#4337 / capsicum #465）。app-level の `SpotifyService`（§8 enrich でも使う track 検索）とは別系統の user-level（Authorization Code Flow）。
+
+### エンドポイント（5.27.0 実装・code-post 方式）
+
+| メソッド | パス | 用途 | 認証 |
+| --- | --- | --- | --- |
+| GET | `/spotify/oauth_uri` | OAuth 認可 URL 取得 | 不要 |
+| POST | `/spotify/auth` | 認可コードを token に交換・保管（body: `code`） | SNS token |
+| GET | `/spotify/currently_playing` | 現在再生中の URL（`{url}` / 無再生は `{url: null}`） | SNS token |
+| DELETE | `/spotify/auth` | 連携解除 | SNS token |
+
+- **認証フロー**: capsicum がブラウザで認可 URL を開き、Redirect URI で捕捉した認可コードを `POST /spotify/auth` に渡す。ユーザー特定は SNS トークンで行うため `state` は不要。詳細は `docs/api.md` の「Spotify user OAuth」節。
+- **トークン管理**: access_token（3600s 失効）と refresh_token をモロヘイヤが暗号化保管し、失効・401 時に自動リフレッシュ。capsicum は意識不要。refresh_token 失効時は 403（要再連携）。
+- **エラー**: 未連携・refresh 失効 → 403、Spotify API 障害 → 502、無再生／広告／プライベートセッション → `{url: null}`（200）。
+
+### features フラグ
+
+`GET /mulukhiya/api/about` の `features` に 2 つ追加（capsicum が連携導線の出し分けに使う）:
+
+- `spotify_enabled`: サーバーで user OAuth が有効か（資格情報設定 + `/service/spotify/oauth/user_oauth_enabled`）。Spotify Developer Dashboard 登録が済むまで `false`。
+- `spotify_linked`: 当該ユーザーが連携済みか。
+
+### pooza 作業（モロヘイヤ実装とは独立）
+
+Spotify Developer Dashboard で Redirect URI（`/service/spotify/oauth/redirect_uri`、capsicum が捕捉できる値）と `user-read-currently-playing` スコープを登録し、config の `user_oauth_enabled` を `true` にする。
+
+### 関連
+
+- 本節の実装 Issue: #4337（5.27.0）
+- capsicum 側 Issue: pooza/capsicum（本 API 実装後に着手予定）
+- capsicum 側設計: <https://github.com/pooza/capsicum/blob/develop/docs/spotify-nowplaying-design.md>
+
+## 11. 今後の API 変更時の連携
 
 モロヘイヤ側でエンドポイントの追加・変更・廃止がある場合:
 

--- a/test/contract/spotify_auth_contract.rb
+++ b/test/contract/spotify_auth_contract.rb
@@ -5,15 +5,16 @@ module Mulukhiya
     end
 
     def test_call
-      errors = @contract.call(token: 'sns-token', code: 'auth-code').errors
+      # ユーザー特定は bearer 認証で行うため code のみ必須・token は不要。
+      errors = @contract.call(code: 'auth-code').errors
 
       assert_empty(errors)
 
-      errors = @contract.call(token: 'sns-token', code: nil).errors
+      errors = @contract.call(code: nil).errors
 
       assert_false(errors.empty?)
 
-      errors = @contract.call(code: 'auth-code').errors
+      errors = @contract.call({}).errors
 
       assert_false(errors.empty?)
     end

--- a/test/contract/spotify_auth_contract.rb
+++ b/test/contract/spotify_auth_contract.rb
@@ -1,0 +1,21 @@
+module Mulukhiya
+  class SpotifyAuthContractTest < TestCase
+    def setup
+      @contract = SpotifyAuthContract.new
+    end
+
+    def test_call
+      errors = @contract.call(token: 'sns-token', code: 'auth-code').errors
+
+      assert_empty(errors)
+
+      errors = @contract.call(token: 'sns-token', code: nil).errors
+
+      assert_false(errors.empty?)
+
+      errors = @contract.call(code: 'auth-code').errors
+
+      assert_false(errors.empty?)
+    end
+  end
+end

--- a/test/unit/lib/dynamic_features.rb
+++ b/test/unit/lib/dynamic_features.rb
@@ -3,7 +3,7 @@ module Mulukhiya
     def test_registry_keys
       assert_equal(
         ['annict_linked', 'media_catalog', 'program_editable', 'word_suggest',
-          'nowplaying_resolver'].to_set,
+          'nowplaying_resolver', 'spotify_enabled', 'spotify_linked'].to_set,
         DynamicFeatures::REGISTRY.keys.to_set,
       )
     end
@@ -23,6 +23,14 @@ module Mulukhiya
       assert_true(DynamicFeatures.new(sns_double(linked_account)).to_h['annict_linked'])
     end
 
+    def test_spotify_linked_is_false_without_account
+      assert_false(DynamicFeatures.new(sns_double(nil)).to_h['spotify_linked'])
+    end
+
+    def test_spotify_linked_reflects_linked_account
+      assert_true(DynamicFeatures.new(sns_double(linked_account)).to_h['spotify_linked'])
+    end
+
     private
 
     # 実 SNS/Account モデル (DB 依存) を読み込まないための最小ダブル。
@@ -33,6 +41,7 @@ module Mulukhiya
     def linked_account
       account = Object.new
       def account.annict_linked? = true
+      def account.spotify_linked? = true
       return account
     end
   end

--- a/test/unit/service/spotify_user_service.rb
+++ b/test/unit/service/spotify_user_service.rb
@@ -15,19 +15,23 @@ module Mulukhiya
 
     def test_config_false_when_user_oauth_disabled
       config['/service/spotify/oauth/user_oauth_enabled'] = false
+
       assert_false(SpotifyUserService.config?)
     end
 
     def test_config_false_without_client_id
       config['/service/spotify/client/id'] = nil
+
       assert_false(SpotifyUserService.config?)
     end
 
     def test_oauth_uri
       uri = SpotifyUserService.new.oauth_uri
+
       assert_equal('accounts.spotify.com', uri.host)
       assert_equal('/authorize', uri.path)
       query = uri.query_values
+
       assert_equal('test_client_id', query['client_id'])
       assert_equal('code', query['response_type'])
       assert_equal('user-read-currently-playing', query['scope'])
@@ -36,7 +40,7 @@ module Mulukhiya
 
     def test_auth_exchanges_code_and_stores_tokens
       stub = stub_token_endpoint(
-        access_token: 'access-1', refresh_token: 'refresh-1', expires_in: 3600
+        access_token: 'access-1', refresh_token: 'refresh-1', expires_in: 3600,
       )
       account = account_double
 
@@ -127,7 +131,7 @@ module Mulukhiya
       )
       stub_request(:post, token_url).to_return(
         status: 400, body: {error: 'invalid_grant'}.to_json,
-        headers: {'Content-Type' => 'application/json'},
+        headers: {'Content-Type' => 'application/json'}
       )
 
       assert_raises(Ginseng::AuthError) do
@@ -163,14 +167,14 @@ module Mulukhiya
       body = {access_token:, token_type: 'Bearer', expires_in:}
       body[:refresh_token] = refresh_token if refresh_token
       return stub_request(:post, token_url).to_return(
-        status: 200, body: body.to_json, headers: {'Content-Type' => 'application/json'}
+        status: 200, body: body.to_json, headers: {'Content-Type' => 'application/json'},
       )
     end
 
     def stub_currently_playing(status:, body:)
       payload = body.is_a?(String) ? body : body.to_json
       return stub_request(:get, currently_playing_url).to_return(
-        status:, body: payload, headers: {'Content-Type' => 'application/json'}
+        status:, body: payload, headers: {'Content-Type' => 'application/json'},
       )
     end
 

--- a/test/unit/service/spotify_user_service.rb
+++ b/test/unit/service/spotify_user_service.rb
@@ -1,0 +1,224 @@
+module Mulukhiya
+  class SpotifyUserServiceTest < TestCase
+    def setup
+      config['/service/spotify/client/id'] = 'test_client_id'
+      config['/service/spotify/client/secret'] = 'test_client_secret'
+      config['/service/spotify/oauth/user_oauth_enabled'] = true
+      # repeat の内部リトライ (config['/http/retry/limit']) が WebMock の逐次レスポンスを
+      # 食ってしまい 401→refresh の検証が非決定になるため、テストでは無効化する。
+      config['/http/retry/limit'] = 1
+    end
+
+    def test_config_true_when_enabled
+      assert_predicate(SpotifyUserService, :config?)
+    end
+
+    def test_config_false_when_user_oauth_disabled
+      config['/service/spotify/oauth/user_oauth_enabled'] = false
+      assert_false(SpotifyUserService.config?)
+    end
+
+    def test_config_false_without_client_id
+      config['/service/spotify/client/id'] = nil
+      assert_false(SpotifyUserService.config?)
+    end
+
+    def test_oauth_uri
+      uri = SpotifyUserService.new.oauth_uri
+      assert_equal('accounts.spotify.com', uri.host)
+      assert_equal('/authorize', uri.path)
+      query = uri.query_values
+      assert_equal('test_client_id', query['client_id'])
+      assert_equal('code', query['response_type'])
+      assert_equal('user-read-currently-playing', query['scope'])
+      assert_equal(config['/service/spotify/oauth/redirect_uri'], query['redirect_uri'])
+    end
+
+    def test_auth_exchanges_code_and_stores_tokens
+      stub = stub_token_endpoint(
+        access_token: 'access-1', refresh_token: 'refresh-1', expires_in: 3600
+      )
+      account = account_double
+
+      SpotifyUserService.new(account).auth('the-code')
+
+      assert_requested(stub.with do |req|
+        body = URI.decode_www_form(req.body).to_h
+        body['grant_type'] == 'authorization_code' && body['code'] == 'the-code'
+      end)
+      assert_equal('access-1', account.user_config['/service/spotify/token'])
+      assert_equal('refresh-1', account.user_config['/service/spotify/refresh_token'])
+      assert_operator(account.user_config['/service/spotify/expires_at'], :>, Time.now.to_i)
+    end
+
+    def test_currently_playing_returns_track_url
+      account = account_double(
+        '/service/spotify/token' => 'access-1',
+        '/service/spotify/refresh_token' => 'refresh-1',
+        '/service/spotify/expires_at' => Time.now.to_i + 3600,
+      )
+      stub_currently_playing(status: 200, body: {
+        is_playing: true,
+        item: {external_urls: {spotify: 'https://open.spotify.com/track/abc123'}},
+      })
+
+      assert_equal(
+        'https://open.spotify.com/track/abc123',
+        SpotifyUserService.new(account).currently_playing,
+      )
+    end
+
+    def test_currently_playing_returns_nil_when_nothing_playing
+      account = account_double(
+        '/service/spotify/token' => 'access-1',
+        '/service/spotify/refresh_token' => 'refresh-1',
+        '/service/spotify/expires_at' => Time.now.to_i + 3600,
+      )
+      stub_currently_playing(status: 204, body: '')
+
+      assert_nil(SpotifyUserService.new(account).currently_playing)
+    end
+
+    def test_currently_playing_refreshes_when_token_expired
+      account = account_double(
+        '/service/spotify/token' => 'stale',
+        '/service/spotify/refresh_token' => 'refresh-1',
+        '/service/spotify/expires_at' => Time.now.to_i - 1,
+      )
+      token_stub = stub_token_endpoint(access_token: 'access-2', expires_in: 3600)
+      stub_currently_playing(status: 200, body: {
+        item: {external_urls: {spotify: 'https://open.spotify.com/track/xyz'}},
+      })
+
+      url = SpotifyUserService.new(account).currently_playing
+
+      assert_equal('https://open.spotify.com/track/xyz', url)
+      assert_requested(token_stub)
+      assert_equal('access-2', account.user_config['/service/spotify/token'])
+      # Spotify が refresh_token を返さなかった場合は既存値を保持する。
+      assert_equal('refresh-1', account.user_config['/service/spotify/refresh_token'])
+    end
+
+    def test_currently_playing_refreshes_on_401_then_retries
+      account = account_double(
+        '/service/spotify/token' => 'access-1',
+        '/service/spotify/refresh_token' => 'refresh-1',
+        '/service/spotify/expires_at' => Time.now.to_i + 3600,
+      )
+      stub_token_endpoint(access_token: 'access-2', expires_in: 3600)
+      stub_request(:get, currently_playing_url).to_return(
+        {status: 401, body: '{}', headers: {'Content-Type' => 'application/json'}},
+        {status: 200, body: {item: {external_urls: {spotify: 'https://open.spotify.com/track/r'}}}.to_json,
+         headers: {'Content-Type' => 'application/json'}},
+      )
+
+      assert_equal(
+        'https://open.spotify.com/track/r',
+        SpotifyUserService.new(account).currently_playing,
+      )
+      assert_equal('access-2', account.user_config['/service/spotify/token'])
+    end
+
+    def test_currently_playing_raises_auth_error_when_refresh_token_revoked
+      account = account_double(
+        '/service/spotify/token' => 'access-1',
+        '/service/spotify/refresh_token' => 'revoked',
+        '/service/spotify/expires_at' => Time.now.to_i - 1,
+      )
+      stub_request(:post, token_url).to_return(
+        status: 400, body: {error: 'invalid_grant'}.to_json,
+        headers: {'Content-Type' => 'application/json'},
+      )
+
+      assert_raises(Ginseng::AuthError) do
+        SpotifyUserService.new(account).currently_playing
+      end
+    end
+
+    def test_unlink_clears_tokens
+      account = account_double(
+        '/service/spotify/token' => 'access-1',
+        '/service/spotify/refresh_token' => 'refresh-1',
+        '/service/spotify/expires_at' => Time.now.to_i + 3600,
+      )
+
+      SpotifyUserService.new(account).unlink
+
+      assert_nil(account.user_config['/service/spotify/token'])
+      assert_nil(account.user_config['/service/spotify/refresh_token'])
+      assert_nil(account.user_config['/service/spotify/expires_at'])
+    end
+
+    private
+
+    def token_url
+      return "#{config['/service/spotify/urls/accounts']}/api/token"
+    end
+
+    def currently_playing_url
+      return "#{config['/service/spotify/urls/api']}/v1/me/player/currently-playing"
+    end
+
+    def stub_token_endpoint(access_token:, expires_in:, refresh_token: nil)
+      body = {access_token:, token_type: 'Bearer', expires_in:}
+      body[:refresh_token] = refresh_token if refresh_token
+      return stub_request(:post, token_url).to_return(
+        status: 200, body: body.to_json, headers: {'Content-Type' => 'application/json'}
+      )
+    end
+
+    def stub_currently_playing(status:, body:)
+      payload = body.is_a?(String) ? body : body.to_json
+      return stub_request(:get, currently_playing_url).to_return(
+        status:, body: payload, headers: {'Content-Type' => 'application/json'}
+      )
+    end
+
+    # 実 Account/UserConfig (DB・Redis 依存) を避けるための最小ダブル。
+    # UserConfig は暗号化値をそのまま保持し read 時に復号しない仕様だが、本ダブルは
+    # 平文を保持する (service 側 decrypt は復号失敗時に値をそのまま返すため整合する)。
+    def account_double(store = {})
+      user_config = FakeUserConfig.new(store)
+      return Struct.new(:user_config).new(user_config)
+    end
+
+    class FakeUserConfig
+      def initialize(store = {})
+        @store = store.dup
+      end
+
+      def [](key)
+        return @store[key]
+      end
+
+      def update(values)
+        flatten(values.deep_stringify_keys).each do |key, value|
+          if value.nil?
+            @store.delete(key)
+          else
+            @store[key] = value
+          end
+        end
+      end
+
+      def to_h
+        return @store.dup
+      end
+
+      private
+
+      def flatten(hash, prefix = '')
+        result = {}
+        hash.each do |key, value|
+          path = "#{prefix}/#{key}"
+          if value.is_a?(Hash)
+            result.merge!(flatten(value, path))
+          else
+            result[path] = value
+          end
+        end
+        return result
+      end
+    end
+  end
+end

--- a/test/unit/service/spotify_user_service.rb
+++ b/test/unit/service/spotify_user_service.rb
@@ -83,6 +83,33 @@ module Mulukhiya
       assert_nil(SpotifyUserService.new(account).currently_playing)
     end
 
+    def test_currently_playing_returns_nil_when_paused
+      account = account_double(
+        '/service/spotify/token' => 'access-1',
+        '/service/spotify/refresh_token' => 'refresh-1',
+        '/service/spotify/expires_at' => Time.now.to_i + 3600,
+      )
+      # 一時停止中は item が直前トラックのまま 200 で返るが is_playing:false。
+      stub_currently_playing(status: 200, body: {
+        is_playing: false,
+        item: {external_urls: {spotify: 'https://open.spotify.com/track/paused'}},
+      })
+
+      assert_nil(SpotifyUserService.new(account).currently_playing)
+    end
+
+    def test_auth_sends_client_credentials_via_basic_header
+      stub = stub_token_endpoint(access_token: 'a', refresh_token: 'r', expires_in: 3600)
+      expected = Base64.strict_encode64('test_client_id:test_client_secret')
+
+      SpotifyUserService.new(account_double).auth('the-code')
+
+      assert_requested(stub.with do |req|
+        req.headers['Authorization'] == "Basic #{expected}" &&
+          !URI.decode_www_form(req.body).to_h.key?('client_secret')
+      end)
+    end
+
     def test_currently_playing_refreshes_when_token_expired
       account = account_double(
         '/service/spotify/token' => 'stale',
@@ -91,6 +118,7 @@ module Mulukhiya
       )
       token_stub = stub_token_endpoint(access_token: 'access-2', expires_in: 3600)
       stub_currently_playing(status: 200, body: {
+        is_playing: true,
         item: {external_urls: {spotify: 'https://open.spotify.com/track/xyz'}},
       })
 
@@ -112,7 +140,7 @@ module Mulukhiya
       stub_token_endpoint(access_token: 'access-2', expires_in: 3600)
       stub_request(:get, currently_playing_url).to_return(
         {status: 401, body: '{}', headers: {'Content-Type' => 'application/json'}},
-        {status: 200, body: {item: {external_urls: {spotify: 'https://open.spotify.com/track/r'}}}.to_json,
+        {status: 200, body: {is_playing: true, item: {external_urls: {spotify: 'https://open.spotify.com/track/r'}}}.to_json,
          headers: {'Content-Type' => 'application/json'}},
       )
 


### PR DESCRIPTION
## 概要

capsicum (pooza/capsicum#465) のナウプレ投稿向けに、Spotify Web API の `GET /me/player/currently-playing` を OS 非依存で呼ぶための **user-level OAuth + currently-playing API** を新設する (#4337)。app-level の `SpotifyService`（track 検索・`/nowplaying/resolve` 用）は残し、別系統で Authorization Code Flow を追加。

`client_secret` を capsicum に置かず、モロヘイヤがトークンを暗号化保管する点は Annict 連携と同方針。**code-post 方式**でユーザー特定は SNS トークンで行うため `state` は不要。

## 変更点

- **`SpotifyUserService`**（新規）: `oauth_uri` / `auth(code)` / `currently_playing` / `unlink` / `refresh!`。access_token 失効（3600s）は事前 refresh、保管値が古い等の 401 は事後 refresh + 1 回リトライで吸収。refresh_token 失効/revoke は `AuthError`（403=要再連携）、Spotify 障害は `GatewayError`（502）に切り分け。無再生・広告・204 は `{url: null}`。
- **エンドポイント**（`api_controller.rb`）: `GET /spotify/oauth_uri` / `POST /spotify/auth` / `GET /spotify/currently_playing` / `DELETE /spotify/auth`。`SpotifyUserService.config?` でガード。`currently_playing` の `AuthError` は capsicum の定期ポーリングを想定し alert せず log。
- **features**: `spotify_enabled`（サーバー有効）/ `spotify_linked`（ユーザー連携済み）を `DynamicFeatures` に追加。
- **トークン保管**: `user_config`（Redis・暗号化）。`encrypt_fields` に `refresh_token` を追加。
- **config**: `service.spotify.oauth.{redirect_uri, scopes, user_oauth_enabled}` と `urls.{accounts, api}`。Dashboard 登録が済むまで `user_oauth_enabled: false` 既定（= `spotify_enabled` false）。
- **docs**: `docs/api.md`（Spotify user OAuth 節 + features 表）/ `docs/capsicum-requirements.md`（§10）。

## テスト

`SpotifyUserService`（config?/oauth_uri/auth 保管/currently_playing/204/失効 refresh/401 retry/revoke→403/unlink）、`SpotifyAuthContract`、`DynamicFeatures`（新フラグ）。ローカルで全 20 ケース green。

## pooza 側の前提作業（本実装とは独立）

Spotify Developer Dashboard で Redirect URI と `user-read-currently-playing` スコープを登録 → config の `user_oauth_enabled` を `true`。詳細は本 PR コメント / Issue 参照。

## 関連

- Issue: #4337（5.27.0）
- capsicum 側: pooza/capsicum#465（本 API 着地後に着手）

🤖 Generated with [Claude Code](https://claude.com/claude-code)