### PR TITLE
feat: /about に preopened_at（プレ公開日）を追加 (#4434)

### DIFF
--- a/app/lib/mulukhiya/config.rb
+++ b/app/lib/mulukhiya/config.rb
@@ -40,6 +40,7 @@ module Mulukhiya
           info_bot: info_bot_profile,
           status_url: (self['/status_url'] rescue nil),
           founded_at: founded_at,
+          preopened_at: preopened_at,
         },
       }
     end
@@ -61,9 +62,28 @@ module Mulukhiya
     # 取得不能・未設定・DB 未接続なら nil。
     def founded_at
       configured = self['/founded_on'] rescue nil
-      return Date.parse(configured.to_s).iso8601 if configured.present?
+      return normalize_iso_date(configured) if configured.present?
       date = Environment.account_class&.founded_at
       return date&.to_date&.iso8601
+    rescue
+      return nil
+    end
+
+    # プレ公開（限定公開）を経たサーバーの、正式オープン前の公開開始日を ISO 8601
+    # date で返す (#4434)。config `/preopened_on` が設定されている場合のみ値を返し、
+    # プレ公開の無いサーバーでは nil。founded_at と違い最古アカウント fallback は
+    # 持たない（プレ公開の有無は運用者しか知り得ず、最古アカウント≒プレ公開日を
+    # 一律にプレ公開扱いすると誤りになるため）。
+    def preopened_at
+      return normalize_iso_date(self['/preopened_on'])
+    rescue
+      return nil
+    end
+
+    # config 値を ISO 8601 date (YYYY-MM-DD) 文字列へ正規化する。空・パース不能は nil。
+    def normalize_iso_date(value)
+      return nil unless value.present?
+      return Date.parse(value.to_s).iso8601
     rescue
       return nil
     end

--- a/config/schema/base.yaml
+++ b/config/schema/base.yaml
@@ -386,6 +386,8 @@ properties:
     type: string
   founded_on:
     type: string
+  preopened_on:
+    type: string
   spotify:
     properties:
       client:

--- a/docs/api.md
+++ b/docs/api.md
@@ -290,7 +290,8 @@ URL 正規化、短縮 URL 展開、NowPlaying URL 展開（iTunes/Spotify/YouTu
       "display_name": "モロヘイヤからのお知らせ"
     },
     "status_url": "https://uptime.b-shock.org/status/bshockdon",
-    "founded_at": "2018-04-01"
+    "founded_at": "2018-04-01",
+    "preopened_at": null
   }
 }
 ```
@@ -301,7 +302,9 @@ URL 正規化、短縮 URL 展開、NowPlaying URL 展開（iTunes/Spotify/YouTu
 
 **`status_url`**: ステータスページの URL。`config/local.yaml` の `/status_url` で設定する。未設定時は `null`。Mastodon は `/api/v2/instance` から取得可能だが、Misskey には該当 API がないため、モロヘイヤ経由で統一的に提供する（`pooza/capsicum#247`）。
 
-**`founded_at`**: サーバーの正式オープン日（ISO 8601 date, `YYYY-MM-DD`）。`config/local.yaml` の `/founded_on` で設定する。**未設定時は最古ローカルアカウントの作成日で近似**（Mastodon は `accounts` の最古ローカル行、Misskey は最古 `user` の aid から復号）。DB 未接続時は `null`。「サーバーが物理起動した日」と「正式オープン日」が異なるサーバー（きゅあすきー / ダイスキー / デルムリン丼）は `/founded_on` を明示設定する。capsicum はヒューリスティックを持たず本値を単純採用する（`pooza/capsicum#818`）。
+**`founded_at`**: サーバーの正式オープン日（本公開日。ISO 8601 date, `YYYY-MM-DD`）。`config/local.yaml` の `/founded_on` で設定する。**未設定時は最古ローカルアカウントの作成日で近似**（Mastodon は `accounts` の最古ローカル行、Misskey は最古 `user` の aid から復号）。DB 未接続時は `null`。最古アカウントの作成日が正式オープン日とずれるサーバー（プレ公開を経た台、管理者アカウントを開設前に作った台など）は `/founded_on` を明示設定する。capsicum はヒューリスティックを持たず本値を単純採用する（`pooza/capsicum#818`）。
+
+**`preopened_at`**: プレ公開（限定公開）を経たサーバーの、正式オープン前の公開開始日（ISO 8601 date, `YYYY-MM-DD`）。`config/local.yaml` の `/preopened_on` で設定する。`founded_at` と違い**最古アカウント fallback は持たず**、設定時のみ値を返す（プレ公開の有無は運用者しか判定できないため）。プレ公開の無いサーバーでは `null`。`preopened_at ≤ founded_at` の関係になる。capsicum は両値を並べてサーバー沿革を表示する（`pooza/capsicum#818`）。
 
 **`features.annict` / `features.annict_linked`**: `features.annict` は **サーバーレベル**の設定（当該モロヘイヤサーバーで Annict の client_id/secret が設定済みか）。`features.annict_linked` は **ユーザーレベル**の状態で、リクエストの Bearer トークンに紐付く SNS アカウントに Annict access_token が保管済みなら `true`（未連携・トークン無しは `false`、無認証リクエストでも `false`）。token 存在のみで判定し liveness/refresh の確認は行わない。capsicum は両者を組み合わせ、「サーバーは Annict 対応かつ当該ユーザーが連携済み」のときのみ感想投稿ボタンを表示する（`pooza/capsicum#298`）。
 

--- a/test/unit/lib/config.rb
+++ b/test/unit/lib/config.rb
@@ -39,5 +39,25 @@ module Mulukhiya
         klass.define_singleton_method(:founded_at, original)
       end
     end
+
+    # /preopened_on 設定時は ISO 8601 date に正規化して返す (#4434)。
+    def test_preopened_at_from_config
+      config['/preopened_on'] = '2021-03-14'
+
+      assert_equal('2021-03-14', config.send(:preopened_at))
+    end
+
+    def test_preopened_at_normalizes_non_iso_input
+      config['/preopened_on'] = '2021/03/14'
+
+      assert_equal('2021-03-14', config.send(:preopened_at))
+    end
+
+    # founded_at と違い最古アカウント fallback を持たず、未設定なら nil を返す。
+    def test_preopened_at_nil_when_unset
+      config['/preopened_on'] = nil
+
+      assert_nil(config.send(:preopened_at))
+    end
   end
 end


### PR DESCRIPTION
## 概要

#4434 で追加した `founded_at`（正式オープン日＝本公開日）に対し、**プレ公開（限定公開）を経たサーバーの公開開始日**を `preopened_at` として `/about` に併記する。プレ公開のある台（デルムリン丼・ダイスキー等）で「プレ公開日」と「本公開日」の両方を表示できるようにする（pooza/capsicum#818）。

## 仕様

- `preopened_at`: config `/preopened_on` 設定時のみ ISO 8601 date で返す。
- `founded_at` と違い**最古アカウント fallback を持たない**（プレ公開の有無は運用者しか判定できず、最古アカウント≒プレ公開日を一律にプレ公開扱いすると誤りになるため）。
- プレ公開の無いサーバーでは `null`。`preopened_at ≤ founded_at` の関係。
- 日付正規化を `normalize_iso_date` に抽出し `founded_at` と共有（挙動不変）。

## 各サーバーの投入値（overlay config 運用作業、本 PR 対象外）

| サーバー | `/founded_on`（本公開） | `/preopened_on`（プレ公開） |
|---|---|---|
| 美食丼 | 未設定（fallback 2017-04-19） | 未設定 |
| キュアスタ！ | 2017-04-23 | 未設定 |
| デルムリン丼 | 2021-03-17 | 2021-03-14 |
| ダイスキー | 2023-03-17 | 2023-02-26 |

## 変更

- `app/lib/mulukhiya/config.rb`: `preopened_at` / `normalize_iso_date` 追加、about に併記
- `config/schema/base.yaml`: `preopened_on` 追加
- `docs/api.md`: `preopened_at` の説明・レスポンス例、`founded_at` の override 条件を一般化
- `test/unit/lib/config.rb`: `preopened_at` の config 正規化・未設定 nil（DB 不要、ローカル通過）

## 関連

- #4434 / pooza/capsicum#818
- マイルストーン: 5.28.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)