### PR TITLE
docs: fedi-test-harness verified を Misskey 2026.6.0 へ bump

### DIFF
--- a/docs/harness-verified-versions.yaml
+++ b/docs/harness-verified-versions.yaml
@@ -33,8 +33,8 @@ mastodon:
   verified_at: '2026-06-21'
 
 misskey:
-  verified: 2026.5.4
-  verified_at: '2026-06-21'
+  verified: 2026.6.0
+  verified_at: '2026-06-23'
 
 # upstream 最新リリースを最後に確認した日（同期手順が更新する）。
-last_checked: '2026-06-21'
+last_checked: '2026-06-23'


### PR DESCRIPTION
## 概要

Misskey **2026.6.0** (stable, 2026-06-22) を chubo2 fedi-test-harness で実機検証し、互換性を確認したため台帳 `docs/harness-verified-versions.yaml` の `misskey.verified` を `2026.5.4` → `2026.6.0` へ bump する。`verified_at` / `last_checked` も本日 (2026-06-23) へ更新。

## 検証方法・結果

- ハーネスを 2026.6.0 で再構築 (`update-version.sh` + `reset.sh`)。setup 全工程成功（管理者/info アカウント作成・トークン発行・signup・`/api/i` 疎通・公開ノート投入・`users/notes` 読み出し）
- 直接 `POST /api/notes/create` → `{"createdNote":{…}}` 正常（投稿主経路）
- フルスイート (`rake test`, harness sourced): **834 tests / 95.2% pass**。失敗 40 件はすべて切り分け済み:
  - ローカル環境ノイズ（テストメディア/sidekiq/実ネット不在、redis-double 等） — バージョン非依存
  - harness データ起因（`maintainerName` が null 等、バニラ新規インスタンスに設定が無いため）— API 形状の変化ではない（直接 `/api/meta` で実確認）
  - いずれも Misskey 2026.6.0 の回帰ではない
- CHANGELOG 上も破壊的 API/スキーマ変更なし（キュー一時停止・アンテナ個別削除・ノート検索の期間条件等の追加と性能改善・バグ修正主体）

## 関連

- chubo2 `fedi-test-harness/misskey/.env.example` の `MISSKEY_VERSION` も同版へ追従（別コミット）
- 同期手順 §8 / `feedback_upstream-release-harness-verification`

🤖 Generated with [Claude Code](https://claude.com/claude-code)