### PR TITLE
fix: sw_subscription 集約の register race を決定化＋トランザクションで防ぐ (#4420)

### DIFF
--- a/app/lib/mulukhiya/service/misskey_service.rb
+++ b/app/lib/mulukhiya/service/misskey_service.rb
@@ -155,25 +155,36 @@ module Mulukhiya
       # auth / publickey は端末側で再生成され得る（再インストール・鍵ローテ等）ため
       # キーに含めず、再登録時は既存行を UPDATE で置換して行を増やさない (#4408)。
       send_read_message = params[:sendReadMessage] == true
-      rows = sw_subscriptions(account, params).all
-      if rows.any?
-        subscription = consolidate_sw_subscriptions(rows, params, send_read_message)
-        state = :already_subscribed
-      else
+      # 同一 (userId, endpoint) への同時 register で read-then-write が交錯すると、
+      # 互いの canonical を stale と見なして相互削除し購読が一時消失する窓がある。
+      # 行取得〜集約/新規作成を 1 トランザクションに括り、canonical を order(:id)
+      # で決定化（sw_subscriptions 側）して並行リクエストが同一行を canonical に
+      # 選ぶことを保証する (#4420)。
+      result = Misskey::SwSubscription.db.transaction do
+        rows = sw_subscriptions(account, params).all
+        if rows.any?
+          subscription = consolidate_sw_subscriptions(rows, params, send_read_message)
+          next {subscription:, state: :already_subscribed}
+        end
         subscription = create_sw_subscription(account, params, send_read_message)
-        state = :subscribed
+        {subscription:, state: :subscribed}
       end
       invalidate_sw_subscription_cache(account.id)
-      return {subscription:, state:}
+      return result
     end
 
     def unregister_sw_subscription(account, params)
-      rows = sw_subscriptions(account, params).all
-      return nil if rows.empty?
-      # pre-fix の鍵ローテ蓄積で複数行残り得るため、endpoint 単位で全行削除する。
-      rows.each(&:delete)
+      # pre-fix の鍵ローテ蓄積で複数行残り得るため endpoint 単位で全行削除する。
+      # 同時 register との交錯を避けるためトランザクション内で取得→削除する (#4420)。
+      removed = Misskey::SwSubscription.db.transaction do
+        rows = sw_subscriptions(account, params).all
+        next nil if rows.empty?
+        rows.each(&:delete)
+        rows.first
+      end
+      return nil unless removed
       invalidate_sw_subscription_cache(account.id)
-      return rows.first
+      return removed
     end
 
     def self.parse_aid(aid)
@@ -209,10 +220,13 @@ module Mulukhiya
     private
 
     def sw_subscriptions(account, params)
+      # canonical 選択（consolidate の先頭行）を並行リクエスト間で決定化するため
+      # order(:id) を必ず付す。無序だと同時 register が別々の行を canonical に
+      # 選び相互削除する余地が残る (#4420)。
       return Misskey::SwSubscription.where(
         userId: account.id,
         endpoint: params[:endpoint],
-      )
+      ).order(:id)
     end
 
     # pre-fix の鍵ローテ蓄積で同一 (userId, endpoint) に複数行ある場合、先頭を

--- a/test/unit/service/misskey_service.rb
+++ b/test/unit/service/misskey_service.rb
@@ -182,6 +182,33 @@ module Mulukhiya
       end
     end
 
+    def test_register_sw_subscription_keeps_lowest_id_canonical
+      return unless Environment.misskey? && account
+
+      # canonical 選択が order(:id) で決定化されていること（#4420）。既存重複行の
+      # うち最小 id 行が残り、同時 register 間で相互削除が起きないことを担保する。
+      endpoint = "https://push.test/#{SecureRandom.hex(8)}"
+      cleanup = -> {Misskey::SwSubscription.where(userId: account.id, endpoint:).delete}
+      cleanup.call
+      begin
+        ids = Array.new(3) do |i|
+          Misskey::SwSubscription.create(
+            id: MisskeyService.create_aid, userId: account.id, endpoint:,
+            auth: "old_#{i}", publickey: "oldkey_#{i}", sendReadMessage: true
+          ).id
+        end
+        @service.register_sw_subscription(account, {
+          endpoint:, auth: 'auth_new', publickey: 'key_new', sendReadMessage: false
+        })
+        rows = Misskey::SwSubscription.where(userId: account.id, endpoint:).all
+
+        assert_equal(1, rows.size)
+        assert_equal(ids.min, rows.first.id)
+      ensure
+        cleanup.call
+      end
+    end
+
     def test_parse_emoji_palette_entries_with_nil
       assert_equal([], @service.send(:parse_emoji_palette_entries, nil))
     end


### PR DESCRIPTION
## 概要

5.27.0 リリース前 5観点レビュー（並行性観点）由来の #4420 を修正。

`MisskeyService` の sw_subscription 集約(consolidate)/unregister は `sw_subscriptions(account, params).all` → `stale.each(&:delete)` ＋ canonical `update` という read-then-write を**無序・トランザクション外**で行っていた。同一 (userId, endpoint) に 2 リクエストが同時着すると、`ORDER BY` が無いため両者が別の行を canonical に選び、互いの canonical を stale として相互削除する → 一時的に購読が消える窓があった。

## 対応

- `sw_subscriptions` に `.order(:id)` を付与し canonical 選択を並行リクエスト間で決定化（両者が最小 id を canonical に選ぶ→相互削除が起きない）。
- `register`（集約経路）と `unregister` の取得→書き込みを `Misskey::SwSubscription.db.transaction` で括り、部分適用が観測されないようにする。
- 最小 id 行が canonical として残ることを検証する回帰テスト `test_register_sw_subscription_keeps_lowest_id_canonical` を追加（DB 必須のため harness 下でのみ実行）。

## 関連

- #4420 / #4408（sw/register dedup）
- マイルストーン: 5.28.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)