### PR TITLE
feat: 投稿テンプレートの per-user CRUD API (#4457)

### DIFF
--- a/app/lib/mulukhiya/compose_template_container.rb
+++ b/app/lib/mulukhiya/compose_template_container.rb
@@ -27,40 +27,52 @@ module Mulukhiya
       return all.find {|v| v['id'].to_s == id.to_s}
     end
 
+    # 以下 3 メソッドは read-modify-write なので、多端末同時書き込みの lost update
+    # を防ぐため account 単位のロックで直列化する（保持中は 409、#4457/#4460）。
     def create(attributes)
-      templates = all
-      if templates.size >= MAX_COUNT
-        raise Ginseng::ConflictError, "テンプレートは最大 #{MAX_COUNT} 件までです。"
+      lock.synchronize(@account.id) do
+        templates = all
+        if templates.size >= MAX_COUNT
+          raise Ginseng::ConflictError, "テンプレートは最大 #{MAX_COUNT} 件までです。"
+        end
+        template = normalize(attributes).merge('id' => SecureRandom.uuid)
+        persist(templates + [template])
+        saved = find(template['id'])
+        raise Ginseng::GatewayError, 'テンプレートを保存できませんでした。' unless persisted?(saved, template)
+        next saved
       end
-      template = normalize(attributes).merge('id' => SecureRandom.uuid)
-      persist(templates + [template])
-      saved = find(template['id'])
-      raise Ginseng::GatewayError, 'テンプレートを保存できませんでした。' unless persisted?(saved, template)
-      return saved
     end
 
     def update(id, attributes)
-      templates = all
-      index = templates.index {|v| v['id'].to_s == id.to_s}
-      raise Ginseng::NotFoundError, "テンプレート '#{id}' が見つかりません。" unless index
-      template = normalize(attributes).merge('id' => id.to_s)
-      templates[index] = template
-      persist(templates)
-      saved = find(id)
-      raise Ginseng::GatewayError, 'テンプレートを保存できませんでした。' unless persisted?(saved, template)
-      return saved
+      lock.synchronize(@account.id) do
+        templates = all
+        index = templates.index {|v| v['id'].to_s == id.to_s}
+        raise Ginseng::NotFoundError, "テンプレート '#{id}' が見つかりません。" unless index
+        template = normalize(attributes).merge('id' => id.to_s)
+        templates[index] = template
+        persist(templates)
+        saved = find(id)
+        raise Ginseng::GatewayError, 'テンプレートを保存できませんでした。' unless persisted?(saved, template)
+        next saved
+      end
     end
 
     def delete(id)
-      templates = all
-      target = templates.find {|v| v['id'].to_s == id.to_s}
-      raise Ginseng::NotFoundError, "テンプレート '#{id}' が見つかりません。" unless target
-      persist(templates.reject {|v| v['id'].to_s == id.to_s})
-      raise Ginseng::GatewayError, 'テンプレートを削除できませんでした。' if find(id)
-      return target
+      lock.synchronize(@account.id) do
+        templates = all
+        target = templates.find {|v| v['id'].to_s == id.to_s}
+        raise Ginseng::NotFoundError, "テンプレート '#{id}' が見つかりません。" unless target
+        persist(templates.reject {|v| v['id'].to_s == id.to_s})
+        raise Ginseng::GatewayError, 'テンプレートを削除できませんでした。' if find(id)
+        next target
+      end
     end
 
     private
+
+    def lock
+      return @lock ||= ComposeTemplateLockStorage.new
+    end
 
     def user_config
       return @account.user_config

--- a/app/lib/mulukhiya/compose_template_container.rb
+++ b/app/lib/mulukhiya/compose_template_container.rb
@@ -1,0 +1,91 @@
+module Mulukhiya
+  # 投稿テンプレート（定形投稿）の per-user CRUD (#4457, pooza/capsicum#767)。
+  # 保存先は user_config の `/compose/templates`（モロヘイヤ自身の Redis・db 1）で、
+  # `/tagging/user_tags`・`/decoration/saved_state` と同じ per-user storage の系譜。
+  #
+  # UserConfig#update が例外を握りつぶす（`rescue => e; e.alert`）ため、書き込み後に
+  # read-back で永続化を検証し、失敗時は GatewayError を上げて capsicum に返す。
+  # これが専用エンドポイントにした主目的＝「保存したのに消えた」を検知可能にする点。
+  class ComposeTemplateContainer
+    include Package
+
+    # 1 アカウントあたりの上限。user_config への書き込みは Redis SAVE（同期・全体
+    # ブロッキング）を伴うため、青天井の blob をサーバー側で止める (#4457)。
+    MAX_COUNT = 50
+    # 保存・出力で保持するフィールド。`id` はサーバー採番なので照合対象に含めない。
+    FIELDS = %w[name body cw].freeze
+
+    def initialize(account)
+      @account = account
+    end
+
+    def all
+      return Array(user_config['/compose/templates']).select {|v| v.is_a?(Hash)}
+    end
+
+    def find(id)
+      return all.find {|v| v['id'].to_s == id.to_s}
+    end
+
+    def create(attributes)
+      templates = all
+      if templates.size >= MAX_COUNT
+        raise Ginseng::ConflictError, "テンプレートは最大 #{MAX_COUNT} 件までです。"
+      end
+      template = normalize(attributes).merge('id' => SecureRandom.uuid)
+      persist(templates + [template])
+      saved = find(template['id'])
+      raise Ginseng::GatewayError, 'テンプレートを保存できませんでした。' unless persisted?(saved, template)
+      return saved
+    end
+
+    def update(id, attributes)
+      templates = all
+      index = templates.index {|v| v['id'].to_s == id.to_s}
+      raise Ginseng::NotFoundError, "テンプレート '#{id}' が見つかりません。" unless index
+      template = normalize(attributes).merge('id' => id.to_s)
+      templates[index] = template
+      persist(templates)
+      saved = find(id)
+      raise Ginseng::GatewayError, 'テンプレートを保存できませんでした。' unless persisted?(saved, template)
+      return saved
+    end
+
+    def delete(id)
+      templates = all
+      target = templates.find {|v| v['id'].to_s == id.to_s}
+      raise Ginseng::NotFoundError, "テンプレート '#{id}' が見つかりません。" unless target
+      persist(templates.reject {|v| v['id'].to_s == id.to_s})
+      raise Ginseng::GatewayError, 'テンプレートを削除できませんでした。' if find(id)
+      return target
+    end
+
+    private
+
+    def user_config
+      return @account.user_config
+    end
+
+    def normalize(attributes)
+      attributes = attributes.transform_keys(&:to_s)
+      cw = attributes['cw'].to_s
+      return {
+        'name' => attributes['name'].to_s,
+        'body' => attributes['body'].to_s,
+        'cw' => cw.empty? ? nil : cw,
+      }
+    end
+
+    # nil の cw は保存時に deep_compact で除去されるため、read-back の照合はフィールド
+    # 単位（アクセサ経由・欠落キーは nil を返し expected の nil と一致）で行う。
+    # 空文字列の body は deep_compact で保持されるので照合を通る。
+    def persisted?(saved, expected)
+      return false unless saved
+      return FIELDS.all? {|k| saved[k] == expected[k]}
+    end
+
+    def persist(templates)
+      user_config.update(compose: {templates: templates})
+    end
+  end
+end

--- a/app/lib/mulukhiya/contract/compose_template_contract.rb
+++ b/app/lib/mulukhiya/contract/compose_template_contract.rb
@@ -1,0 +1,20 @@
+module Mulukhiya
+  # 投稿テンプレート (#4457) の作成・更新の入力検証。`name` は必須・非空、`body` は
+  # 必須だが空文字は許容（capsicum の設計で「本文だけ空のテンプレ」を認める）、
+  # `cw` は任意。件数上限は状態依存のため ComposeTemplateContainer 側で検証する。
+  class ComposeTemplateContract < Contract
+    MAX_NAME_SIZE = 100
+    MAX_BODY_SIZE = 5000
+    MAX_CW_SIZE = 200
+
+    params do
+      required(:name).value(:string, max_size?: MAX_NAME_SIZE)
+      required(:body).value(:string, max_size?: MAX_BODY_SIZE)
+      optional(:cw).maybe(:string, max_size?: MAX_CW_SIZE)
+    end
+
+    rule(:name) do
+      key.failure('テンプレート名が空欄です。') if value.to_s.strip.empty?
+    end
+  end
+end

--- a/app/lib/mulukhiya/controller/api_controller.rb
+++ b/app/lib/mulukhiya/controller/api_controller.rb
@@ -56,6 +56,74 @@ module Mulukhiya
       return @renderer.to_s
     end
 
+    # 投稿テンプレート（定形投稿）の per-user CRUD (#4457, pooza/capsicum#767)。
+    # 保存先は user_config の `/compose/templates`。書き込み結果は
+    # ComposeTemplateContainer が read-back で検証し、失敗時は 5xx を返す。
+    get '/compose/templates' do
+      raise Ginseng::AuthError, 'Unauthorized' unless sns.account
+      @renderer.message = {templates: ComposeTemplateContainer.new(sns.account).all}
+      return @renderer.to_s
+    rescue => e
+      e.log
+      @renderer.status = e.status
+      @renderer.message = {error: e.message}
+      return @renderer.to_s
+    end
+
+    post '/compose/templates' do
+      raise Ginseng::AuthError, 'Unauthorized' unless sns.account
+      errors = ComposeTemplateContract.new.exec(params)
+      if errors.present?
+        @renderer.status = 422
+        @renderer.message = {errors:}
+        return @renderer.to_s
+      end
+      container = ComposeTemplateContainer.new(sns.account)
+      template = container.create(params)
+      @renderer.message = {template:, templates: container.all}
+      return @renderer.to_s
+    rescue => e
+      # 上限超過 (409) 等の想定内クライアントエラーは log に留め、保存失敗 (5xx) だけ
+      # alert する（想定内 4xx で Sentry を汚さない）。
+      e.status < 500 ? e.log : e.alert
+      @renderer.status = e.status
+      @renderer.message = {error: e.message}
+      return @renderer.to_s
+    end
+
+    put '/compose/templates/:id' do
+      raise Ginseng::AuthError, 'Unauthorized' unless sns.account
+      errors = ComposeTemplateContract.new.exec(params)
+      if errors.present?
+        @renderer.status = 422
+        @renderer.message = {errors:}
+        return @renderer.to_s
+      end
+      container = ComposeTemplateContainer.new(sns.account)
+      template = container.update(params[:id], params)
+      @renderer.message = {template:, templates: container.all}
+      return @renderer.to_s
+    rescue => e
+      e.status < 500 ? e.log : e.alert
+      @renderer.status = e.status
+      @renderer.message = {error: e.message}
+      return @renderer.to_s
+    end
+
+    delete '/compose/templates/:id' do
+      raise Ginseng::AuthError, 'Unauthorized' unless sns.account
+      container = ComposeTemplateContainer.new(sns.account)
+      template = container.delete(params[:id])
+      @renderer.message = {template:, templates: container.all}
+      return @renderer.to_s
+    rescue => e
+      # 既に削除済み (404) は race で起こる想定内。log に留める。
+      e.status < 500 ? e.log : e.alert
+      @renderer.status = e.status
+      @renderer.message = {error: e.message}
+      return @renderer.to_s
+    end
+
     post '/mastodon/auth' do
       raise Ginseng::NotFoundError, 'Not Found' unless Environment.mastodon_type?
       errors = MastodonAuthContract.new.exec(params)

--- a/app/lib/mulukhiya/dynamic_features.rb
+++ b/app/lib/mulukhiya/dynamic_features.rb
@@ -8,6 +8,10 @@ module Mulukhiya
   #                        が稼働可能か (= サーバーが annict? を満たすか)。#4342 未デプロイの
   #                        バージョンではキー自体が無く capsicum は false 判定できる (#4433)。
   #                        capsicum の review 投稿ボタン出し分けに使う (pooza/capsicum#677)
+  #   - compose_templates : 投稿テンプレート CRUD `/compose/templates` (#4457) が使えるか。
+  #                        サーバー設定を要さず、デプロイされていれば常に利用可能なので
+  #                        presence ベース (true 固定)。未デプロイのバージョンではキー自体が
+  #                        無く capsicum は false 判定して導線を出さない (pooza/capsicum#767)
   #   - media_catalog    : /{controller}/data 配下の機能フラグ。discovery を features
   #                        に一本化するため合流 (#4343)
   #   - program_editable : 番組表エディタ (livecure かつ auto_update 無効) で書き込み
@@ -31,6 +35,7 @@ module Mulukhiya
     REGISTRY = {
       'annict_linked' => ->(sns) {sns.account&.annict_linked? || false},
       'annict_review' => ->(_sns) {Environment.controller_class.annict?},
+      'compose_templates' => ->(_sns) {true},
       'media_catalog' => ->(_sns) {Environment.controller_class.media_catalog?},
       'program_editable' => lambda {|_sns|
         Environment.controller_class.livecure? && !Program.instance.auto_update?

--- a/app/lib/mulukhiya/storage/compose_template_lock_storage.rb
+++ b/app/lib/mulukhiya/storage/compose_template_lock_storage.rb
@@ -1,0 +1,68 @@
+require 'securerandom'
+
+module Mulukhiya
+  # 投稿テンプレート CRUD の per-account 書き込み直列化ロック (#4457, #4460)。
+  # 保存は user_config への read-modify-write（`all` → 配列編集 → `persist`）で
+  # 非原子的なため、多端末同時書き込みで lost update が起こりうる（Codex P2）。
+  # account 単位でロックを取り、保持中の競合は 409 (ConflictError) で即返して
+  # クライアントに再取得 → 再試行させる（テンプレ CRUD は低頻度なのでキューイング
+  # しない）。Redis 障害時はロックを諦めて実行を阻害しない (fail-open)。
+  class ComposeTemplateLockStorage < Redis
+    # TTL 切れで自然解放後に別リクエストが同一 key を acquire したケースで、遅延
+    # release が他者の新ロックを消さないよう compare-and-delete する。
+    RELEASE_SCRIPT = <<~LUA.freeze
+      if redis.call('GET', KEYS[1]) == ARGV[1] then
+        return redis.call('DEL', KEYS[1])
+      else
+        return 0
+      end
+    LUA
+
+    # ロック保持の TTL 秒。テンプレ CRUD は一瞬で完了するため短くてよい。
+    # 定数にして config ルックアップを持たない（存在しないパスは ConfigError を
+    # raise し、acquire の rescue に飲まれてロックが黙って無効化される footgun を
+    # 避けるため。rescue は Redis 障害のみを対象に保つ）。
+    LOCK_TTL_SECONDS = 10
+
+    # account 単位で block を直列化して実行する。保持中は ConflictError(409)。
+    def synchronize(account_id)
+      token = acquire(account_id)
+      begin
+        return yield
+      ensure
+        release(account_id, token) if token
+      end
+    end
+
+    def ttl
+      return LOCK_TTL_SECONDS
+    end
+
+    private
+
+    # SET key value NX EX ttl で原子的に獲得。獲得できれば token を返す。
+    # 他者保有中は ConflictError。Redis 障害時は fail-open で nil を返す
+    # （nil の間はロック無しで実行され、release も走らない）。
+    def acquire(account_id)
+      key = create_key(lock_key(account_id))
+      token = SecureRandom.uuid
+      return token if redis.call('SET', key, token, 'NX', 'EX', ttl) == 'OK'
+      raise Ginseng::ConflictError, '別の更新が進行中です。少し待って再試行してください。'
+    rescue Ginseng::ConflictError
+      raise
+    rescue => e
+      e.log(account_id:)
+      return nil
+    end
+
+    def release(account_id, token)
+      redis.call('EVAL', RELEASE_SCRIPT, 1, create_key(lock_key(account_id)), token)
+    rescue => e
+      e.log(account_id:)
+    end
+
+    def lock_key(account_id)
+      return ['compose_template_lock', account_id].join(':')
+    end
+  end
+end

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -681,6 +681,7 @@ user_config:
     - annict
     - service
     - piefed
+    - compose
   redis:
     dsn: redis://localhost:6379/1
 webhook:

--- a/test/contract/compose_template_contract.rb
+++ b/test/contract/compose_template_contract.rb
@@ -1,0 +1,27 @@
+module Mulukhiya
+  class ComposeTemplateContractTest < TestCase
+    def setup
+      @contract = ComposeTemplateContract.new
+    end
+
+    def test_call
+      assert_empty(@contract.call(name: '実況開始', body: 'はじまるよ').errors)
+      assert_empty(@contract.call(name: 'CW あり', body: '本文', cw: '注意').errors)
+      # body の空文字は許容（本文だけ空のテンプレを認める）。
+      assert_empty(@contract.call(name: '空本文', body: '').errors)
+      # cw は任意（欠落・nil 許容）。
+      assert_empty(@contract.call(name: 'x', body: 'y', cw: nil).errors)
+
+      # name 必須・非空（空白のみも rule で弾く）。
+      assert_false(@contract.call(body: 'y').errors.empty?)
+      assert_false(@contract.call(name: '', body: 'y').errors.empty?)
+      assert_false(@contract.call(name: '  ', body: 'y').errors.empty?)
+      # body 必須。
+      assert_false(@contract.call(name: 'x').errors.empty?)
+      # 各上限超過。
+      assert_false(@contract.call(name: 'a' * (ComposeTemplateContract::MAX_NAME_SIZE + 1), body: 'y').errors.empty?)
+      assert_false(@contract.call(name: 'x', body: 'a' * (ComposeTemplateContract::MAX_BODY_SIZE + 1)).errors.empty?)
+      assert_false(@contract.call(name: 'x', body: 'y', cw: 'a' * (ComposeTemplateContract::MAX_CW_SIZE + 1)).errors.empty?)
+    end
+  end
+end

--- a/test/unit/lib/compose_template_container.rb
+++ b/test/unit/lib/compose_template_container.rb
@@ -92,6 +92,21 @@ module Mulukhiya
       end
     end
 
+    # 別リクエストがロック保持中は 409 で弾き、lost update を防ぐ（#4457/#4460）。
+    def test_write_conflicts_while_locked
+      lock = ComposeTemplateLockStorage.new
+      token = lock.send(:acquire, account.id)
+      begin
+        assert_raise(Ginseng::ConflictError) do
+          @container.create(name: 'x', body: 'y')
+        end
+      ensure
+        lock.send(:release, account.id, token)
+      end
+      # 解放後は通常どおり作成できる。
+      assert(@container.create(name: 'x', body: 'y')['id'].present?)
+    end
+
     def test_max_count
       templates = Array.new(ComposeTemplateContainer::MAX_COUNT) do |i|
         {'id' => SecureRandom.uuid, 'name' => "t#{i}", 'body' => 'x'}

--- a/test/unit/lib/compose_template_container.rb
+++ b/test/unit/lib/compose_template_container.rb
@@ -1,0 +1,107 @@
+module Mulukhiya
+  class ComposeTemplateContainerTest < TestCase
+    def disable?
+      return true unless account
+      return super
+    end
+
+    def setup
+      return if disable?
+      @container = ComposeTemplateContainer.new(account)
+      account.user_config.update(compose: nil)
+    end
+
+    def teardown
+      return if disable?
+      account.user_config.update(compose: nil)
+    end
+
+    def test_empty
+      assert_equal([], @container.all)
+      assert_nil(@container.find('nonexistent'))
+    end
+
+    def test_create
+      template = @container.create(name: '実況開始', body: 'はじまるよ')
+
+      assert(template['id'].present?)
+      assert_equal('実況開始', template['name'])
+      assert_equal('はじまるよ', template['body'])
+      assert_nil(template['cw'])
+      assert_equal(1, @container.all.size)
+      assert_equal(template, @container.find(template['id']))
+    end
+
+    def test_create_assigns_unique_id
+      a = @container.create(name: 'a', body: 'a')
+      b = @container.create(name: 'b', body: 'b')
+
+      assert_not_equal(a['id'], b['id'])
+      assert_equal(2, @container.all.size)
+    end
+
+    def test_create_with_cw
+      template = @container.create(name: 'CW あり', body: '本文', cw: '注意書き')
+
+      assert_equal('注意書き', template['cw'])
+      assert_equal('注意書き', @container.find(template['id'])['cw'])
+    end
+
+    def test_create_blank_cw_becomes_nil
+      template = @container.create(name: '空 CW', body: '本文', cw: '')
+
+      assert_nil(template['cw'])
+    end
+
+    def test_create_empty_body_is_allowed
+      template = @container.create(name: '空本文', body: '')
+
+      assert_equal('', template['body'])
+      assert_equal('', @container.find(template['id'])['body'])
+    end
+
+    def test_update
+      template = @container.create(name: '旧', body: '旧本文')
+      updated = @container.update(template['id'], name: '新', body: '新本文', cw: 'CW')
+
+      assert_equal(template['id'], updated['id'])
+      assert_equal('新', updated['name'])
+      assert_equal('新本文', updated['body'])
+      assert_equal('CW', updated['cw'])
+      assert_equal(1, @container.all.size)
+      assert_equal('新本文', @container.find(template['id'])['body'])
+    end
+
+    def test_update_not_found
+      assert_raise(Ginseng::NotFoundError) do
+        @container.update('nonexistent', name: 'x', body: 'y')
+      end
+    end
+
+    def test_delete
+      template = @container.create(name: '消す', body: '本文')
+
+      assert_equal(template, @container.delete(template['id']))
+      assert_equal([], @container.all)
+      assert_nil(@container.find(template['id']))
+    end
+
+    def test_delete_not_found
+      assert_raise(Ginseng::NotFoundError) do
+        @container.delete('nonexistent')
+      end
+    end
+
+    def test_max_count
+      templates = Array.new(ComposeTemplateContainer::MAX_COUNT) do |i|
+        {'id' => SecureRandom.uuid, 'name' => "t#{i}", 'body' => 'x'}
+      end
+      account.user_config.update(compose: {templates:})
+
+      assert_equal(ComposeTemplateContainer::MAX_COUNT, @container.all.size)
+      assert_raise(Ginseng::ConflictError) do
+        @container.create(name: 'over', body: 'x')
+      end
+    end
+  end
+end

--- a/test/unit/lib/dynamic_features.rb
+++ b/test/unit/lib/dynamic_features.rb
@@ -2,9 +2,9 @@ module Mulukhiya
   class DynamicFeaturesTest < TestCase
     def test_registry_keys
       assert_equal(
-        ['annict_linked', 'annict_review', 'media_catalog', 'program_editable',
-          'word_suggest', 'nowplaying_resolver', 'nowplaying_url_resolver',
-          'spotify_enabled', 'spotify_linked'].to_set,
+        ['annict_linked', 'annict_review', 'compose_templates', 'media_catalog',
+          'program_editable', 'word_suggest', 'nowplaying_resolver',
+          'nowplaying_url_resolver', 'spotify_enabled', 'spotify_linked'].to_set,
         DynamicFeatures::REGISTRY.keys.to_set,
       )
     end


### PR DESCRIPTION
## 概要

capsicum の投稿テンプレート（定形投稿・pooza/capsicum#767）の保存先として、端末をまたいで共有できる per-user CRUD API を新設する。#4457 の実装。

## エンドポイント

```
GET    /mulukhiya/api/compose/templates        一覧 {templates:[...]}
POST   /mulukhiya/api/compose/templates        作成（id サーバー採番）
PUT    /mulukhiya/api/compose/templates/:id    更新
DELETE /mulukhiya/api/compose/templates/:id    削除
```

- 認証: `sns.account` ガード（既存の per-user 書き込み系に倣う）
- 保存先: `user_config` の `/compose/templates`（自身の Redis db 1）。`/tagging/user_tags`・`/decoration/saved_state` と同じ per-user storage の系譜
- データモデル: `id` / `name` / `body` / `cw` の4フィールド（capsicum #767 の確定設計。末尾ハッシュタグ・公開範囲・並び順は持たない）

## 設計上のポイント

- **書き込み後 read-back で永続化を検証**（`ComposeTemplateContainer#persisted?`）。`UserConfig#update` が例外を握りつぶす（`rescue => e; e.alert`）ため、そのままでは保存失敗を検知できない。専用エンドポイントにした主目的がこれ（「保存したのに消えた」を capsicum に返せるようにする）。失敗時は `GatewayError`（5xx）
- **件数上限 50**。`user_config` への書き込みは Redis `SAVE`（同期・全体ブロッキング）を伴うため、青天井の blob をサーバー側で止める。超過は `ConflictError`（409）
- **想定内 4xx は Sentry alert せず log**（上限 409・not found 404）。5xx（保存失敗）のみ alert
- `cw` 空文字→nil / 空 body 許容。nil の cw は保存時に `deep_compact` で除去されるため、read-back 照合はフィールド単位（アクセサ経由・nil 同士一致）で行う
- `valid_keys` に `compose` を追加（`clean` 掃除で消えないように）
- `DynamicFeatures` に `compose_templates`（presence ベース true）。未デプロイのバージョンではキー自体が無く、capsicum は false 判定して導線を出さない（#4433 `annict_review` と同じ probing）

## テスト

`test/unit/lib/compose_template_container.rb` — CRUD・id 一意・cw/空body・上限 409 の round-trip。

> ⚠️ 実装マシンの bundle が壊れており（`faye-websocket-ruby` の git gem パス欠落）ローカルでテスト実行できていません。**ステージングでの検証が必要**です。レビュー後に調整修正が入る可能性があります。

関連: pooza/capsicum#767

🤖 Generated with [Claude Code](https://claude.com/claude-code)
