### PR TITLE
fix: 5.28.0 リリース前レビュー指摘対応（ABBA デッドロック回避・config typo 可視化）

### DIFF
--- a/app/lib/mulukhiya/config.rb
+++ b/app/lib/mulukhiya/config.rb
@@ -80,11 +80,14 @@ module Mulukhiya
       return nil
     end
 
-    # config 値を ISO 8601 date (YYYY-MM-DD) 文字列へ正規化する。空・パース不能は nil。
+    # config 値を ISO 8601 date (YYYY-MM-DD) 文字列へ正規化する。空は nil。
+    # 設定済みだがパース不能（typo など）の場合は運用者の切り分け用に log を
+    # 残して nil に倒す（未設定と typo を区別できるようにする）。alert はしない。
     def normalize_iso_date(value)
       return nil unless value.present?
       return Date.parse(value.to_s).iso8601
-    rescue
+    rescue => e
+      e.log(value: value.to_s)
       return nil
     end
 

--- a/app/lib/mulukhiya/service/misskey_service.rb
+++ b/app/lib/mulukhiya/service/misskey_service.rb
@@ -235,8 +235,13 @@ module Mulukhiya
     # 続くため、再登録経路で必ず全行を 1 行へ集約する (#4408 Codex P1)。
     def consolidate_sw_subscriptions(rows, params, send_read_message)
       canonical, *stale = rows
-      stale.each(&:delete)
+      # unregister は行を id 昇順に削除するため、集約側も canonical（rows は
+      # order(:id) 済みなので最小 id）を先に UPDATE してから stale を削除し、
+      # 両経路のロック取得順を id 昇順に統一する。逆順（stale 削除→canonical
+      # 更新）だと同時 register↔unregister で ABBA デッドロックの余地が生じる
+      # (#4420 リリース前レビュー指摘)。
       replace_sw_subscription(canonical, params, send_read_message)
+      stale.each(&:delete)
       return canonical
     end
 

--- a/test/unit/lib/config.rb
+++ b/test/unit/lib/config.rb
@@ -59,5 +59,18 @@ module Mulukhiya
 
       assert_nil(config.send(:preopened_at))
     end
+
+    # 設定済みだがパース不能（typo 等）なら log を残して nil に倒す (#4420 レビュー)。
+    def test_founded_at_nil_when_config_malformed
+      config['/founded_on'] = 'not-a-date'
+
+      assert_nil(config.send(:founded_at))
+    end
+
+    def test_preopened_at_nil_when_config_malformed
+      config['/preopened_on'] = 'not-a-date'
+
+      assert_nil(config.send(:preopened_at))
+    end
   end
 end


### PR DESCRIPTION
## 概要

5.28.0 リリース前 5 観点並列レビューで検出した指摘への対応。

## 🟡黄 並行性: register↔unregister ABBA デッドロック回避（#4420 の後始末）

#4420 で `sw_subscriptions` に `order(:id)` を入れて register↔register の相互削除を潰したが、集約経路 `consolidate_sw_subscriptions` が **stale 削除 → canonical 更新**の順で行ロックを取るため、`unregister`（id 昇順に全行削除）と**ロック取得順が逆**になり、重複行が残存する台での同時 register↔unregister で ABBA デッドロック（`deadlock_detected` → 未捕捉 500）の余地があった。

`consolidate` を **canonical 更新 → stale 削除**の順に変更し、両経路のロック取得順を id 昇順へ統一。結果は不変（canonical を UPDATE・stale を削除）。

※ 同レビューで挙がった empty→create の重複 insert 窓は、Misskey 本体 `/api/sw/register` の SELECT-then-INSERT と同 race であり、本体所有テーブルへの UNIQUE 制約追加は「本体改造最小化」方針で見送り・self-healing のため受容（CLAUDE.md R8 判断に準拠）。既存 `invalidate_sw_subscription_cache` の Redis blip `e.alert`→`e.log` は diff 外の既存挙動のため別 Issue（#4441 予定）。

## 🟢緑 観測性: config 日付 typo の可視化

`normalize_iso_date` が設定済みだがパース不能な `/founded_on`・`/preopened_on`（typo 等）を無ログで握っていたのを `e.log(value:)` で info ログ化（未設定と typo を切り分け可能に、alert はしない）。これから各サーバーへ開設日 config を投入するため直接有用。malformed→nil のテストを追加。

## 変更

- `app/lib/mulukhiya/service/misskey_service.rb`: consolidate のロック順統一
- `app/lib/mulukhiya/config.rb`: normalize_iso_date の parse 失敗ログ
- `test/unit/lib/config.rb`: malformed config → nil のテスト 2 件

## 関連

- #4420 / マイルストーン 5.28.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)