### PR TITLE
fix: nginx サンプルの status_put_backend を本番の実態に戻す (#4469)

### DIFF
--- a/config/sample/mastodon/mulukhiya.nginx
+++ b/config/sample/mastodon/mulukhiya.nginx
@@ -7,8 +7,11 @@ map "${request_method}:${http_x_mulukhiya}" $media_put_backend {
   "~^PUT:$"  http://localhost:3008;
   default    http://localhost:3000;
 }
+# PUT /api/v1/statuses/:id（ステータス編集）は、モロヘイヤが自分の用途を
+# X-Mulukhiya-Purpose で名乗った場合だけ通す。名乗りの無い素の編集要求は
+# reject に落として 405 を返す（下の location 参照）。
 map "${request_method}:${http_x_mulukhiya}" $status_put_backend {
-  "~^PUT:$"  http://localhost:3008;
+  "~^PUT:$"  reject;
   default    http://localhost:3000;
 }
 
@@ -28,6 +31,12 @@ location ~ ^/api/v[0-9]+/media/[0-9]+$ {
 }
 location ~ ^/api/v[0-9]+/statuses/[0-9]+$ {
   include /path/to/mulukhiya_proxy.conf;
+  if ($http_x_mulukhiya_purpose != '') {
+    proxy_pass http://localhost:3008;
+  }
+  if ($status_put_backend = reject) {
+    return 405;
+  }
   proxy_pass $status_put_backend;
 }
 location = /api/v1/timelines/public {


### PR DESCRIPTION
Close #4469

## 問題

`config/sample/mastodon/mulukhiya.nginx` の `$status_put_backend` が本番の実態と食い違っていた。サンプルどおりに構築すると、`X-Mulukhiya-Purpose` を伴わない `PUT /api/v1/statuses/:id`（ステータス編集）が **405 で弾かれず、モロヘイヤへ素通しされる**。

| | `"~^PUT:$"` | 405 ガード |
| --- | --- | --- |
| サンプル（修正前） | `http://localhost:3008` | 無し |
| lbock / zugoga / shallu | `reject` | 有り |
| フォーク `dist/servers/*.conf`（curesta / delmulin） | — | 有り |

## 原因

8aeda04f「chore: nginx サンプルを簡素化し 5.8.0 ステータスを更新」(2026-03-16)。`X-Mulukhiya-Purpose` 分岐を map のキーから外す意図だったが、その際に `"~^PUT::$" → reject` が `"~^PUT:$" → http://localhost:3008` に化け、`return 405` も一緒に消えた。

**本番はこの簡素化を取り込んでおらず**、Purpose 判定を map のキーから `if` に移した形で旧設計のまま動いている。サンプルだけが取り残されていた。

## 検証

正規化して機械的に突き合わせ、map・location とも本番 (zugoga の `00-mulukhiya-maps.conf` / lbock の vhost) と一致することを確認した。

```
=== status_put_backend map: サンプル vs 本番 ===   ✅ 一致
=== statuses/:id location: サンプル vs 本番 vhost === ✅ 一致
```

## 経緯

キュアスタ！の lbock → gomander 移行（pooza/chubo2#68）の棚卸しで発見。gomander では map ファイルを新規作成する必要があり、vhost 本体はフォークの `dist/servers/` を symlink するので正しい版が入るが、**map はこのサンプルを見て作る**ことになるため、このままだと本番と挙動が変わるところだった。

🤖 Generated with [Claude Code](https://claude.com/claude-code)