### PR TITLE
feat: /about に founded_at（正式オープン日）を追加 (#4434)

### DIFF
--- a/app/lib/mulukhiya/config.rb
+++ b/app/lib/mulukhiya/config.rb
@@ -39,6 +39,7 @@ module Mulukhiya
           admin_role_ids: admin_role_ids,
           info_bot: info_bot_profile,
           status_url: (self['/status_url'] rescue nil),
+          founded_at: founded_at,
         },
       }
     end
@@ -53,6 +54,19 @@ module Mulukhiya
     end
 
     private
+
+    # サーバーの正式オープン日を ISO 8601 date (YYYY-MM-DD) で返す (#4434)。
+    # `/founded_on` が設定されていればそれを、無ければ最古ローカルアカウントの
+    # 作成日で近似する (capsicum はヒューリスティックを持たず /about を単純採用する)。
+    # 取得不能・未設定・DB 未接続なら nil。
+    def founded_at
+      configured = self['/founded_on'] rescue nil
+      return Date.parse(configured.to_s).iso8601 if configured.present?
+      date = Environment.account_class&.founded_at
+      return date&.to_date&.iso8601
+    rescue
+      return nil
+    end
 
     def detect_unknown_keys(data, sch, prefix = '')
       if data.is_a?(Array)

--- a/app/lib/mulukhiya/model/mastodon/account.rb
+++ b/app/lib/mulukhiya/model/mastodon/account.rb
@@ -9,6 +9,18 @@ module Mulukhiya
       one_to_many :attachment, key: :account_id
       attr_accessor :token
 
+      # 最古のローカルアカウント作成日を「設立日」の近似として返す (#4434)。
+      # ローカル (domain IS NULL) を作成日昇順で 1 件。値は不変のためプロセス内で
+      # メモ化する。DB 未接続・不在時は nil。
+      def self.founded_at
+        return @founded_at if defined?(@founded_at) && @founded_at
+        account = where(domain: nil).order(:created_at).first
+        return @founded_at = account&.created_at
+      rescue => e
+        e.log
+        return nil
+      end
+
       def to_h
         return super.except(:private_key, :public_key)
       end

--- a/app/lib/mulukhiya/model/misskey/account.rb
+++ b/app/lib/mulukhiya/model/misskey/account.rb
@@ -9,6 +9,18 @@ module Mulukhiya
       one_to_many :attachment, key: :userId
       many_to_many :roles, left_key: :userId, right_key: :roleId, join_table: :role_assignment
 
+      # Misskey は作成時刻を持たず id (aid) に埋め込むため、最古 id = 最古アカウント。
+      # 「設立日」の近似として最古ローカルアカウントの作成日を返す (#4434)。値は不変の
+      # ためメモ化する。DB 未接続・不在時は nil。
+      def self.founded_at
+        return @founded_at if defined?(@founded_at) && @founded_at
+        account = where(host: nil).order(:id).first
+        return @founded_at = account && MisskeyService.parse_aid(account.id)
+      rescue => e
+        e.log
+        return nil
+      end
+
       def to_h
         return super.except(:token)
       end

--- a/config/schema/base.yaml
+++ b/config/schema/base.yaml
@@ -384,6 +384,8 @@ properties:
   status_url:
     format: uri
     type: string
+  founded_on:
+    type: string
   spotify:
     properties:
       client:

--- a/docs/api.md
+++ b/docs/api.md
@@ -287,7 +287,8 @@ URL 正規化、短縮 URL 展開、NowPlaying URL 展開（iTunes/Spotify/YouTu
       "url": "https://precure.ml/@info",
       "display_name": "モロヘイヤからのお知らせ"
     },
-    "status_url": "https://uptime.b-shock.org/status/bshockdon"
+    "status_url": "https://uptime.b-shock.org/status/bshockdon",
+    "founded_at": "2018-04-01"
   }
 }
 ```
@@ -297,6 +298,8 @@ URL 正規化、短縮 URL 展開、NowPlaying URL 展開（iTunes/Spotify/YouTu
 **`info_bot`**: お知らせボットのプロフィール情報。`username`、`acct`（@user@domain 形式）、`url`（プロフィールページURL）、`display_name` を含む。お知らせボットのトークンが未設定の環境では `null` を返す。capsicum のお知らせ画面でボットのプロフィールリンク表示に利用する（`pooza/capsicum#189`）。
 
 **`status_url`**: ステータスページの URL。`config/local.yaml` の `/status_url` で設定する。未設定時は `null`。Mastodon は `/api/v2/instance` から取得可能だが、Misskey には該当 API がないため、モロヘイヤ経由で統一的に提供する（`pooza/capsicum#247`）。
+
+**`founded_at`**: サーバーの正式オープン日（ISO 8601 date, `YYYY-MM-DD`）。`config/local.yaml` の `/founded_on` で設定する。**未設定時は最古ローカルアカウントの作成日で近似**（Mastodon は `accounts` の最古ローカル行、Misskey は最古 `user` の aid から復号）。DB 未接続時は `null`。「サーバーが物理起動した日」と「正式オープン日」が異なるサーバー（きゅあすきー / ダイスキー / デルムリン丼）は `/founded_on` を明示設定する。capsicum はヒューリスティックを持たず本値を単純採用する（`pooza/capsicum#818`）。
 
 **`features.annict` / `features.annict_linked`**: `features.annict` は **サーバーレベル**の設定（当該モロヘイヤサーバーで Annict の client_id/secret が設定済みか）。`features.annict_linked` は **ユーザーレベル**の状態で、リクエストの Bearer トークンに紐付く SNS アカウントに Annict access_token が保管済みなら `true`（未連携・トークン無しは `false`、無認証リクエストでも `false`）。token 存在のみで判定し liveness/refresh の確認は行わない。capsicum は両者を組み合わせ、「サーバーは Annict 対応かつ当該ユーザーが連携済み」のときのみ感想投稿ボタンを表示する（`pooza/capsicum#298`）。
 

--- a/test/unit/lib/config.rb
+++ b/test/unit/lib/config.rb
@@ -1,0 +1,43 @@
+module Mulukhiya
+  class ConfigTest < TestCase
+    # /founded_on 設定時は ISO 8601 date に正規化して返す (#4434)。
+    def test_founded_at_from_config
+      config['/founded_on'] = '2021-04-01'
+
+      assert_equal('2021-04-01', config.send(:founded_at))
+    end
+
+    def test_founded_at_normalizes_non_iso_input
+      config['/founded_on'] = '2021/04/01'
+
+      assert_equal('2021-04-01', config.send(:founded_at))
+    end
+
+    # 未設定かつ最古アカウント取得不能（DB 未接続）なら nil に倒す。
+    def test_founded_at_nil_when_unset_and_no_db
+      config['/founded_on'] = nil
+
+      assert_nil(config.send(:founded_at))
+    end
+
+    # 未設定時は account_class の最古アカウント作成日で近似する (#4434)。
+    # account_class (Sequel::Model) はクラス定義時に DB 接続を要求するため、
+    # DB 未接続 (harness 無し) 環境では omit する。
+    def test_founded_at_falls_back_to_oldest_account
+      klass = begin
+        Environment.account_class
+      rescue
+        nil
+      end
+      omit('DB 未接続のため account_class をロードできない') unless klass
+      config['/founded_on'] = nil
+      original = klass.method(:founded_at)
+      klass.define_singleton_method(:founded_at) {Time.new(2019, 5, 1, 12, 34, 56)}
+      begin
+        assert_equal('2019-05-01', config.send(:founded_at))
+      ensure
+        klass.define_singleton_method(:founded_at, original)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

capsicum サーバー情報画面（pooza/capsicum#818）向けに、サーバーの正式オープン日を `/about` の `config.founded_at`（ISO 8601 date, `YYYY-MM-DD`）として返す。closes #4434

capsicum は現状、最古アカウント作成日で近似しているが、これは**物理起動日**であって**正式オープン日**とは別概念のサーバー（きゅあすきー / ダイスキー / デルムリン丼）がある。正式オープン日はモロヘイヤ側で持ち、capsicum は単純採用する（役割分担をプロキシに寄せる）。

## 設計（pooza と合意した fallback 方式）

- `config/local.yaml` の `/founded_on` が設定されていれば**それ**を返す
- **未設定なら最古ローカルアカウントの作成日で近似**（capsicum はヒューリスティックを持たない）
- 取得不能・DB 未接続なら `null`

SNS 別の最古アカウント抽出:
- **Mastodon**: `accounts`（`domain IS NULL`）を `created_at` 昇順で 1 件
- **Misskey**: `user`（`host IS NULL`）の最古 `id` を `MisskeyService.parse_aid` で復号（Misskey は作成時刻を持たず aid に埋め込むため）

値は不変のため `account_class` 側でプロセス内メモ化。

## 変更

- `Config#about`: `founded_at` 追加 + private `founded_at`（config 優先→fallback→nil、ISO 正規化）
- `Mastodon::Account.founded_at` / `Misskey::Account.founded_at`（最古ローカルアカウント作成日）
- `config/schema/base.yaml`: `founded_on`（string）追加
- `docs/api.md`: `founded_at` 項目 + `/about` レスポンス例
- `test/unit/lib/config.rb` 新設

## 検証

- `rake test` 768 tests / 0 failures / 0 errors（fallback テストは Sequel::Model がクラス定義時に DB 接続を要するため DB 無し環境では **omit**、harness/実 DB 下で走る）。rubocop 無指摘

## 補足（デプロイ側 follow-up）

対象サーバーの `/founded_on` 実値は各サーバーの overlay config でデプロイ時に設定する（本 PR はプロキシ側の受け口のみ。repo には各サーバー config は無い）。

## 関連
- pooza/capsicum#818（capsicum 側の受け口・表示）

🤖 Generated with [Claude Code](https://claude.com/claude-code)