### PR TITLE
fix: 設立日TZ二重シフト撤回＋config日付クォート不要化 (5.28.1 hotfix)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-core.git
-  revision: 98a72b02e5c560e7bf9914fe5b13e89bfbff51b6
+  revision: 0a3a69c93c9fc1bab3edc4232f53a28d7e89034a
   branch: main
   specs:
-    ginseng-core (1.15.26)
+    ginseng-core (1.15.27)
       activesupport (>= 7.0.7.1)
       addressable (>= 2.9.0)
       cgi (>= 0.4.2)

--- a/app/lib/mulukhiya/model/mastodon/account.rb
+++ b/app/lib/mulukhiya/model/mastodon/account.rb
@@ -10,15 +10,16 @@ module Mulukhiya
       attr_accessor :token
 
       # 最古のローカルアカウント作成日を「設立日」の近似として返す (#4434)。
-      # ローカル (domain IS NULL) を作成日昇順で 1 件。created_at は GMT 保存なので
-      # Status#date / Attachment#date と同じく getlocal してから返し、東経サーバーで
-      # 現地深夜作成のアカウントが暦日 1 日前にずれるのを防ぐ (#4437 Codex P2)。
+      # ローカル (domain IS NULL) を作成日昇順で 1 件。Sequel が返す created_at は
+      # 既に zone 付き Time（本番実測で +0900）なので getlocal で系のローカルへ
+      # 正規化するだけでよい。#4437 で入れた strftime('...GMT') 経由の再解釈は、
+      # 既にローカルな壁時計を UTC と偽って +9h する二重シフトになり設立日が翌日に
+      # ずれていたため撤回する（実測: pooza 2017-04-19 22:46 JST が 04-20 化）。
       # 値は不変のためプロセス内でメモ化する。DB 未接続・不在時は nil。
       def self.founded_at
         return @founded_at if defined?(@founded_at) && @founded_at
         return nil unless account = where(domain: nil).order(:created_at).first
-        gmt = account.created_at.strftime('%Y/%m/%d %H:%M:%S GMT')
-        return @founded_at = Time.parse(gmt).getlocal
+        return @founded_at = account.created_at.getlocal
       rescue => e
         e.log
         return nil

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -439,7 +439,7 @@ package:
     - tkoishi@b-shock.co.jp
   license: MIT
   url: https://github.com/pooza/mulukhiya-toot-proxy
-  version: 5.28.0
+  version: 5.28.1
 parser:
   note:
     fields:


### PR DESCRIPTION
## 概要

5.28.0 本番適用後に美食丼で判明した 2 点＋関連 footgun へのホットフィックス。

### ① founded_at fallback の 1 日ズレ（バグ）
#4437（Codex P2）で入れた `created_at.strftime('%Y/%m/%d %H:%M:%S GMT')` → `getlocal` 再解釈が、Sequel が既に zone 付き（本番実測 +0900）で返す `created_at` の壁時計を UTC と偽って +9h する**二重シフト**になり、設立日が翌日にずれていた（実測: pooza `2017-04-19 22:46 JST` → `2017-04-20`）。`account.created_at.getlocal` に是正（UTC/ローカルどちらで返っても正しい）。

### ② 未クォート日付での起動クラッシュ（footgun）
Psych 4 の `YAML.load_file` は safe_load 相当で Date 不許可のため、`founded_on: 2021-03-14` のようにクォート無しで書くと `Psych::DisallowedClass: Date` で起動時クラッシュ（本番 delmulin/daisskey/lbock で実害）。**ginseng-core 1.15.27** で Config の YAML ロードに `permitted_classes: [Date, Time, DateTime]` を渡し、クォート不要にした（Gemfile.lock 追随）。

## 補足（本 PR 対象外・別途対応済み）
- 美食丼の「webhook が 422 連発」は GitHub の誤設定 webhook（GitHub 生イベントを Slack 形式 webhook へ送信）が原因で、mulukhiya のバグではない。該当 hook 4 件（ginseng-core/ginseng-fediverse/ginseng-web/cure-api）を削除済み。

## 関連
- #4437（TZ 是正の撤回）/ 5.28.1 hotfix

🤖 Generated with [Claude Code](https://claude.com/claude-code)