### PR TITLE
test: #4447 harness の omit を harness? シグナルでゲート（Codex P2×5 follow-up）

### DIFF
--- a/app/lib/mulukhiya/test_case.rb
+++ b/app/lib/mulukhiya/test_case.rb
@@ -36,6 +36,13 @@ module Mulukhiya
       return @http
     end
 
+    # chubo2 fedi-test-harness 駆動の run か。harness の構造的未提供（デーモン層・webhook・
+    # streaming・nodeinfo・seed 等）を omit する条件を、本番/フルスタックの実退行と切り分ける
+    # ためのゲート。非 harness では症状が出たら omit せず実アサートで落とす (#4447)。
+    def harness?
+      return TestHarness.active?
+    end
+
     def self.load(cases = nil)
       ENV['TEST'] = Package.full_name
       TestHarness.apply!

--- a/app/lib/mulukhiya/test_harness.rb
+++ b/app/lib/mulukhiya/test_harness.rb
@@ -13,6 +13,15 @@ module Mulukhiya
       return new.apply!
     end
 
+    # harness 由来の接続情報が注入された run かを表すシグナル。テストの omit を
+    # 「本番・フルスタックの実退行」から切り分けるために使う (#4447)。本番の通常 run では
+    # harness 固有 ENV（MULUKHIYA_HARNESS_DIR / <PREFIX>_URL + <PREFIX>_ACCESS_TOKEN）が
+    # 無いため false になり、各テストは症状ではなく実アサートで退行を検出する。
+    def self.active?
+      return @active unless @active.nil?
+      return @active = new.connections.present?
+    end
+
     # 接続情報を config に流し込む。適用したコントローラの接続情報を返す（無ければ nil）。
     # TestCase#teardown の `config.reload` を跨いで残るよう、フラットキー代入ではなく
     # raw['local'] 層へ deep-merge してから reload する。reload は raw のキャッシュから

--- a/test/unit/lib/media_feed_renderer.rb
+++ b/test/unit/lib/media_feed_renderer.rb
@@ -16,9 +16,10 @@ module Mulukhiya
 
       assert_equal('<?xml version="1.0" encoding="UTF-8"?>', r.each_line.to_a.first.chomp)
       # <item> は media が seed されている時のみ現れる（to_s は attachment_class.feed から描画）。
-      # harness 等 media 未 seed の環境では precondition 明示 omit。seed 追加は chubo2#64。
+      # harness は media を seed しないため harness 駆動時のみ omit する。seed 追加は chubo2#64。
+      # 非 harness（本番等）で media が無いのは実退行なので下の assert で落とす。
       # feed はブロック無しだと Enumerator を返すため none? で実データの有無を判定する。
-      omit('テスト用メディア未 seed（chubo2#64）') if attachment_class.feed.none?
+      omit('テスト用メディア未 seed（chubo2#64）') if harness? && attachment_class.feed.none?
 
       assert_includes(r, '<item>')
     end
@@ -28,12 +29,13 @@ module Mulukhiya
       assert_predicate(MediaFeedRenderer.uri, :absolute?)
 
       # http.get は mulukhiya の HTTP エンドポイント（/mulukhiya/feed/media）に到達する。
-      # harness はこれを提供せず 404 を返すため、endpoint 未提供（404）の環境でのみ omit する。
-      # 404 以外の異常はそのまま失敗させ product の回帰検出力を保つ。provisioning は chubo2#63。
+      # harness はこれを提供せず 404 を返すため、harness 駆動時の 404 でのみ omit する。
+      # 非 harness の 404（＝本番でエンドポイント消失）や 404 以外の異常はそのまま失敗させ
+      # product の回帰検出力を保つ。provisioning は chubo2#63。
       begin
         response = http.get(MediaFeedRenderer.uri)
       rescue Ginseng::GatewayError => e
-        raise unless e.message.include?('404')
+        raise unless harness? && e.message.include?('404')
 
         omit("mulukhiya HTTP エンドポイント未提供（#{e.message}・chubo2#63）")
       end

--- a/test/unit/model/environment.rb
+++ b/test/unit/model/environment.rb
@@ -20,10 +20,11 @@ module Mulukhiya
 
       # sidekiq / streaming / 総合ステータス 200 は mulukhiya デーモン層の常駐を前提とする。
       # harness は proxy=nginx・web/sidekiq=Mastodon 自身のみで mulukhiya のデーモンを持たず、
-      # sidekiq は構造的に NG になる。デーモン未提供の環境では precondition で明示 omit する
-      # （silent skip ではない）。harness 側の provisioning は chubo2#63。
+      # sidekiq は構造的に NG になる。harness 駆動時のみ明示 omit する（silent skip ではない）。
+      # 非 harness（本番/フルスタックのスモーク）で sidekiq NG なら実退行として下の assert で
+      # 落とす。harness 側の provisioning は chubo2#63。
       omit('mulukhiya sidekiq 未常駐（harness はデーモン層を提供しない・chubo2#63）') \
-        unless SidekiqDaemon.health[:status] == 'OK'
+        if harness? && SidekiqDaemon.health[:status] != 'OK'
 
       assert_equal('OK', health.dig(:sidekiq, :status))
       assert_equal('OK', health.dig(:streaming, :status)) if environment_class.daemon_classes.member?(ListenerDaemon)

--- a/test/unit/model/listener.rb
+++ b/test/unit/model/listener.rb
@@ -12,12 +12,21 @@ module Mulukhiya
 
       # Listener 構築は Mastodon instance info の urls.streaming_api を要する。harness は
       # streaming を提供せず nil のため構築できない（create_streaming_uri が nil.path= で落ちる）。
-      # streaming 未提供環境では precondition 明示 omit（silent skip ではない）。
-      # harness 側の streaming provisioning は chubo2#63。
-      omit('streaming_api 未提供（harness は streaming を持たない・chubo2#63）') \
-        if info_agent_service&.info&.dig('urls', 'streaming_api').blank?
+      # ここでは omit せず @listener を nil のままにする。omit を setup に置くと @listener を
+      # 使わない class-only テスト（retry_delay 系）まで巻き込むため、@listener を実際に使う
+      # テストだけが require_listener! でゲートする（#4447）。streaming provisioning は chubo2#63。
+      return if info_agent_service&.info&.dig('urls', 'streaming_api').blank?
 
       @listener = @listener_class.new
+    end
+
+    # @listener を要するテストの前提ガード。streaming_api を広告する環境（フルスタック）でのみ
+    # @listener が構築でき、標準の config プロパティを実アサートする。streaming 未提供の環境
+    # （standalone / harness いずれも）では live streaming ではなくこれら config 検証自体が
+    # 成立しないため、silent な `return`（fake pass）ではなく可視 omit でスキップする（#4447）。
+    # harness の streaming provisioning は chubo2#63。
+    def require_listener!
+      omit('streaming_api 未提供（Listener を構築できない・harness は chubo2#63）') unless @listener
     end
 
     def teardown
@@ -28,7 +37,7 @@ module Mulukhiya
     end
 
     def test_verify_peer?
-      return false unless @listener
+      require_listener!
       expected = config["/#{Environment.controller_name}/streaming/verify_peer"]
 
       assert_boolean(@listener.verify_peer?)
@@ -36,19 +45,19 @@ module Mulukhiya
     end
 
     def test_root_cert_file
-      return unless @listener
+      require_listener!
 
       assert_path_exist(@listener.root_cert_file)
     end
 
     def test_keepalive
-      return unless @listener
+      require_listener!
 
       assert_predicate(@listener.keepalive, :positive?)
     end
 
     def test_underscore
-      return unless @listener
+      require_listener!
 
       assert_kind_of(String, @listener.underscore)
     end

--- a/test/unit/model/webhook.rb
+++ b/test/unit/model/webhook.rb
@@ -86,10 +86,11 @@ module Mulukhiya
 
       # webhook エンドポイント（/mulukhiya/webhook/<digest>）は mulukhiya アプリが処理して
       # JSON を返す。harness の proxy は nginx→Mastodon をパスするのみで mulukhiya webhook
-      # ルートを提供しないため HTML(エラーページ)が返る。その環境では precondition で明示 omit
-      # する（silent skip ではない）。harness 側の provisioning は chubo2#63。
+      # ルートを提供しないため HTML(エラーページ)が返る。harness 駆動時のみ明示 omit する
+      # （silent skip ではない）。非 harness で HTML が返るのは実退行なので下の JSON.parse で
+      # 落とす。harness 側の provisioning は chubo2#63。
       omit('mulukhiya webhook エンドポイント未提供（HTML 応答・chubo2#63）') \
-        if command.stdout.lstrip.start_with?('<')
+        if harness? && command.stdout.lstrip.start_with?('<')
 
       assert_predicate(command.status, :zero?)
       status = JSON.parse(command.stdout)

--- a/test/unit/service/sns_service.rb
+++ b/test/unit/service/sns_service.rb
@@ -15,10 +15,11 @@ module Mulukhiya
 
       # node_name / maintainer_name は nodeinfo(metadata) 由来。harness の Mastodon は
       # nodeinfo href を https://localhost:3000 で広告するが 3000 は平文 http のみ提供のため
-      # 取得に失敗し info が空 {} になる（node_name も nil に倒れる）。nodeinfo 未取得の
-      # 環境では precondition 明示 omit（silent skip ではない）。
-      # harness 側の nodeinfo 到達性（https/http 不整合）改善は chubo2#63。
-      omit('harness で nodeinfo を取得できない（https/http 不整合・chubo2#63）') if @sns.node_name.nil?
+      # 取得に失敗し info が空 {} になる（node_name も nil に倒れる）。harness 駆動時のみ
+      # 明示 omit する（silent skip ではない）。非 harness（本番等）で node_name が nil なのは
+      # 実退行なので下の assert で落とす。harness 側の nodeinfo 到達性改善は chubo2#63。
+      omit('harness で nodeinfo を取得できない（https/http 不整合・chubo2#63）') \
+        if harness? && @sns.node_name.nil?
 
       assert_kind_of(String, @sns.node_name)
       assert_kind_of(String, @sns.maintainer_name)


### PR DESCRIPTION
## 概要

#4447 で Codex が PR#4451〜#4454 に投稿した P2×5 の共通指摘を是正する。

指摘の核: harness の構造的未提供（デーモン層/webhook/streaming/nodeinfo/seed）を omit する条件が **「症状」でゲート**されており、本番・フルスタックのスモークで**実退行が起きても omit に化ける**。DB 接続経路は事実上 harness のみのため即時実害は無いが、将来のステージング/本番スモークで潜在穴になる。

## 変更

- **`TestHarness.active?` / `TestCase#harness?` を追加** — harness 由来の接続情報（`MULUKHIYA_HARNESS_DIR` / `<PREFIX>_URL`+`ACCESS_TOKEN`）が注入された run かを表すシグナル。本番の通常 run では false。
- **5箇所の omit を「症状」→「`harness?` && 症状」へ括り直し**:
  - `environment.rb`（sidekiq NG）/ `webhook.rb`（HTML 応答）/ `media_feed_renderer.rb`（feed 未 seed・404）/ `sns_service.rb`（nodeinfo 未取得）
  - 非 harness で症状が出たら omit せず実アサート（`raise`/`assert`/`JSON.parse`）で退行を検出
- **`listener.rb` を再構成**（Codex 指摘4）:
  - setup の omit を外し、`@listener` を使わない class-only テスト（`retry_delay` 系）を巻き込みから解放
  - `@listener` 依存テストは silent `return`（fake pass）を可視 omit（`require_listener!`）へ是正

## 検証（fedi-test-harness / Mastodon v4.6.3・同一ウォーム環境で A/B）

| | tests | assertions | failures | errors | omissions |
|---|---|---|---|---|---|
| 旧 | 850 | 1692 | 0 | 0 | 15 |
| 新 | 850 | 1697 | 0 | 0 | 11 |

- omission −4 は全て ListenerTest の class-only テスト（omit→実アサートへ昇格、assertion +5＝カバレッジ純増）
- 他の omit（sidekiq/webhook/nodeinfo/feed/seed）は harness? ゲートで同一挙動を維持
- standalone（非 harness）でも 0 failures を確認。listener の従来 silent fake-pass が可視 omission 化

残 omission は全て chubo2#63/#64 で追跡する env/seed gap。

Refs #4447

🤖 Generated with [Claude Code](https://claude.com/claude-code)