### PR TITLE
fix: #4448 redis.incr 未定義でヒステリシス通知が沈黙する不具合を修正

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,10 +65,10 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-redis.git
-  revision: 9b46bdf6c2a34d385d84716ea69f1c40d3399cb3
+  revision: 91e9a516451b3001e4b65ed36132390343f9e9bc
   branch: main
   specs:
-    ginseng-redis (2.0.3)
+    ginseng-redis (2.0.4)
       redis-client
 
 GIT


### PR DESCRIPTION
## 概要

`StartupNotificationWorker#bump_ng_count` の `redis.incr` が `Mulukhiya::Redis`（← `Ginseng::Redis::Service`）に未実装で、環境非依存に `NoMethodError` を送出。`perform` の `rescue` に飲まれるため、**ヘルスが NG に転じた瞬間にヒステリシスが機能せず #4168/#4244 のヘルス変化再通知が本番で沈黙**していた（5分毎 worker）。

fedi-test-harness テスト（#4447 の triage）で検出。

## 変更

- `ginseng-redis` を **2.0.4** へ bump（`Service#incr` 追加 = pooza/ginseng-redis#50）。mulukhiya 側はこの lock 更新のみ（worker コードは正しい）。

## 確認

harness（Mastodon v4.6.3・DB 接続あり）で:

```
StartupNotificationWorker: 14 tests / 0 failures / 0 errors（従来 3 errors → 解消）
```

Closes #4448

🤖 Generated with [Claude Code](https://claude.com/claude-code)