### PR TITLE
docs: fedi-test-harness 互換性検証済みバージョン台帳を追加

### DIFF
--- a/docs/harness-verified-versions.yaml
+++ b/docs/harness-verified-versions.yaml
@@ -1,0 +1,32 @@
+# fedi-test-harness 互換性検証済み upstream バージョン台帳
+#
+# モロヘイヤ (mulukhiya-toot-proxy) が chubo2 の fedi-test-harness を使って
+# 「バニラ Mastodon / Misskey との互換性を実機検証した最新バージョン」を記録する。
+#
+# 用途:
+#   - upstream リリース監視ルーチン (cloud routine "fedi upstream release watch")
+#     がこのファイルを基準値として読み、GitHub 公開リリースと比較して新しい
+#     stable / RC があれば検証を促す Issue を起票する。
+#   - chubo2 側 fedi-test-harness/{mastodon,misskey}/.env.example の
+#     MASTODON_VERSION / MISSKEY_VERSION と対になる値。互換性検証を終えて
+#     harness の既定を bump したら、このファイルも同じ版に更新する。
+#
+# 更新手順 (検証フロー):
+#   1. cd ~/repos/chubo2/fedi-test-harness/<mastodon|misskey>
+#   2. ./scripts/update-version.sh   # upstream 最新 stable に追従
+#   3. ./scripts/reset.sh            # 新イメージ + クリーン DB で再構築
+#   4. mulukhiya 側で account / status / controller 等の harness テストを実走
+#      (要 mulukhiya 自前 Redis localhost:6379)
+#   5. 緑なら chubo2 .env.example と本ファイルの両方を新バージョンに更新
+#
+# 運用方針の詳細は MEMORY の feedback_upstream-release-harness-verification 参照。
+
+mastodon:
+  # GitHub: mastodon/mastodon (stable は vX.Y.Z, RC は vX.Y.Z-rc.N)
+  verified: v4.6.0
+  verified_at: '2026-06-21'
+
+misskey:
+  # GitHub: misskey-dev/misskey (stable は YYYY.M.P, alpha/beta は prerelease)
+  verified: 2026.5.4
+  verified_at: '2026-06-21'


### PR DESCRIPTION
## 概要

upstream リリース監視 cloud routine を **mulukhiya 完結**（chubo2 アクセス不要）で動かすための基準値台帳 `docs/harness-verified-versions.yaml` を追加する。

cloud 実行環境の `gh` トークンがソース repo スコープしか持たず、chubo2 を読めなかったため、検証済みバージョンを mulukhiya 側で管理する方式に変更。ルーチンは本ファイルを読み、GitHub 公開リリース（`mastodon/mastodon` / `misskey-dev/misskey`、curl で取得）と比較して新しい stable/RC があれば mulukhiya に Issue を起票する。

## 内容
- `docs/harness-verified-versions.yaml`: Mastodon `v4.6.0` / Misskey `2026.5.4`（いずれも 2026-06-21 に実機検証済み）
- chubo2 の `fedi-test-harness/{mastodon,misskey}/.env.example` と対。検証して harness を bump する際に本ファイルも同じ版へ更新する運用

## 関連
- pooza/chubo2#48（harness） / 運用方針メモリ feedback_upstream-release-harness-verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)