### PR TITLE
feat: 読み付き単語辞書の一括取得 API GET /word/all (#4430)

### DIFF
--- a/app/lib/mulukhiya/controller/api_controller.rb
+++ b/app/lib/mulukhiya/controller/api_controller.rb
@@ -773,6 +773,28 @@ module Mulukhiya
       return @renderer.to_s
     end
 
+    # 辞書全件取得 (capsicum 投稿サジェストの一括取得 + ローカル絞り込み #687 /
+    # mulukhiya#4430)。word/suggest と同じ feature gate・公開・読み取り専用。
+    # ETag (= digest) を付与し、If-None-Match 一致時は 304 で本文を返さない
+    # (capsicum の一括取得キャッシュの再検証用)。
+    get '/word/all' do
+      dictionary = PronunciationDictionary.new
+      raise Ginseng::NotFoundError, 'Not Found' unless dictionary.enabled?
+      digest = dictionary.digest
+      headers 'ETag' => %("#{digest}")
+      if request.env['HTTP_IF_NONE_MATCH'].to_s.delete('"') == digest
+        @renderer.status = 304
+        return ''
+      end
+      @renderer.message = {words: dictionary.all, size: dictionary.size, digest:}
+      return @renderer.to_s
+    rescue => e
+      e.log
+      @renderer.status = e.status
+      @renderer.message = {error: e.message}
+      return @renderer.to_s
+    end
+
     get '/piefed/communities' do
       raise Ginseng::NotFoundError, 'Not Found' unless controller_class.piefed?
       raise Ginseng::AuthError, 'Unauthorized' unless sns.account

--- a/app/lib/mulukhiya/pronunciation_dictionary.rb
+++ b/app/lib/mulukhiya/pronunciation_dictionary.rb
@@ -57,6 +57,21 @@ module Mulukhiya
       return ranked.first(limit).map {|_, _, entry| present(entry)}
     end
 
+    # 全候補を suggest と同じ present 形式で返す。capsicum 投稿サジェストの
+    # 一括取得 + ローカル絞り込み (capsicum#687) 向け。読み取り専用で、suggest と
+    # 同じ entries キャッシュ (Redis) をそのまま全件投影するだけ。cold-cache 時は
+    # suggest と同様に空配列 + 非同期ワーカー充填へ倒れる (リクエストをブロックしない)。
+    def all
+      return entries.map {|entry| present(entry)}
+    end
+
+    # 辞書内容のダイジェスト。capsicum が一括取得キャッシュの更新検知
+    # (ETag / If-None-Match による再検証) に用いる。entries が変わらない限り安定し、
+    # 辞書 (スプレッドシート) の増減で値が変わる。cold-cache (空) でも安定値を返す。
+    def digest
+      return Digest::SHA256.hexdigest(entries.to_json)
+    end
+
     def update
       entries = fetch_remote
       return nil unless entries

--- a/docs/api.md
+++ b/docs/api.md
@@ -673,6 +673,33 @@ Web Push サブスクリプションを解除する。
 - `reading`: 並べ替え・ハイライト用（カタカナ）
 - `category`: 品詞細分類（人名 / 技名 / 作品名 / 一般 等）。スプレッドシートに列がある場合のみ付く**任意**フィールド。capsicum 側のカテゴリ別ブラウズ用。空欄・未整備のサーバーでは省略される
 
+#### GET /mulukhiya/api/word/all
+
+読み付き単語辞書の**全件取得**（capsicum#687 / #4430）。`word/suggest` が読みごとの都度クエリなのに対し、本 API は辞書を丸ごと返す。capsicum が一度取得してローカルで絞り込むことで、実況の打鍵テンポを損なわず往復ゼロにするための最適化用。`word/suggest` と同じ辞書（`PronunciationDictionary` の Redis キャッシュ）をそのまま投影するだけで、新規データ源・DB 書き込みはない（読み取り専用）。
+
+- **認証**: 不要
+- **前提条件**: `features.word_suggest` が `true`（= `word_suggest/urls` が設定済み）。未設定サーバーは 404
+- **パラメータ**: なし
+- **キャッシュ再検証**: レスポンスに `ETag`（辞書ダイジェスト）を付与する。`If-None-Match` に同じ値を送ると本文を返さず `304 Not Modified` を返す。body 内の `digest` も同値で、ヘッダを使えないクライアントはこちらで更新検知できる
+- **cold-cache**: Redis 未充填時（flush / 再起動直後）は `word/suggest` と同じく空の `words` を即返し、`PronunciationDictionaryUpdateWorker` の充填を待つ（同期 fetch でリクエストをブロックしない）
+
+**レスポンス例**:
+
+```json
+{
+  "words": [
+    { "surface": "愛崎えみる", "reading": "アイサキエミル", "category": "人名" },
+    { "surface": "閃華裂光拳", "reading": "センカレッコウケン", "category": "技名" }
+  ],
+  "size": 2,
+  "digest": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+}
+```
+
+- `words`: 候補の配列。各要素は `word/suggest` の `candidates` と同一の形（`surface` / `reading` / 任意 `category`）
+- `size`: `words` の件数
+- `digest`: 辞書内容の SHA256。`ETag` と同値。辞書（スプレッドシート）の増減で変わる
+
 #### GET /mulukhiya/api/announcement/list
 
 サーバーのお知らせ一覧を取得する（Redis キャッシュ参照、SNS への問い合わせは発生しない）。capsicum-relay (capsicum-relay#14) のお知らせ push 配信パイプラインから利用する想定で公開している（#4355）。

--- a/test/unit/lib/pronunciation_dictionary.rb
+++ b/test/unit/lib/pronunciation_dictionary.rb
@@ -56,6 +56,38 @@ module Mulukhiya
       assert_empty(@dic.suggest(''))
     end
 
+    def test_all_returns_every_entry_in_present_format
+      surfaces = @dic.all.map {|r| r[:surface]}
+
+      assert_equal(ENTRIES.size, @dic.all.size)
+      assert_includes(surfaces, '愛崎えみる')
+      assert_includes(surfaces, '閃華裂光拳')
+      assert_includes(surfaces, 'アイス')
+      first = @dic.all.find {|r| r[:surface] == '愛崎えみる'}
+
+      assert_equal('アイサキエミル', first[:reading])
+      assert_equal('人名', first[:category])
+    end
+
+    def test_all_omits_category_when_absent
+      entry = @dic.all.find {|r| r[:surface] == 'アイス'}
+
+      assert_not_nil(entry)
+      assert_false(entry.key?(:category))
+    end
+
+    def test_digest_is_stable_for_same_entries
+      assert_equal(@dic.digest, PronunciationDictionary.new.digest)
+    end
+
+    def test_digest_changes_when_entries_change
+      before = @dic.digest
+      @dic.redis[PronunciationDictionary::REDIS_KEY] =
+        (ENTRIES + [{'surface' => '相生', 'reading' => 'アイオイ'}]).to_json
+
+      assert_not_equal(before, PronunciationDictionary.new.digest)
+    end
+
     def test_suggest_respects_limit
       assert_operator(@dic.suggest('あい', limit: 1).size, :<=, 1)
     end


### PR DESCRIPTION
## 概要

capsicum 投稿サジェスト（pooza/capsicum#687）の「辞書を一括取得してローカル絞り込み」最適化のための全件取得エンドポイント。closes #4430

`word/suggest` が読みごとの都度クエリなのに対し、本 API は辞書を丸ごと返す。capsicum が一度取得してローカルで絞り込むことで往復ゼロにし、実況の打鍵テンポを損なわないようにする。

## 変更

- `PronunciationDictionary#all` — 全件を `present` 形式（`surface` / `reading` / 任意 `category`）で返す
- `PronunciationDictionary#digest` — `entries` の SHA256。更新検知用
- `GET /mulukhiya/api/word/all` — `word/suggest` と同じ feature gate（`features.word_suggest`、未設定は 404）・公開・読み取り専用
  - `ETag`（= digest）+ `If-None-Match` で `304 Not Modified`。body にも `digest` を載せヘッダ非対応クライアントもフォールバック可
  - cold-cache（Redis 未充填）は `word/suggest` と同じく空 + `PronunciationDictionaryUpdateWorker` 充填へ倒す（同期 fetch でブロックしない）
- `docs/api.md` 追記 + `PronunciationDictionary` 単体テスト（all の present 形式 / category 省略 / digest 安定性・変化）

新規データ源・DB 書き込みなし。既存の Redis キャッシュをそのまま投影するだけ。

## レスポンス例

```json
{
  "words": [
    { "surface": "愛崎えみる", "reading": "アイサキエミル", "category": "人名" }
  ],
  "size": 1,
  "digest": "<sha256>"
}
```

## 検証

- ローカル（開発 Mac）は bundle/Redis 未整備のため構文チェックのみ（3 ファイル Syntax OK）。テストは CI（redis:7 + `rake test`）と dev ステージング実機 curl で検証する。
- 本番デプロイ後に capsicum#687（capsicum 側・on-hold）を着手する。

## 関連

- pooza/capsicum#687（capsicum 側・本 API 待ちで on-hold）
- #4397 / capsicum#614（word/suggest 本体）