### PR TITLE
fix(log): OAuth 認可コード(code)を info ログから scrub する (#4418)

### DIFF
--- a/app/lib/mulukhiya/controller.rb
+++ b/app/lib/mulukhiya/controller.rb
@@ -11,7 +11,8 @@ module Mulukhiya
     # @params を使うため、ログ用の複製だけ top-level の該当キーをマスクする。
     SCRUBBED_LOG_PARAMS = [
       'status', 'text', 'body', 'comment', 'spoiler_text', 'cw',
-      'q', 'title', 'artist', 'album' # word/suggest・nowplaying のユーザー入力 (#4394)
+      'q', 'title', 'artist', 'album', # word/suggest・nowplaying のユーザー入力 (#4394)
+      'code' # OAuth 認可コード (spotify/auth・annict/auth)。短命だが資格情報なので伏せる
     ].freeze
 
     set :root, Environment.dir


### PR DESCRIPTION
## 概要

5.27.0 リリース前 5観点レビュー（セキュリティ観点）由来の赤近い黄インライン対応。

`Controller` の before フィルタが全リクエストの params を info ログに出すが、`SCRUBBED_LOG_PARAMS` に `code` が無く、`POST /spotify/auth`（#4337）・既存 `POST /annict/auth` の OAuth 認可コードが平文で記録されていた。`code` を scrub 対象に追加（Spotify・Annict 共通改善）。

## 変更

- `app/lib/mulukhiya/controller.rb`: `SCRUBBED_LOG_PARAMS` に `'code'` を追加

## 確認

- rubocop: no offenses
- `code` は string キー（IndifferentHash 配下）で `key?('code')` によりマスクされる

Closes #4418

🤖 Generated with [Claude Code](https://claude.com/claude-code)