### PR TITLE
test: #4447 GroupTag community-map キャッシュのテスト間汚染を解消

### DIFF
--- a/test/integration/pre_toot_pipeline.rb
+++ b/test/integration/pre_toot_pipeline.rb
@@ -14,6 +14,9 @@ module Mulukhiya
 
     def teardown
       WebMock.allow_net_connect!
+      # pipeline 実行で GroupTagHandler が空 community-map を CACHE_KEY に書くため、
+      # 後続テストへ汚染しないよう掃除する。
+      Redis.new.del(GroupTagHandler::CACHE_KEY)
     end
 
     def test_plain_text

--- a/test/unit/handler/group_tag_handler.rb
+++ b/test/unit/handler/group_tag_handler.rb
@@ -8,6 +8,10 @@ module Mulukhiya
       # harness の SNS（localhost）へ実アクセスする。allow_localhost で harness を通し、
       # 外部（pf.korako.me）はスタブに閉じる。
       WebMock.disable_net_connect!(allow_localhost: true)
+      # community_map は redis(CACHE_KEY)にキャッシュされ他テストと共有される。前段のテスト
+      # （例 PreTootPipelineTest）が空マップを残していると cache_valid? が true になり本テストの
+      # スタブが fetch されない。setup で必ず消して毎回スタブから引き直す（順序非依存化）。
+      redis.del(GroupTagHandler::CACHE_KEY)
       @handler = Handler.create(:group_tag)
       stub_community_map
     end


### PR DESCRIPTION
## 概要

#4453 で `PreTootPipelineTest` / `GroupTagHandlerTest` が harness で実走するようになった副作用で、両者が共有する redis の `GroupTagHandler::CACHE_KEY`（`group_tag:communities`）を介した**テスト順序依存**が生じた。

- `PreTootPipelineTest` は pipeline 実行で GroupTagHandler に空 community-map（`{communities: []}`）を CACHE_KEY へ書くが cleanup しない。
- 後続の `GroupTagHandlerTest` は `cache_valid?`（`redis.key?(CACHE_KEY)`）が true になるため自分のスタブを fetch せず、空キャッシュを再利用 → `addition_tags` が空で `test_handle_pre_toot_with_matching_acct` が失敗。
- **単体では出ず、全件実行時のみ**顕在化（順序依存）。

## 対応

- `GroupTagHandlerTest#setup`: `redis.del(CACHE_KEY)` を追加し、毎回スタブから引き直す（順序非依存化）。
- `PreTootPipelineTest#teardown`: 書いた CACHE_KEY を掃除し後続テストを汚染しない。

## 検証

- 汚染順序を強制（`pre_toot_pipeline,group_tag_handler`）→ **14 tests, 23 assertions, 0 failures, 0 errors**
- 全件 harness 再計測でも 0 failures / 0 errors（PR 本文更新前の最終確認は別途コメント）
- rubocop: クリーン

Refs #4447

🤖 Generated with [Claude Code](https://claude.com/claude-code)