### PR TITLE
test: #4447 harness 残りの依存4クラスタを是正/honest 隔離

### DIFF
--- a/test/unit/handler/announcement_mention_handler.rb
+++ b/test/unit/handler/announcement_mention_handler.rb
@@ -6,6 +6,10 @@ module Mulukhiya
 
     def test_template
       template = @handler.template
+      # mention/announcement.erb は params[:announcement] を参照する（.count / .load）。
+      # 通常は handle_mention が Announcement を注入するが、template を直接検証する本テストでは
+      # 明示的に params を与えてからレンダーする（未設定だと nil.count で落ちる）。
+      template.params = {announcement: Announcement.new}
 
       assert_kind_of(Template, template)
       assert_respond_to(template, :to_s)

--- a/test/unit/handler/shortened_url_handler.rb
+++ b/test/unit/handler/shortened_url_handler.rb
@@ -14,7 +14,9 @@ module Mulukhiya
       url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
       @handler.handle_pre_toot(status_field => url)
 
-      assert_equal({result: [], errors: []}, @handler.debug_info)
+      # 非ホワイトリスト URL は rewritable? false でスキップされ result/errors とも空。
+      # debug_info は両者空なら nil を返す契約（handler.rb）なので nil を検証する。
+      assert_nil(@handler.debug_info)
     end
   end
 end

--- a/test/unit/model/listener.rb
+++ b/test/unit/model/listener.rb
@@ -8,7 +8,16 @@ module Mulukhiya
     def setup
       return if disable?
       @listener_class = Environment.listener_class
-      @listener = @listener_class.new if Environment.daemon_classes.member?(ListenerDaemon)
+      return unless Environment.daemon_classes.member?(ListenerDaemon)
+
+      # Listener 構築は Mastodon instance info の urls.streaming_api を要する。harness は
+      # streaming を提供せず nil のため構築できない（create_streaming_uri が nil.path= で落ちる）。
+      # streaming 未提供環境では precondition 明示 omit（silent skip ではない）。
+      # harness 側の streaming provisioning は chubo2#63。
+      omit('streaming_api 未提供（harness は streaming を持たない・chubo2#63）') \
+        if info_agent_service&.info&.dig('urls', 'streaming_api').blank?
+
+      @listener = @listener_class.new
     end
 
     def teardown

--- a/test/unit/service/sns_service.rb
+++ b/test/unit/service/sns_service.rb
@@ -12,8 +12,16 @@ module Mulukhiya
 
     def test_info
       assert_kind_of(Hash, @sns.info)
-      assert_kind_of(String, @sns.maintainer_name)
+
+      # node_name / maintainer_name は nodeinfo(metadata) 由来。harness の Mastodon は
+      # nodeinfo href を https://localhost:3000 で広告するが 3000 は平文 http のみ提供のため
+      # 取得に失敗し info が空 {} になる（node_name も nil に倒れる）。nodeinfo 未取得の
+      # 環境では precondition 明示 omit（silent skip ではない）。
+      # harness 側の nodeinfo 到達性（https/http 不整合）改善は chubo2#63。
+      omit('harness で nodeinfo を取得できない（https/http 不整合・chubo2#63）') if @sns.node_name.nil?
+
       assert_kind_of(String, @sns.node_name)
+      assert_kind_of(String, @sns.maintainer_name)
     end
 
     def test_account


### PR DESCRIPTION
## 概要

pooza/mulukhiya-toot-proxy#4447 の全件 harness 計測で残った赤のうち、WebMock 系（#4453）を除く**残り4クラスタ**を処理する。実 green 化できるものは是正し、harness の構造的未提供は precondition 明示 omit で honest 隔離する。

### 実 green 化（テスト自体の不備を是正）

| テスト | 従来 | 是正 |
|---|---|---|
| `ShortenedURLHandler#test_skip_non_whitelisted_url` | `debug_info` に `{result:[],errors:[]}` を期待し nil で失敗 | 空なら nil を返す契約（handler.rb）に合わせ `assert_nil` へ |
| `AnnouncementMentionHandler#test_template` | template 直接検証で `params[:announcement]` 未設定 → ERB が `nil.count` で error | 必須 params を明示注入してレンダー |

いずれも標準では DB 非接続で self-disable するため CI で顕在化せず、harness で初めて露見した latent なテスト不備。

### honest 隔離（harness の構造的未提供 → omit）

| テスト | 原因 | 受け皿 |
|---|---|---|
| `ListenerTest`（×8） | harness に `urls.streaming_api` 不在 → `Listener.new` が `nil.path=` で落ちる | chubo2#63 |
| `SNSServiceTest#test_info` | harness の nodeinfo href が `https://localhost:3000` だが 3000 は平文 http のみ → 取得失敗で `info` が空 `{}`、`node_name`/`maintainer_name` が nil | chubo2#63 |

実デプロイ / フルスタック環境では streaming・nodeinfo が到達可能なため従来どおりアサートが走り、product の回帰検出力は維持される。

## 検証

- harness: `shortened_url_handler,announcement_mention_handler,sns_service,listener` → **18 tests, 0 failures, 0 errors, 9 omissions**（従来 2 failures + 8 errors）
- standalone: 回帰なし
- rubocop: クリーン

Refs #4447, chubo2#63

🤖 Generated with [Claude Code](https://claude.com/claude-code)