### PR TITLE
fix: 5.28.0 Codex レビュー指摘対応（TZ・sw_subscription FOR UPDATE・api.md）

### DIFF
--- a/app/lib/mulukhiya/model/mastodon/account.rb
+++ b/app/lib/mulukhiya/model/mastodon/account.rb
@@ -10,12 +10,15 @@ module Mulukhiya
       attr_accessor :token
 
       # 最古のローカルアカウント作成日を「設立日」の近似として返す (#4434)。
-      # ローカル (domain IS NULL) を作成日昇順で 1 件。値は不変のためプロセス内で
-      # メモ化する。DB 未接続・不在時は nil。
+      # ローカル (domain IS NULL) を作成日昇順で 1 件。created_at は GMT 保存なので
+      # Status#date / Attachment#date と同じく getlocal してから返し、東経サーバーで
+      # 現地深夜作成のアカウントが暦日 1 日前にずれるのを防ぐ (#4437 Codex P2)。
+      # 値は不変のためプロセス内でメモ化する。DB 未接続・不在時は nil。
       def self.founded_at
         return @founded_at if defined?(@founded_at) && @founded_at
-        account = where(domain: nil).order(:created_at).first
-        return @founded_at = account&.created_at
+        return nil unless account = where(domain: nil).order(:created_at).first
+        gmt = account.created_at.strftime('%Y/%m/%d %H:%M:%S GMT')
+        return @founded_at = Time.parse(gmt).getlocal
       rescue => e
         e.log
         return nil

--- a/app/lib/mulukhiya/service/misskey_service.rb
+++ b/app/lib/mulukhiya/service/misskey_service.rb
@@ -157,11 +157,12 @@ module Mulukhiya
       send_read_message = params[:sendReadMessage] == true
       # 同一 (userId, endpoint) への同時 register で read-then-write が交錯すると、
       # 互いの canonical を stale と見なして相互削除し購読が一時消失する窓がある。
-      # 行取得〜集約/新規作成を 1 トランザクションに括り、canonical を order(:id)
-      # で決定化（sw_subscriptions 側）して並行リクエストが同一行を canonical に
-      # 選ぶことを保証する (#4420)。
+      # 行取得〜集約/新規作成を 1 トランザクションに括り、SELECT ... FOR UPDATE で
+      # 対象行を order(:id) 順に先取りロックする。これで canonical を並行 register
+      # 間で決定化しつつ、canonical が無変更で UPDATE されない場合でも SELECT 時点で
+      # ロック済みとなり、unregister との重なりで購読が消失する窓を塞ぐ (#4420)。
       result = Misskey::SwSubscription.db.transaction do
-        rows = sw_subscriptions(account, params).all
+        rows = locked_sw_subscriptions(account, params)
         if rows.any?
           subscription = consolidate_sw_subscriptions(rows, params, send_read_message)
           next {subscription:, state: :already_subscribed}
@@ -175,9 +176,11 @@ module Mulukhiya
 
     def unregister_sw_subscription(account, params)
       # pre-fix の鍵ローテ蓄積で複数行残り得るため endpoint 単位で全行削除する。
-      # 同時 register との交錯を避けるためトランザクション内で取得→削除する (#4420)。
+      # 同時 register との交錯を避けるためトランザクション内で FOR UPDATE 取得→削除する。
+      # register と同じ order(:id) 順にロックを取り、ロック順不一致による ABBA
+      # デッドロックを避ける (#4420)。
       removed = Misskey::SwSubscription.db.transaction do
-        rows = sw_subscriptions(account, params).all
+        rows = locked_sw_subscriptions(account, params)
         next nil if rows.empty?
         rows.each(&:delete)
         rows.first
@@ -227,6 +230,14 @@ module Mulukhiya
         userId: account.id,
         endpoint: params[:endpoint],
       ).order(:id)
+    end
+
+    # トランザクション内で対象行を id 昇順に FOR UPDATE ロックして配列で返す。
+    # register / unregister が同一のロック順で全対象行を先取りするため、
+    # 相互削除・ロック順不一致デッドロック・無変更 canonical 未ロックの窓を塞ぐ。
+    # 必ず db.transaction ブロック内から呼ぶこと (#4420)。
+    def locked_sw_subscriptions(account, params)
+      return sw_subscriptions(account, params).for_update.all
     end
 
     # pre-fix の鍵ローテ蓄積で同一 (userId, endpoint) に複数行ある場合、先頭を

--- a/docs/api.md
+++ b/docs/api.md
@@ -91,8 +91,8 @@ SNS 本体への転送が失敗した場合、SNS が返したステータスコ
 | `/{controller}/data/media_catalog` | `/media`（無効時は 503 + JSON `{available: false, ...}`）, `/feed/media`（無効時は 503 + 空 RSS チャネル） |
 | `/{controller}/features/feed` | `/feed/list` |
 | `/{controller}/features/announcement` | `/announcement/update` |
-| `/{controller}/features/annict` | `/annict/oauth_uri`, `/annict/auth`, `/tagging/dic/annict/episodes`, `/program/works`, `/program/works/:id/episodes` |
-| `features.annict_review`（サーバーが `annict?` を満たすとき `true`。#4342 未デプロイのバージョンではキー自体が欠落し capsicum は false 判定できる） | `/annict/review`, `/annict/record` |
+| `/{controller}/features/annict` | `/annict/oauth_uri`, `/annict/auth`, `/annict/record`, `/tagging/dic/annict/episodes`, `/program/works`, `/program/works/:id/episodes` |
+| `features.annict_review`（サーバーが `annict?` を満たすとき `true`。#4342 未デプロイのバージョンではキー自体が欠落し capsicum は false 判定できる） | `/annict/review` |
 | `features.word_suggest`（`/word_suggest/urls` 設定時に有効） | `/word/suggest` |
 | `features.nowplaying_resolver`（常時 `true`） | `/nowplaying/resolve` |
 | `features.spotify_enabled`（`/service/spotify/oauth/user_oauth_enabled` + 資格情報設定時に有効） | `/spotify/oauth_uri`, `/spotify/auth`, `/spotify/currently_playing` |


### PR DESCRIPTION
## 概要

5.28.0 の直近マージ PR へ届いた Codex P2 指摘のうち、有効な 3 件を修正。

### #4437 Codex P2: Mastodon founded_at fallback の TZ ずれ

`Mastodon::Account.founded_at` は `created_at`（GMT 保存）を生で返し、`Config#founded_at` が UTC 暦日で `iso8601` していたため、東経サーバー（JST 等）で現地深夜作成の最古アカウントが暦日 1 日前にずれていた（例: 2021-04-01 00:30 JST = 2021-03-31 15:30 UTC → `2021-03-31`）。`Status#date` / `Attachment#date` と同じ `GMT→getlocal` 変換に統一。開設日は日粒度で意味を持つため実害。

### #4441 Codex P2: 無変更 canonical のロック漏れ窓

#4441 の集約ロック順統一だけでは、canonical が既に同じ資格情報を持ち `replace_sw_subscription` が UPDATE を発行しない場合、canonical 行がロックされないまま `stale.each(&:delete)` に到達し、unregister との重なりで購読が消失する窓が残っていた。register / unregister とも `SELECT ... FOR UPDATE`（`locked_sw_subscriptions`）で対象行を `order(:id)` 順に**先取りロック**し、無変更 canonical 未ロック・ABBA デッドロック・相互削除の窓をまとめて塞ぐ。empty→create は行が無くロック対象が無いため従来どおり（Misskey 本体パリティで受容）。

### #4436 Codex P2: api.md の /annict/record 分類ミス

`/annict/record` を `features.annict_review` 行に掲載していたため、クライアントが annict_review 欠落の旧サーバーで record 投稿まで無効化しうる誤り。`/annict/record` は `annict?` 基準（`features.annict`）へ移動、`annict_review` 行は `/annict/review` のみに。

## テスト

- config 11 / misskey_service 20 tests パス（ローカル）、rubocop 緑

## 関連

- #4437 / #4441 / #4436（Codex P2）/ マイルストーン 5.28.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)