### PR TITLE
test: #4447 harness で handler テストが WebMock に弾かれる問題を是正（実 green 化）

### DIFF
--- a/test/integration/pre_toot_pipeline.rb
+++ b/test/integration/pre_toot_pipeline.rb
@@ -1,10 +1,19 @@
+require 'webmock/test_unit'
+
 module Mulukhiya
   class PreTootPipelineTest < TestCase
     def setup
       WebMock.disable_net_connect!(allow_localhost: true)
+      # pipeline は GroupTagHandler を含み、community-map を外部（pf.korako.me）から取得する。
+      # 実サーバー非依存にするためスタブに閉じる（harness=localhost は allow_localhost で通す）。
+      stub_community_map
       @sns = sns_class.new('https://sns.test', 'test_token')
       def @sns.account = nil
       config['/agent/accts'] = ['@relayctl@hashtag-relay.dtp-mstdn.jp']
+    end
+
+    def teardown
+      WebMock.allow_net_connect!
     end
 
     def test_plain_text
@@ -105,6 +114,12 @@ module Mulukhiya
 
     def create_event
       Event.new(:pre_toot, sns: @sns)
+    end
+
+    def stub_community_map
+      body = {communities: []}.to_json
+      stub_request(:get, 'https://pf.korako.me/plugins/community-hashtag-map.json')
+        .to_return(status: 200, body:, headers: {'Content-Type' => 'application/json'})
     end
   end
 end

--- a/test/unit/handler/group_tag_handler.rb
+++ b/test/unit/handler/group_tag_handler.rb
@@ -4,7 +4,10 @@ module Mulukhiya
   class GroupTagHandlerTest < TestCase
     def setup
       return if disable?
-      WebMock.disable_net_connect!
+      # community-map は下でスタブする一方、GroupTagHandler は local instance 解決で
+      # harness の SNS（localhost）へ実アクセスする。allow_localhost で harness を通し、
+      # 外部（pf.korako.me）はスタブに閉じる。
+      WebMock.disable_net_connect!(allow_localhost: true)
       @handler = Handler.create(:group_tag)
       stub_community_map
     end


### PR DESCRIPTION
## 概要

pooza/mulukhiya-toot-proxy#4447 の残り赤のうち、**omit ではなく実アサートで green にできる** WebMock 起因 8 件を是正する。

harness（DB 接続）では `GroupTagHandler` が有効化され、community-map 取得や local instance 解決で外部 / localhost へ実 HTTP を発する。WebMock の `NetConnectNotAllowedError` は **Exception 継承**のため、handler 側の `rescue => e`（本番では接続失敗を握る堅牢設計）を貫通し、テストが error になっていた。

| テスト | 従来 | 原因 |
|---|---|---|
| `GroupTagHandlerTest`（×4） | `localhost:3000/api/v1/instance` unregistered | `disable_net_connect!` が harness(localhost) を弾く |
| `PreTootPipelineTest`（×4） | `pf.korako.me/.../community-hashtag-map.json` unregistered | pipeline 内 GroupTagHandler の外部取得が未スタブ |

## 対応

- `GroupTagHandlerTest`: `disable_net_connect!` → `disable_net_connect!(allow_localhost: true)`。harness の SNS(localhost) を通し、外部 community-map は従来どおりスタブに閉じる。
- `PreTootPipelineTest`: pipeline に含まれる GroupTagHandler の community-map 取得（pf.korako.me）をスタブ追加。`teardown` で `allow_net_connect!` に戻す。

いずれも **omit ではなく実アサート**で green（harness の handler ロジックを実際に検証）。

## 検証

- harness: `group_tag_handler,pre_toot_pipeline` → **14 tests, 23 assertions, 0 failures, 0 errors**（従来 8 errors）
- standalone: 回帰なし
- rubocop: クリーン

Refs #4447

🤖 Generated with [Claude Code](https://claude.com/claude-code)