### PR TITLE
feat(nowplaying): URL→メタ解決エンドポイント /nowplaying/resolve-url を新設 (#4415)

### DIFF
--- a/app/lib/mulukhiya/contract/nowplaying_resolve_url_contract.rb
+++ b/app/lib/mulukhiya/contract/nowplaying_resolve_url_contract.rb
@@ -1,0 +1,14 @@
+module Mulukhiya
+  class NowplayingResolveUrlContract < Contract
+    MAX_URL_SIZE = 2048
+    URL_FORMAT = %r{\Ahttps?://}
+
+    params do
+      required(:url).filled(:string, max_size?: MAX_URL_SIZE)
+    end
+
+    rule(:url) do
+      key.failure('URL は http(s):// で始まる URL を指定してください。') unless URL_FORMAT.match?(value.to_s)
+    end
+  end
+end

--- a/app/lib/mulukhiya/controller/api_controller.rb
+++ b/app/lib/mulukhiya/controller/api_controller.rb
@@ -456,6 +456,23 @@ module Mulukhiya
       return @renderer.to_s
     end
 
+    post '/nowplaying/resolve-url' do
+      raise Ginseng::AuthError, 'Unauthorized' unless sns.account
+      errors = NowplayingResolveUrlContract.new.exec(params)
+      if errors.present?
+        @renderer.status = 422
+        @renderer.message = {errors:}
+        return @renderer.to_s
+      end
+      @renderer.message = NowplayingUrlResolver.new(url: params[:url]).resolve
+      return @renderer.to_s
+    rescue => e
+      e.log
+      @renderer.status = e.status
+      @renderer.message = {error: e.message}
+      return @renderer.to_s
+    end
+
     get '/annict/oauth_uri' do
       raise Ginseng::NotFoundError, 'Not Found' unless controller_class.annict?
       @renderer.message = {oauth_uri: AnnictService.new.oauth_uri.to_s}

--- a/app/lib/mulukhiya/dynamic_features.rb
+++ b/app/lib/mulukhiya/dynamic_features.rb
@@ -13,6 +13,8 @@ module Mulukhiya
   #                        URL 設定の有無に一本化し二重管理を避ける
   #   - nowplaying_resolver : ナウプレ enrich (#4382)。メタデータ → 共有 URL 解決
   #                        エンドポイントの可否。capsicum が enrich を試みるか判定に使う
+  #   - nowplaying_url_resolver : ナウプレ enrich の逆方向 (#4415)。共有 URL → メタ解決
+  #                        エンドポイントの可否。capsicum の Share 経路 enrich 判定に使う
   #
   # 新しい動的フラグ (例: spotify_linked) を増やす際は REGISTRY に 1 行追加する。
   class DynamicFeatures
@@ -26,6 +28,7 @@ module Mulukhiya
       },
       'word_suggest' => ->(_sns) {PronunciationDictionary.new.enabled?},
       'nowplaying_resolver' => ->(_sns) {NowplayingResolver.enabled?},
+      'nowplaying_url_resolver' => ->(_sns) {NowplayingUrlResolver.enabled?},
     }.freeze
 
     def initialize(sns)

--- a/app/lib/mulukhiya/nowplaying_url_resolver.rb
+++ b/app/lib/mulukhiya/nowplaying_url_resolver.rb
@@ -1,0 +1,78 @@
+module Mulukhiya
+  # ナウプレ URL→メタ解決プロキシ (#4415 / capsicum#729)。共有 (Share) 経路は
+  # ShareExtension から URL しか受け取らず title/artist/album を持たないため、
+  # capsicum が in-app と同じ formatter で整形できるよう URL からメタを逆引きする。
+  #
+  # メタデータ → 共有 URL を解決する NowplayingResolver (#4382) と対になる、逆方向
+  # (URL → メタデータ) の読み取り専用 enrich。テキスト整形は行わず (整形は capsicum
+  # 側)、外部 API が返す正規化済みメタデータと URL のみを返す。
+  class NowplayingUrlResolver
+    include Package
+
+    # iTunes 経路は資格情報不要で常時利用可能なため resolver は常に有効。
+    # /about の features.nowplaying_url_resolver の正本 (capsicum の enrich 試行判定)。
+    def self.enabled?
+      return true
+    end
+
+    def initialize(url:)
+      @url = url.to_s.strip
+    end
+
+    # host でプロバイダを振り分け、URL からメタを抽出した
+    # {url:, provider:, normalized: {title, artist, album}} を返す (resolve と同形)。
+    # 解決不可 (未対応 host / track・album とも nil) は {url: nil} (404 ではなく 200 + null)。
+    def resolve
+      return {url: nil} if @url.empty?
+      uri = parse
+      return {url: nil} unless uri
+      title = uri.track_name
+      album = uri.album_name
+      return {url: nil} if title.nil? && album.nil?
+      return {
+        url: uri.to_s,
+        provider:,
+        normalized: {
+          title:,
+          artist: Array(uri.artists).join(', ').presence,
+          album:,
+        }.compact,
+      }
+    rescue => e
+      # url はユーザー入力なのでログに残さない (#4394 と同方針)。
+      e.log(provider: provider)
+      return {url: nil}
+    end
+
+    private
+
+    # host から振り分けた URI クラスでパースする。Spotify は資格情報必須なので
+    # 未設定なら nil (apple_music は資格情報不要)。未対応 host も nil。
+    def parse
+      case provider
+      when 'spotify'
+        return nil unless SpotifyService.config?
+        return SpotifyURI.parse(@url)
+      when 'apple_music'
+        return ItunesURI.create(@url)
+      end
+    end
+
+    def provider
+      @provider ||= detect_provider
+    end
+
+    def detect_provider
+      host = base_uri&.host.to_s.downcase
+      return 'spotify' if host.split('.').member?('spotify')
+      return 'apple_music' if config['/service/itunes/hosts'].member?(host)
+      return nil
+    end
+
+    def base_uri
+      @base_uri ||= Ginseng::URI.parse(@url)
+    rescue
+      return nil
+    end
+  end
+end

--- a/docs/api.md
+++ b/docs/api.md
@@ -806,6 +806,23 @@ NowPlaying 情報を除去して再投稿する。
   - `/nowplaying/resolve/default_provider`: 優先指定・ヒントが無いときの既定プロバイダ（`apple_music` / `spotify`、既定 `apple_music`）
 - **備考**: Spotify は `/service/spotify` の資格情報が設定済みのときのみ候補。iTunes Search API は資格情報不要のため常時利用可能。capsicum は `features.nowplaying_resolver`（下記）で enrich を試みるか判定する。
 
+#### POST /mulukhiya/api/nowplaying/resolve-url
+
+ナウプレ enrich プロキシの**逆方向**（#4415）。共有 URL を受け取り、URL からメタデータ（曲名・アーティスト名・アルバム名）を逆引きする。共有（Share）経路は ShareExtension から URL しか受け取らずメタを持たないため、capsicum が in-app と同じ formatter で整形できるようにする。`/nowplaying/resolve`（メタ → URL）と対になる読み取り専用エンドポイント。外部 API 濫用防止のため Bearer 必須。
+
+- **認証**: 必須（Bearer / SNS token）
+- **パラメータ**:
+
+| 名前 | 型 | 必須 | 説明 |
+|------|-----|------|------|
+| `url` | string | 必須 | 楽曲の共有 URL（`http(s)://` 始まり、最大 2048 文字） |
+
+- **プロバイダ振り分け（host）**: `*.spotify.com` → Spotify、`music.apple.com` / `itunes.apple.com` → iTunes、それ以外 → 解決なし。
+- **レスポンス**:
+  - 解決時: `{ "url": "https://music.apple.com/...", "provider": "apple_music", "normalized": { "title": "...", "artist": "...", "album": "..." } }`（`normalized` は外部 API が返した値のみ。欠落要素は省く）
+  - 解決なし（未対応 host / メタ取得不可）: `{ "url": null }`（404 ではなく 200）
+- **備考**: Spotify は `/service/spotify` の資格情報が設定済みのときのみ候補。iTunes は資格情報不要のため常時利用可能。capsicum は `features.nowplaying_url_resolver`（下記）で Share 経路 enrich を試みるか判定する。
+
 #### GET /mulukhiya/api/program
 
 番組情報を取得する。

--- a/test/contract/nowplaying_resolve_url_contract.rb
+++ b/test/contract/nowplaying_resolve_url_contract.rb
@@ -1,0 +1,37 @@
+module Mulukhiya
+  class NowplayingResolveUrlContractTest < TestCase
+    def setup
+      @contract = NowplayingResolveUrlContract.new
+    end
+
+    def test_accepts_valid_url
+      errors = @contract.call(url: 'https://music.apple.com/jp/album/1299587212?i=1299587213').errors
+
+      assert_empty(errors)
+    end
+
+    def test_rejects_missing_url
+      errors = @contract.call({}).errors
+
+      assert_false(errors.empty?)
+    end
+
+    def test_rejects_blank_url
+      errors = @contract.call(url: '').errors
+
+      assert_false(errors.empty?)
+    end
+
+    def test_rejects_non_http_url
+      errors = @contract.call(url: 'spotify:track:abc').errors
+
+      assert_false(errors.empty?)
+    end
+
+    def test_rejects_oversized_url
+      errors = @contract.call(url: "https://example.com/#{'a' * NowplayingResolveUrlContract::MAX_URL_SIZE}").errors
+
+      assert_false(errors.empty?)
+    end
+  end
+end

--- a/test/unit/lib/dynamic_features.rb
+++ b/test/unit/lib/dynamic_features.rb
@@ -3,7 +3,7 @@ module Mulukhiya
     def test_registry_keys
       assert_equal(
         ['annict_linked', 'media_catalog', 'program_editable', 'word_suggest',
-          'nowplaying_resolver'].to_set,
+          'nowplaying_resolver', 'nowplaying_url_resolver'].to_set,
         DynamicFeatures::REGISTRY.keys.to_set,
       )
     end

--- a/test/unit/lib/nowplaying_url_resolver.rb
+++ b/test/unit/lib/nowplaying_url_resolver.rb
@@ -1,0 +1,38 @@
+module Mulukhiya
+  class NowplayingUrlResolverTest < TestCase
+    def test_enabled
+      assert_true(NowplayingUrlResolver.enabled?)
+    end
+
+    # iTunes 経路は資格情報不要で実 API を叩ける (既存 itunes_url_nowplaying_handler
+    # テストと同様)。URL → メタの逆引きを確認する。
+    def test_resolve_apple_music
+      url = 'https://music.apple.com/jp/album/1299587212?i=1299587213&uo=4'
+      result = NowplayingUrlResolver.new(url: url).resolve
+
+      assert_equal('apple_music', result[:provider])
+      assert_equal('シュビドゥビ☆スイーツタイム', result[:normalized][:title])
+      assert_equal('宮本佳那子', result[:normalized][:artist])
+      assert_includes(result[:url], 'music.apple.com')
+    end
+
+    def test_resolve_returns_nil_url_for_blank
+      assert_nil(NowplayingUrlResolver.new(url: '   ').resolve[:url])
+    end
+
+    def test_resolve_returns_nil_url_for_unsupported_host
+      result = NowplayingUrlResolver.new(url: 'https://www.youtube.com/watch?v=abc').resolve
+
+      assert_nil(result[:url])
+    end
+
+    # Spotify 経路は SpotifyService.config? が前提。未設定 (CI 既定) では解決せず
+    # {url: nil} を返す (404 にはしない)。
+    def test_resolve_spotify_returns_nil_url_without_config
+      omit('Spotify configured in this environment') if SpotifyService.config?
+      result = NowplayingUrlResolver.new(url: 'https://open.spotify.com/track/2oBorZqiVTpXAD8h7DCYWZ').resolve
+
+      assert_nil(result[:url])
+    end
+  end
+end


### PR DESCRIPTION
## 概要

共有 (Share) 経路のナウプレを capsicum が in-app と同じ formatter で整形できるよう、**URL → メタ (title/artist/album) の逆引き**エンドポイントを新設する (#4415 / pooza/capsicum#729)。既存 `POST /nowplaying/resolve`（メタ → URL、#4382）と対になる読み取り専用 enrich。

## 変更

- **`NowplayingUrlResolver`**: host で振り分け（`*.spotify.com` → Spotify / `music.apple.com`・`itunes.apple.com` → iTunes / それ以外 → 解決なし）。`SpotifyURI` / `ItunesURI` の既存パースを再利用。解決不可（未対応 host・メタ取得不可）は `{ url: nil }`（404 ではなく 200）。
- **`NowplayingResolveUrlContract`**: `url` 必須・`http(s)://` 始まり・最大 2048 文字。
- **`POST /nowplaying/resolve-url`**: 既存 resolve ルートを雛形に追加（auth → contract(422) → resolver → rescue）。
- **`/about` features**: `nowplaying_url_resolver` フラグを登録（capsicum の Share 経路 enrich 試行判定）。
- **docs/api.md**: エンドポイント仕様を追記。

## テスト

- iTunes 経路は資格情報不要のため実 API で URL→メタを検証（既存 iTunes テストと同方針）。
- Spotify 経路は `SpotifyService.config?` 未設定時に `{ url: nil }` を返すことを確認。
- contract（必須・http(s)・max_size）と dynamic_features レジストリキーのテストを追加。
- 全テスト green / rubocop offense なし。

Closes #4415

🤖 Generated with [Claude Code](https://claude.com/claude-code)