### PR TITLE
ci: Ruby バージョンを .ruby-version から読むようにする

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 4.0.5
+          ruby-version: .ruby-version
       - name: apt install
         run: |
           sudo apt update


### PR DESCRIPTION
## 概要

`.github/workflows/test.yml` が `ruby-version: 4.0.5` をハードコードしており、リポジトリの `.ruby-version`（4.0.6）と乖離していた。CI だけ古い Ruby で回っている状態だったため、`ruby/setup-ruby` にファイルパスを渡す形に変えてピンの二重管理をなくす。

```diff
-          ruby-version: 4.0.5
+          ruby-version: .ruby-version
```

`ruby/setup-ruby` は `ruby-version` にバージョン文字列だけでなく `.ruby-version` などのファイルパスを指定でき、その内容を読んでセットアップする。以後 `.ruby-version` を上げれば CI も自動で追従する。

## 確認

- 本 PR の CI（mastodon / misskey の両 matrix）が 4.0.6 で緑になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)