### PR TITLE
fix: 出荷設定から localhost を排除する (#4481, #4490)

### DIFF
--- a/config/application.yaml
+++ b/config/application.yaml
@@ -382,7 +382,7 @@ misskey:
   dbms: postgres
   display_name: Misskey
   redis:
-    dsn: redis://localhost:6379/0
+    dsn: redis://127.0.0.1:6379/0 # localhost にしないこと (#4481)
   features:
     annict: true
     announcement: true
@@ -498,6 +498,11 @@ puma:
   threads: 5
   workers: 0
 redis:
+  # DSN のホストは 127.0.0.1 を既定にする。localhost にすると、/etc/hosts に
+  # `::1 localhost` を持たないホストで Happy Eyeballs v2 が AAAA の決着を待ち、
+  # 1 接続あたり 305ms を払う (#4481)。ホスト名を書きたい場合は、そのホストが
+  # A / AAAA の両方を files から引けることを docs/bench/probe_localhost_connect.rb
+  # で確認すること。
   retry:
     limit: 3
     seconds: 1
@@ -629,7 +634,7 @@ sidekiq:
   logger:
     level: 1 # info
   redis:
-    dsn: redis://localhost:6379/2
+    dsn: redis://127.0.0.1:6379/2 # localhost にしないこと (#4481)
   schedule:
     annict_polling:
       class: Mulukhiya::AnnictPollingWorker
@@ -688,7 +693,7 @@ user_config:
     - piefed
     - compose
   redis:
-    dsn: redis://localhost:6379/1
+    dsn: redis://127.0.0.1:6379/1 # localhost にしないこと (#4481)
 webhook:
   sample: |
     あんなの、戦いのうちに入らないわ。

--- a/config/sample/mastodon/mulukhiya.nginx
+++ b/config/sample/mastodon/mulukhiya.nginx
@@ -1,11 +1,27 @@
+# バックエンドは 127.0.0.1 で書く。localhost に戻さないこと。
+#
+# proxy_pass のホスト名は設定読み込み時に解決され、解決された全アドレスが
+# 暗黙の upstream になる。/etc/hosts に 127.0.0.1 と ::1 の両方がある一方で
+# モロヘイヤも Mastodon の puma も IPv4 でしか listen しないため、約半分の確率で
+# ::1 を選んで必ず Connection refused になる。平常時は「片方失敗 → もう片方で
+# 成功」で 200 が返るので気づけないが、負荷時は ::1 が fail_timeout の間 down
+# 扱いのままとなり、127.0.0.1 側も backlog 溢れで一度 refused になった瞬間に
+# 全ピア down ＝ nginx が無条件に 502 を返す（本番実測 refused 1 万件/日超）。
+#
+# /etc/hosts の `::1 localhost` を消す方向で直してはいけない。Ruby 3.4+ の
+# Happy Eyeballs v2 対策として必須で、無いと localhost への接続 1 回につき
+# 305ms を払う (#4481)。参照側を 127.0.0.1 にするのが解。
+# 単一ピアの upstream では nginx は max_fails / fail_timeout を無視するため、
+# ピア down 判定そのものが起きなくなる。
+
 # === http context に追加 ===
 map $http_x_mulukhiya $mulukhiya_backend {
-  default http://localhost:3008;
-  "~.+"   http://localhost:3000;
+  default http://127.0.0.1:3008;
+  "~.+"   http://127.0.0.1:3000;
 }
 map "${request_method}:${http_x_mulukhiya}" $media_put_backend {
-  "~^PUT:$"  http://localhost:3008;
-  default    http://localhost:3000;
+  "~^PUT:$"  http://127.0.0.1:3008;
+  default    http://127.0.0.1:3000;
 }
 # PUT /api/v1/statuses/:id（ステータス編集）は、用途を X-Mulukhiya-Purpose で
 # 名乗った場合だけモロヘイヤへ通す。名乗りの無い素の編集要求は reject に落として
@@ -15,9 +31,9 @@ map "${request_method}:${http_x_mulukhiya}" $media_put_backend {
 # proxy_pass はコンテンツフェーズのハンドラを登録するだけで rewrite フェーズを
 # 終端しないため、後続の if の return が勝って Purpose 付きまで 405 になる (#4474)。
 map "${request_method}:${http_x_mulukhiya}:${http_x_mulukhiya_purpose}" $status_put_backend {
-  "~^PUT::.+"  http://localhost:3008;
+  "~^PUT::.+"  http://127.0.0.1:3008;
   "~^PUT::$"   reject;
-  default      http://localhost:3000;
+  default      http://127.0.0.1:3000;
 }
 
 # === server context に追加 ===
@@ -43,7 +59,7 @@ location ~ ^/api/v[0-9]+/statuses/[0-9]+$ {
 }
 location = /api/v1/timelines/public {
   if ($arg_local !~* ^(true|t|1|on)$) {
-    proxy_pass http://localhost:3000;
+    proxy_pass http://127.0.0.1:3000;
   }
   if ($arg_local ~* ^(true|t|1|on)$) {
     return 302 /api/v1/timelines/tag/your_default_hashtag?max_id=$arg_max_id;
@@ -51,13 +67,13 @@ location = /api/v1/timelines/public {
 }
 location ^~ /mulukhiya {
   include /path/to/mulukhiya_proxy.conf;
-  proxy_pass http://localhost:3008;
+  proxy_pass http://127.0.0.1:3008;
 }
 location ^~ /mulukhiya/sidekiq {
   allow YOUR_IP_OR_CIDR;
   deny all;
   include /path/to/mulukhiya_proxy.conf;
-  proxy_pass http://localhost:3008;
+  proxy_pass http://127.0.0.1:3008;
 }
 location ^~ /nodeinfo {
   include /path/to/mulukhiya_proxy.conf;

--- a/config/sample/misskey/mulukhiya.nginx
+++ b/config/sample/misskey/mulukhiya.nginx
@@ -1,7 +1,23 @@
+# バックエンドは 127.0.0.1 で書く。localhost に戻さないこと。
+#
+# proxy_pass のホスト名は設定読み込み時に解決され、解決された全アドレスが
+# 暗黙の upstream になる。/etc/hosts に 127.0.0.1 と ::1 の両方がある一方で
+# モロヘイヤも Misskey も IPv4 でしか listen しないため、約半分の確率で ::1 を
+# 選んで必ず Connection refused になる。平常時は「片方失敗 → もう片方で成功」
+# で 200 が返るので気づけないが、負荷時は ::1 が fail_timeout の間 down 扱いの
+# ままとなり、127.0.0.1 側も backlog 溢れで一度 refused になった瞬間に全ピア
+# down ＝ nginx が無条件に 502 を返す（本番実測 refused 1 万件/日超）。
+#
+# /etc/hosts の `::1 localhost` を消す方向で直してはいけない。Ruby 3.4+ の
+# Happy Eyeballs v2 対策として必須で、無いと localhost への接続 1 回につき
+# 305ms を払う (#4481)。参照側を 127.0.0.1 にするのが解。
+# 単一ピアの upstream では nginx は max_fails / fail_timeout を無視するため、
+# ピア down 判定そのものが起きなくなる。
+
 # === http context に追加 ===
 map $http_x_mulukhiya $mulukhiya_backend {
-  default http://localhost:3008;
-  "~.+"   http://localhost:3000;
+  default http://127.0.0.1:3008;
+  "~.+"   http://127.0.0.1:3000;
 }
 
 # === server context に追加 ===
@@ -25,13 +41,13 @@ location ~ ^/api/notes/drafts/update$ {
 }
 location ^~ /mulukhiya {
   include /path/to/mulukhiya_proxy.conf;
-  proxy_pass http://localhost:3008;
+  proxy_pass http://127.0.0.1:3008;
 }
 location ^~ /mulukhiya/sidekiq {
   allow YOUR_IP_OR_CIDR;
   deny all;
   include /path/to/mulukhiya_proxy.conf;
-  proxy_pass http://localhost:3008;
+  proxy_pass http://127.0.0.1:3008;
 }
 location ^~ /nodeinfo {
   include /path/to/mulukhiya_proxy.conf;


### PR DESCRIPTION
出荷設定の既定が `localhost` であることに起因する 2 つの地雷を、参照側を `127.0.0.1` に寄せて塞ぐ。

Closes #4481
Closes #4490

## なぜ 2 件まとめてか

症状は逆方向（片や 305ms の遅延、片や 502）だが、**原因は同じ「出荷設定に書かれた `localhost`」**で、しかも**片方を素朴に直すともう片方が悪化する**関係にある（`/etc/hosts` から `::1` を消せば nginx の 502 は止まるが Ruby 側が 305ms を払い始める）。方向を揃えて 1 回で入れる。

## 変更

| ファイル | 変更 |
| --- | --- |
| `config/application.yaml` | 既定 Redis DSN 3 箇所を `redis://127.0.0.1:...` へ (#4481) |
| `config/sample/mastodon/mulukhiya.nginx` | `proxy_pass` 9 箇所 (#4490) |
| `config/sample/misskey/mulukhiya.nginx` | `proxy_pass` 4 箇所 (#4490) |

あわせて **「なぜ `localhost` ではだめか」「`::1` を消す方向で直してはいけない」** を各ファイルの冒頭コメントに書いた（#4490 の要件。書かないと親切心で戻される）。

## 裏付け

#4464 の計装（2026-08-02 のニチアサ実況、gomander）で確定した数字:

- 処理内容の変わっていない `spoiler` / `user_config_command` が **0.652s / 0.632s → 0.026s / 0.023s**。lbock でのこの値は ≒ 305ms × 接続 2 回だった
- 投稿の総所要 p50 は **4.8s → 1.1s**、1 秒超の割合は 89% → 61%

nginx 側は本番実測で refused が gomander 15,700 件/日・shallu 10,987 件/日。

## テスト

- `bundle exec rake lint` 通過（rubocop / erb-lint / slim-lint / bundler-audit）
- `bundle exec rake test` 808 tests, 0 failures, 0 errors
- `ruby bin/test.rb config` 11 tests, 0 failures

## 本番への波及（別途・インフラ側）

本番 4 台の `local.yaml` は Postgres DSN に `postgres://...@localhost:6432/...` を使っている（gomander で確認）。**現状は実害なし**（pooza/chubo2#87 で `::1 localhost` がレシピ保証されたため）だが、同じ地雷の残り。pooza/chubo2#105 へ申し送る。
