### PR TITLE
test: #4447 harness で露見した stale/DB依存テスト3件を是正

### DIFF
--- a/test/unit/lib/config.rb
+++ b/test/unit/lib/config.rb
@@ -13,11 +13,18 @@ module Mulukhiya
       assert_equal('2021-04-01', config.send(:founded_at))
     end
 
-    # 未設定かつ最古アカウント取得不能（DB 未接続）なら nil に倒す。
+    # 未設定かつ最古アカウント取得不能（DB 未接続 = account_class が nil）なら nil に倒す。
+    # harness では DB 接続済み・最古アカウントが存在し fallback が日付を返すため、
+    # account_class を nil に stub して DB 有無に依存せず決定的に検証する。
     def test_founded_at_nil_when_unset_and_no_db
       config['/founded_on'] = nil
-
-      assert_nil(config.send(:founded_at))
+      original = Environment.method(:account_class)
+      Environment.define_singleton_method(:account_class) {nil}
+      begin
+        assert_nil(config.send(:founded_at))
+      ensure
+        Environment.define_singleton_method(:account_class, original)
+      end
     end
 
     # 未設定時は account_class の最古アカウント作成日で近似する (#4434)。

--- a/test/unit/lib/template.rb
+++ b/test/unit/lib/template.rb
@@ -13,7 +13,9 @@ module Mulukhiya
     end
 
     def test_to_s
-      assert(@template.to_s.chomp.end_with?('へようこそ。'))
+      # welcome.erb は「<node_name>へようこそ。」の挨拶行に続けて案内行を持つ複数行
+      # テンプレなので、末尾でなく挨拶行（1行目）が正しくレンダーされることを検証する。
+      assert(@template.to_s.lines.first.chomp.end_with?('へようこそ。'))
     end
   end
 end

--- a/test/unit/worker/announcement_worker.rb
+++ b/test/unit/worker/announcement_worker.rb
@@ -13,7 +13,9 @@ module Mulukhiya
     def test_perform
       @worker.perform
 
-      assert_kind_of(Array, Announcement.new.load)
+      # Announcement#load は save が書く id キーの Hash を読み戻すため Hash を返す
+      # （cache.member?(id) がキー照合に使う）。空でも '{}' → {} で Hash。
+      assert_kind_of(Hash, Announcement.new.load)
     end
   end
 end


### PR DESCRIPTION
## 概要

#4447 の triage で、fedi-test-harness（Mastodon v4.6.3・DB 接続あり）相手に落ちていた「要精査の実 signal 候補」のうち、**テスト側の不備3件**を honest に是正する。standalone（DB 未接続）では `disable?`/omission で skip されて露見せず、harness で走って初めて落ちていたもの。

## 変更

| テスト | 是正内容 |
|---|---|
| `ConfigTest#test_founded_at_nil_when_unset_and_no_db` | `Environment.account_class` を nil に stub し **DB 有無に依存せず決定化**。harness では DB 接続済み・最古アカウント（2026-07-12）が居て `founded_at` が fallback で日付を返し `assert_nil` が落ちていた。 |
| `TemplateTest#test_to_s` | `views/mention/welcome.erb` が複数行化（挨拶行＋案内行）したのに `end_with?('へようこそ。')` のままだった stale assertion を、**挨拶行（1行目）の検証**へ是正。 |
| `AnnouncementWorkerTest#test_perform` | `Announcement#load` は save が書く id キーの **Hash を読み戻す設計**（`cache.member?(id)` がキー照合）。期待を `Array`→`Hash` に是正。 |

## 確認

- harness あり: `config` / `template` / `announcement_worker` = **13 tests / 0 failures / 0 errors**。
- harness なし: 退行なし（12 tests / 100%、DB 依存の fallback は omission）。

## 残（#4447 で継続）

環境ギャップ2件は別途 precondition 整理: `EnvironmentTest#test_health`（harness に mulukhiya sidekiq 不在で NG）／`WebhookTest#test_command`（webhook target が HTML 応答）。実バグ `redis.incr`（#4448）は別 PR #4449。

Refs #4447

🤖 Generated with [Claude Code](https://claude.com/claude-code)