### PR TITLE
5.28.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-core.git
-  revision: 98a72b02e5c560e7bf9914fe5b13e89bfbff51b6
+  revision: 0a3a69c93c9fc1bab3edc4232f53a28d7e89034a
   branch: main
   specs:
-    ginseng-core (1.15.26)
+    ginseng-core (1.15.27)
       activesupport (>= 7.0.7.1)
       addressable (>= 2.9.0)
       cgi (>= 0.4.2)

--- a/app/lib/mulukhiya/model/mastodon/account.rb
+++ b/app/lib/mulukhiya/model/mastodon/account.rb
@@ -10,15 +10,16 @@ module Mulukhiya
       attr_accessor :token
 
       # 最古のローカルアカウント作成日を「設立日」の近似として返す (#4434)。
-      # ローカル (domain IS NULL) を作成日昇順で 1 件。created_at は GMT 保存なので
-      # Status#date / Attachment#date と同じく getlocal してから返し、東経サーバーで
-      # 現地深夜作成のアカウントが暦日 1 日前にずれるのを防ぐ (#4437 Codex P2)。
+      # ローカル (domain IS NULL) を作成日昇順で 1 件。Sequel が返す created_at は
+      # 既に zone 付き Time（本番実測で +0900）なので getlocal で系のローカルへ
+      # 正規化するだけでよい。#4437 で入れた strftime('...GMT') 経由の再解釈は、
+      # 既にローカルな壁時計を UTC と偽って +9h する二重シフトになり設立日が翌日に
+      # ずれていたため撤回する（実測: pooza 2017-04-19 22:46 JST が 04-20 化）。
       # 値は不変のためプロセス内でメモ化する。DB 未接続・不在時は nil。
       def self.founded_at
         return @founded_at if defined?(@founded_at) && @founded_at
         return nil unless account = where(domain: nil).order(:created_at).first
-        gmt = account.created_at.strftime('%Y/%m/%d %H:%M:%S GMT')
-        return @founded_at = Time.parse(gmt).getlocal
+        return @founded_at = account.created_at.getlocal
       rescue => e
         e.log
         return nil

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -439,7 +439,7 @@ package:
     - tkoishi@b-shock.co.jp
   license: MIT
   url: https://github.com/pooza/mulukhiya-toot-proxy
-  version: 5.28.0
+  version: 5.28.1
 parser:
   note:
     fields:


### PR DESCRIPTION
## 概要

5.28.0 本番適用後に判明した設立日（founded_at）まわりの不具合を是正するホットフィックス。

## 変更内容

### バグ修正

- **founded_at fallback の 1 日ズレ** — 最古ローカルアカウント作成日から設立日を近似する際、5.28.0 で入れた `created_at.strftime('%Y/%m/%d %H:%M:%S GMT')` → `getlocal` の再解釈が、Sequel が既に zone 付き（実測 +0900）で返す `created_at` の壁時計を UTC と偽って +9h する二重シフトになり、設立日が翌日にずれていた（例: `2017-04-19 22:46 JST` → `2017-04-20`）。`account.created_at.getlocal` に是正した。

### メンテナンス

- **ginseng-core 1.15.27** — config の YAML ロードで `Date` / `Time` / `DateTime` を許可。`config/local.yaml` に `founded_on: 2021-03-14` のように**クォート無しで日付を書いても** `Psych::DisallowedClass` で起動時クラッシュしないようにした（従来はクォート必須の footgun だった）。

## 運用向け設定変更

`/founded_on`・`/preopened_on` は**クォートの有無どちらでも**安全に読めるようになった（本バージョン以降）。

```yaml
founded_on: 2021-03-17     # クォート不要（'2021-03-17' でも可）
preopened_on: 2021-03-14
```

## アップグレード手順

[更新手順](https://github.com/pooza/mulukhiya-toot-proxy/wiki/%E6%9B%B4%E6%96%B0%E6%89%8B%E9%A0%86)を参照してください。
4.x系からのアップグレードは[4.x → 5.0 アップグレードガイド](https://github.com/pooza/mulukhiya-toot-proxy/wiki/4.x-%E2%86%92-5.0-%E3%82%A2%E3%83%83%E3%83%97%E3%82%B0%E3%83%AC%E3%83%BC%E3%83%89%E3%82%AC%E3%82%A4%E3%83%89)も参照してください。

**必要 Ruby: 4.0.5**（`.ruby-version`。据え置き）。未導入のサーバーは `rbenv install 4.0.5` が前提。

本リリースに起動スクリプトの変更はありません。通常の更新手順（git pull + bundle install + サービス再起動）で適用できます。**gem を更新する（ginseng-core 1.15.27）ため、`bundle install` は省略しないこと**。
