### PR TITLE
fix: Purpose 付き PUT が 405 になる nginx サンプルを直す (#4474)

### DIFF
--- a/config/sample/mastodon/mulukhiya.nginx
+++ b/config/sample/mastodon/mulukhiya.nginx
@@ -7,12 +7,17 @@ map "${request_method}:${http_x_mulukhiya}" $media_put_backend {
   "~^PUT:$"  http://localhost:3008;
   default    http://localhost:3000;
 }
-# PUT /api/v1/statuses/:id（ステータス編集）は、モロヘイヤが自分の用途を
-# X-Mulukhiya-Purpose で名乗った場合だけ通す。名乗りの無い素の編集要求は
-# reject に落として 405 を返す（下の location 参照）。
-map "${request_method}:${http_x_mulukhiya}" $status_put_backend {
-  "~^PUT:$"  reject;
-  default    http://localhost:3000;
+# PUT /api/v1/statuses/:id（ステータス編集）は、用途を X-Mulukhiya-Purpose で
+# 名乗った場合だけモロヘイヤへ通す。名乗りの無い素の編集要求は reject に落として
+# 405 を返す（下の location 参照）。
+#
+# 判定は必ず map のキー側で行う。location に if を 2 つ並べて振り分けようとすると、
+# proxy_pass はコンテンツフェーズのハンドラを登録するだけで rewrite フェーズを
+# 終端しないため、後続の if の return が勝って Purpose 付きまで 405 になる (#4474)。
+map "${request_method}:${http_x_mulukhiya}:${http_x_mulukhiya_purpose}" $status_put_backend {
+  "~^PUT::.+"  http://localhost:3008;
+  "~^PUT::$"   reject;
+  default      http://localhost:3000;
 }
 
 # === server context に追加 ===
@@ -31,9 +36,6 @@ location ~ ^/api/v[0-9]+/media/[0-9]+$ {
 }
 location ~ ^/api/v[0-9]+/statuses/[0-9]+$ {
   include /path/to/mulukhiya_proxy.conf;
-  if ($http_x_mulukhiya_purpose != '') {
-    proxy_pass http://localhost:3008;
-  }
   if ($status_put_backend = reject) {
     return 405;
   }


### PR DESCRIPTION
Close #4474

## 問題

`X-Mulukhiya-Purpose: media_update` を付けた **capsicum の ALT 編集リクエストが、本番 3 台で 405 になっていた**（実機で確認）。

```console
$ curl -o /dev/null -w "%{http_code}\n" -X PUT https://precure.ml/api/v1/statuses/1 \
    -H "X-Mulukhiya-Purpose: media_update" -H "Authorization: Bearer <dummy>"
405
$ curl -o /dev/null -w "%{http_code}\n" -X PUT https://mstdn.delmulin.com/api/v1/statuses/1 \
    -H "X-Mulukhiya-Purpose: media_update" -H "Authorization: Bearer <dummy>"
405
```

`docs/api.md` が「nginx が Purpose ヘッダの有無でルーティングするため、クライアントはこの値を指定する」と書いている経路が塞がっていた。コントローラ側の実装は正しく、リクエストが到達していないだけ。

## 原因

`location` に `if` を 2 つ並べていた。

```nginx
if ($http_x_mulukhiya_purpose != '') { proxy_pass http://localhost:3008; }
if ($status_put_backend = reject)    { return 405; }
proxy_pass $status_put_backend;
```

1 つ目の `proxy_pass` は**コンテンツフェーズのハンドラを登録するだけで rewrite フェーズを終端しない**ので、2 つ目の `if` が評価され `return` が勝つ。かつ map のキーが `"${request_method}:${http_x_mulukhiya}"` で **Purpose を見ていない**ため、外部 PUT は Purpose の有無にかかわらず `reject` に落ちる。

8aeda04f「nginx サンプルを簡素化」(2026-03-16) が Purpose 分岐を map のキーから外した際に壊れた。#4470 は「サンプルが本番と乖離している」として本番の形へ合わせたが、**合わせた先の本番の形自体が壊れていた**。

## 対応

8aeda04f 以前の **3 キー map + `if` 1 つ**へ戻す。`if` が 1 つになるので競合しない。

## 検証（nginx 1.29 コンテナ・スタブバックエンド）

修正後:

| ケース | 期待 | 実測 |
| --- | --- | --- |
| 外部 PUT + Purpose あり | モロヘイヤ | ✅ 200 `MULUKHIYA` |
| 外部 PUT + Purpose なし | 405 | ✅ 405 |
| 内部 PUT (`X-Mulukhiya`) | Mastodon | ✅ 200 `MASTODON` |
| GET | Mastodon | ✅ 200 `MASTODON` |

同じ環境で**壊れた形（2 キー map + `if` 2 つ）を再現**させると、Purpose あり でも **405** になることも確認した。

## 本番への適用

本 PR はサンプルのみ。実サーバーの適用は別途。

- **lbock** — gomander 移行 (pooza/chubo2#68) で新しい設定を組むので自然に解消する
- **zugoga / shallu** — `servers/00-mulukhiya-maps.conf` の差し替えと nginx reload が要る

🤖 Generated with [Claude Code](https://claude.com/claude-code)