### PR TITLE
feat: /about features に annict_review capability を露出 (#4433)

### DIFF
--- a/app/lib/mulukhiya/dynamic_features.rb
+++ b/app/lib/mulukhiya/dynamic_features.rb
@@ -4,6 +4,10 @@ module Mulukhiya
   # サーバーレベルの静的 features (`/{controller}/features/*` の sub_hash) に対し、
   # 以下の実行時状態を合流させる:
   #   - annict_linked    : リクエストの SNS アカウント単位の Annict 連携状態 (#4338)
+  #   - annict_review    : Annict 感想投稿エンドポイント `POST /annict/review` (#4342)
+  #                        が稼働可能か (= サーバーが annict? を満たすか)。#4342 未デプロイの
+  #                        バージョンではキー自体が無く capsicum は false 判定できる (#4433)。
+  #                        capsicum の review 投稿ボタン出し分けに使う (pooza/capsicum#677)
   #   - media_catalog    : /{controller}/data 配下の機能フラグ。discovery を features
   #                        に一本化するため合流 (#4343)
   #   - program_editable : 番組表エディタ (livecure かつ auto_update 無効) で書き込み
@@ -26,6 +30,7 @@ module Mulukhiya
 
     REGISTRY = {
       'annict_linked' => ->(sns) {sns.account&.annict_linked? || false},
+      'annict_review' => ->(_sns) {Environment.controller_class.annict?},
       'media_catalog' => ->(_sns) {Environment.controller_class.media_catalog?},
       'program_editable' => lambda {|_sns|
         Environment.controller_class.livecure? && !Program.instance.auto_update?

--- a/docs/api.md
+++ b/docs/api.md
@@ -92,6 +92,7 @@ SNS 本体への転送が失敗した場合、SNS が返したステータスコ
 | `/{controller}/features/feed` | `/feed/list` |
 | `/{controller}/features/announcement` | `/announcement/update` |
 | `/{controller}/features/annict` | `/annict/oauth_uri`, `/annict/auth`, `/tagging/dic/annict/episodes`, `/program/works`, `/program/works/:id/episodes` |
+| `features.annict_review`（サーバーが `annict?` を満たすとき `true`。#4342 未デプロイのバージョンではキー自体が欠落し capsicum は false 判定できる） | `/annict/review`, `/annict/record` |
 | `features.word_suggest`（`/word_suggest/urls` 設定時に有効） | `/word/suggest` |
 | `features.nowplaying_resolver`（常時 `true`） | `/nowplaying/resolve` |
 | `features.spotify_enabled`（`/service/spotify/oauth/user_oauth_enabled` + 資格情報設定時に有効） | `/spotify/oauth_uri`, `/spotify/auth`, `/spotify/currently_playing` |
@@ -272,6 +273,7 @@ URL 正規化、短縮 URL 展開、NowPlaying URL 展開（iTunes/Spotify/YouTu
     "features": {
       "annict": true,
       "annict_linked": true,
+      "annict_review": true,
       "announcement": true,
       "announcement_push": false,
       "feed": true,

--- a/test/unit/lib/dynamic_features.rb
+++ b/test/unit/lib/dynamic_features.rb
@@ -2,8 +2,8 @@ module Mulukhiya
   class DynamicFeaturesTest < TestCase
     def test_registry_keys
       assert_equal(
-        ['annict_linked', 'media_catalog', 'program_editable', 'word_suggest',
-          'nowplaying_resolver', 'nowplaying_url_resolver',
+        ['annict_linked', 'annict_review', 'media_catalog', 'program_editable',
+          'word_suggest', 'nowplaying_resolver', 'nowplaying_url_resolver',
           'spotify_enabled', 'spotify_linked'].to_set,
         DynamicFeatures::REGISTRY.keys.to_set,
       )
@@ -22,6 +22,14 @@ module Mulukhiya
 
     def test_annict_linked_reflects_linked_account
       assert_true(DynamicFeatures.new(sns_double(linked_account)).to_h['annict_linked'])
+    end
+
+    # annict_review は SNS アカウント非依存で、サーバーの annict? 稼働可否を映す (#4433)。
+    def test_annict_review_reflects_controller_annict
+      assert_equal(
+        Environment.controller_class.annict?,
+        DynamicFeatures.new(sns_double(nil)).to_h['annict_review'],
+      )
     end
 
     def test_spotify_linked_is_false_without_account


### PR DESCRIPTION
## 概要

capsicum の Annict review 投稿ボタン（pooza/capsicum#677）を feature-gate できるよう、`POST /annict/review`（#4342）の稼働可否を `/about` の `features.annict_review` として露出する。closes #4433

現状 capsicum は `features.annict` だけで表示判定しているが、#4342 は新エンドポイントのため **#4342 未デプロイ台では 404** になり、原因がユーザーに伝わらない。capsicum はバージョン分岐せず feature probing で出し分ける方針のため、capability フラグを露出する。

## 変更

- `DynamicFeatures::REGISTRY` に `annict_review` を追加。resolver は `Environment.controller_class.annict?`
- `test/unit/lib/dynamic_features.rb`: `test_registry_keys` のキー集合更新 + `annict_review` が `annict?` を映すことの検証テスト
- `docs/api.md`: features 表に `annict_review` 行、`/about` レスポンス例に `annict_review` を追記

## resolver 意味論の判断（案b を採用）

issue は (a) presence-based `true` / (b) `annict?` 連動 を保守判断に委ねていた。**(b) を採用**:

- `POST /annict/review` は `controller_class.annict?` で 404 ガードされており、**実際に動くのは `annict?` が真のときだけ**。(b) は endpoint の実稼働可否を正直に反映する
- 既存 REGISTRY エントリは全て実行時状態由来で、(a) の bare `true` は idiom の異物
- 旧版（#4342 無し）ではキー自体が欠落 → capsicum は false 判定 → 404 回避、という目的も (b) で満たす
- capsicum 側は `annict && annict_review` の compound 判定で (a)(b) いずれでも実装は不変

## 検証

- `dynamic_features` 単体テスト 9 tests / 0 failures、rubocop 無指摘（ローカル Ruby 4.0.5 + Redis）

## 関連
- #4342（Annict review 投稿 API）
- pooza/capsicum#677（capsicum 側の feature-gate）
- #4348（DynamicFeatures::REGISTRY 集約）

🤖 Generated with [Claude Code](https://claude.com/claude-code)