### PR TITLE
chore: bundle update ginseng-fediverse 1.8.25 (numeric_ap_id 対応取り込み)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,10 +42,10 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-fediverse.git
-  revision: bfb0dc260c8a74ff4e7bdde559a9167ce3b8d3a9
+  revision: 60a38dae2e80096734e408ced2d322b994e4c624
   branch: main
   specs:
-    ginseng-fediverse (1.8.24)
+    ginseng-fediverse (1.8.25)
 
 GIT
   remote: https://github.com/pooza/ginseng-piefed.git


### PR DESCRIPTION
## 概要

`ginseng-fediverse` を **1.8.24 → 1.8.25** に更新し、pooza/ginseng-fediverse#241 (PR #242) を取り込む。

現代 Mastodon は新規ローカルアカウントの AP URI を `/ap/users/<id>/statuses/<id>`（numeric_ap_id）形式で生成する。従来 `TootURI` がこの形式を解釈できず、**ローカル status の `url` カラムが null の場合に `status.uri` が nil**になっていた（本番影響）。1.8.25 で toot patterns に該当パターンが追加され解消する。

## 変更
- `Gemfile.lock`: `ginseng-fediverse` を 1.8.25 (main@60a38da) に更新（lock のみ）

## 検証
バンドル後の gem で:
```
TootURI.parse("https://localhost:3000/ap/users/116701601341929545/statuses/116701682233818969")
  => toot_id=116701682233818969, valid?=true
```
（更新前は `toot_id=nil` / `valid?=false`）

この問題は chubo2 fedi-test-harness の実機テスト (#4379) で `StatusTest#test_uri` の失敗として検出されたもの。

## 関連
- pooza/ginseng-fediverse#241 / PR #242
- pooza/chubo2#48 (発見元の harness)
- 5.28.0 同梱想定

🤖 Generated with [Claude Code](https://claude.com/claude-code)