### PR TITLE
test: record_conflict 計上テストの minute_bucket 境界フレーキーを解消 (#4423)

### DIFF
--- a/test/unit/lib/annict_review_lock_storage.rb
+++ b/test/unit/lib/annict_review_lock_storage.rb
@@ -92,10 +92,15 @@ module Mulukhiya
       config['/service/annict/review/idempotency/alert_threshold'] = 3
       @storage.instance_variable_set(:@alert_threshold, nil)
 
-      assert_false(@storage.record_conflict(@account_id, @work_id))
-      assert_false(@storage.record_conflict(@account_id, @work_id))
-      assert_true(@storage.record_conflict(@account_id, @work_id))
-      assert_false(@storage.record_conflict(@account_id, @work_id))
+      # conflict_key の minute_bucket (Time.now.to_i / 60) が計上シーケンスの途中で
+      # 切り替わると 2 回目以降の INCR が別キー count=1 になり期待値が崩れフレーキー
+      # 化する。時刻を固定して全 INCR を同一 bucket に載せる (#4423)。
+      Timecop.freeze do
+        assert_false(@storage.record_conflict(@account_id, @work_id))
+        assert_false(@storage.record_conflict(@account_id, @work_id))
+        assert_true(@storage.record_conflict(@account_id, @work_id))
+        assert_false(@storage.record_conflict(@account_id, @work_id))
+      end
     ensure
       config['/service/annict/review/idempotency/alert_threshold'] = original
       @storage.instance_variable_set(:@alert_threshold, nil)
@@ -108,9 +113,13 @@ module Mulukhiya
       @storage.instance_variable_set(:@alert_threshold, nil)
       other_account = "test_#{SecureRandom.hex(8)}"
 
-      assert_false(@storage.record_conflict(@account_id, @work_id))
-      assert_false(@storage.record_conflict(other_account, @work_id))
-      assert_true(@storage.record_conflict(@account_id, @work_id))
+      # minute_bucket 切替でカウントがリセットされるフレーキーを避けるため時刻を
+      # 固定して同一 bucket に載せる (#4423)。
+      Timecop.freeze do
+        assert_false(@storage.record_conflict(@account_id, @work_id))
+        assert_false(@storage.record_conflict(other_account, @work_id))
+        assert_true(@storage.record_conflict(@account_id, @work_id))
+      end
     ensure
       config['/service/annict/review/idempotency/alert_threshold'] = original
       @storage.instance_variable_set(:@alert_threshold, nil)


### PR DESCRIPTION
## 概要

`AnnictReviewLockStorageTest#test_record_conflict_counts_per_account`（および同型の `test_record_conflict_returns_true_only_when_threshold_reached`）が CI でまれに false-red 化していた #4423 を修正。

## 原因

`record_conflict` の計上キーは `conflict_key` = `['conflict', account_id, Time.now.to_i / 60].join(':')` の **minute_bucket**。テストは複数回の `INCR` が同一 bucket に載る前提だが、計上シーケンスの途中で分境界（`Time.now.to_i / 60` の変化）を跨ぐと 2 回目以降が別キー `count=1` になり、`count == alert_threshold` の期待が崩れて `assert_true(false)` になる。issue で報告された `class: TypeError` は fail-open（全例外 rescue → false）が握った副次症状で、赤の実体はこの分境界跨ぎ。

## 対応

計上シーケンスを `Timecop.freeze` で括り、全 `INCR` を同一 minute_bucket に載せて決定化。`TestCase#teardown` は既に `Timecop.return` を呼ぶため後始末は不要。プロダクションの分バケット集計仕様（best-effort な alert 昇格）は変更しない。

## 関連

- #4423 / #4346（conflict 集計・alert 昇格）
- マイルストーン: 5.28.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)