### PR TITLE
perf: タグハンドラの無駄な再評価と辞書の重複構築をやめる (#4494, #4482)

### DIFF
--- a/app/lib/mulukhiya/handler.rb
+++ b/app/lib/mulukhiya/handler.rb
@@ -251,6 +251,15 @@ module Mulukhiya
       return @reporter.tags
     end
 
+    # 同一イベントの全ハンドラで TaggingDictionary を共有する (#4482)。
+    # 構築は Redis GET + Marshal.load（実辞書 725KB）で、投稿ごとに何度も
+    # 払うようなものではない。@params は Event#handlers が全ハンドラへ渡す
+    # 同一の Hash なので、メモ化のスコープは 1 イベント＝1 投稿に閉じる。
+    def dictionary
+      @params[:tagging_dictionary] ||= TaggingDictionary.new
+      return @params[:tagging_dictionary]
+    end
+
     def self.create(name, params = {})
       return "Mulukhiya::#{name.to_s.sub(/_handler$/, '').camelize}Handler".constantize.new(params)
     rescue => e
@@ -358,6 +367,7 @@ module Mulukhiya
     end
 
     def initialize(params = {})
+      @params = params
       @result = Concurrent::Array.new
       @errors = Concurrent::Array.new
       @sns = params[:sns] || sns_class.new

--- a/app/lib/mulukhiya/handler/dictionary_tag_handler.rb
+++ b/app/lib/mulukhiya/handler/dictionary_tag_handler.rb
@@ -6,7 +6,7 @@ module Mulukhiya
     end
 
     def addition_tags
-      return TaggingDictionary.new.matches(flatten_payload)
+      return dictionary.matches(flatten_payload)
     end
 
     def without_kanji_pattern

--- a/app/lib/mulukhiya/handler/remote_tag_handler.rb
+++ b/app/lib/mulukhiya/handler/remote_tag_handler.rb
@@ -6,22 +6,39 @@ module Mulukhiya
 
     def addition_tags
       text = flatten_payload
-      dic = TaggingDictionary.new
+      matched = all.select {|remote| text.match?(remote[:pattern])}
+      tags = Concurrent::Array.new
+      tags.concat(matched.flat_map {|remote| remote[:tags]})
+      # 辞書はリモートから返ってきたタグを絞り込むためだけに使う。照会が 1 件も
+      # 起きない投稿（自サーバー宛だけに一致した場合を含む）では作らない (#4482)。
+      remotes = matched.reject {|remote| own_service?(remote)}
+      tags.concat(search_remote_tags(remotes, text)) if remotes.present?
+      return TagContainer.new(tags.uniq)
+    end
+
+    def search_remote_tags(remotes, text)
+      dic = dictionary
       local_tags = dic.matches(text)
       tags = Concurrent::Array.new
-      Parallel.each(all, in_threads: Parallel.processor_count) do |remote|
-        next unless text.match?(remote[:pattern])
-        tags.concat(remote[:tags])
-        service = Ginseng::Fediverse::MulukhiyaService.new(remote[:url])
-        next if sns.uri.host == service.base_uri.host
-        remote_tags = service.search_hashtags(text)
-        tags.concat(remote_tags.reject do |v|
+      Parallel.each(remotes, in_threads: Parallel.processor_count) do |remote|
+        tags.concat(remote_service(remote).search_hashtags(text).reject do |v|
           dic.short?(v) || local_tags.member?(v) || dic.strict_key?(v)
         end)
       rescue => e
         e.log(remote:)
       end
-      return TagContainer.new(tags.uniq)
+      return tags
+    end
+
+    def remote_service(remote)
+      return Ginseng::Fediverse::MulukhiyaService.new(remote[:url])
+    end
+
+    def own_service?(remote)
+      return sns.uri.host == remote_service(remote).base_uri.host
+    rescue => e
+      e.log(remote:)
+      return false
     end
 
     def all(&block)

--- a/app/lib/mulukhiya/tag_handler.rb
+++ b/app/lib/mulukhiya/tag_handler.rb
@@ -1,12 +1,18 @@
 module Mulukhiya
   class TagHandler < Handler
+    # addition_tags / removal_tags は 1 回だけ評価してローカルに束ねる (#4494)。
+    # `result.push(addition_tags:)` の短縮記法は同名のローカルが無ければメソッド
+    # 呼び出しになるため、素直に書くと if の分と合わせて 1 投稿に 3 回走る。
+    # これらは純粋な getter ではなく Redis 読み・辞書スイープ・リモート照会を伴う。
     def handle_pre_toot(payload, params = {})
       self.payload = payload
       return unless executable?
-      tags.merge(addition_tags)
-      result.push(addition_tags:) if addition_tags.present?
-      removal_tags.each {|v| tags.delete(v)}
-      result.push(removal_tags:) if removal_tags.present?
+      addition = addition_tags
+      tags.merge(addition)
+      result.push(addition_tags: addition) if addition.present?
+      removal = removal_tags
+      removal.each {|v| tags.delete(v)}
+      result.push(removal_tags: removal) if removal.present?
     end
 
     def executable?

--- a/test/unit/handler/tag_handler_evaluation.rb
+++ b/test/unit/handler/tag_handler_evaluation.rb
@@ -1,0 +1,84 @@
+# ファイル名を `_handler` で終わらせないこと。TestCase.load は `*_handler` の
+# ケースを `Handler.create(name).disable?` でゲートするため、DB の無い環境
+# （CI を含む）ではファイルごと読み込まれず、この回帰テストが黙って走らなくなる。
+module Mulukhiya
+  class TagHandlerTest < TestCase
+    # 評価回数だけを数えるハンドラ。TagContainer は normalize で
+    # TaggingHandler.normalize_rules（DB）を引くため、ここでは素の Set を使って
+    # DB 非依存にする（CI でも走らせるため）。
+    class CountingTagHandler < TagHandler
+      attr_reader :addition_count, :removal_count
+
+      def initialize(params = {})
+        super
+        @addition_count = 0
+        @removal_count = 0
+      end
+
+      def executable?
+        return true
+      end
+
+      def addition_tags
+        @addition_count += 1
+        return Set['addition']
+      end
+
+      def removal_tags
+        @removal_count += 1
+        return Set['removal']
+      end
+    end
+
+    # params は Event#handlers が全ハンドラへ渡す同一の Hash に相当する。
+    # 共有のスコープを検証するため、新しい Hash を作らず渡された物を使う。
+    def create_handler(params = {})
+      params[:sns] ||= Struct.new(:account).new(nil)
+      params[:reporter] ||= Struct.new(:tags).new(Set['removal'])
+      return CountingTagHandler.new(params)
+    end
+
+    # #4494 の回帰テスト。`result.push(addition_tags:)` の短縮記法が同名の
+    # ローカルが無ければメソッド呼び出しになるため、素直に書くと if の分と
+    # 合わせて 1 投稿につき 3 回ずつ評価されていた。これらは純粋な getter では
+    # なく Redis 読み・辞書スイープ・リモート照会を伴う。
+    def test_handle_pre_toot_evaluates_tags_once
+      handler = create_handler
+      handler.handle_pre_toot(status_field => 'プリキュア')
+
+      assert_equal(1, handler.addition_count)
+      assert_equal(1, handler.removal_count)
+    end
+
+    def test_handle_pre_toot_applies_tags
+      handler = create_handler
+      handler.handle_pre_toot(status_field => 'プリキュア')
+
+      assert_equal(Set['addition'], handler.tags)
+      assert_equal([{addition_tags: Set['addition']}, {removal_tags: Set['removal']}], handler.result.to_a)
+    end
+
+    def test_handle_pre_toot_skips_when_not_executable
+      handler = create_handler
+      def handler.executable?
+        return false
+      end
+      handler.handle_pre_toot(status_field => 'プリキュア')
+
+      assert_equal(0, handler.addition_count)
+      assert_equal(0, handler.removal_count)
+    end
+
+    # #4482 の回帰テスト。TaggingDictionary は 1 イベント＝1 投稿の中で
+    # 全ハンドラが共有する（Event#handlers が同一の params を全ハンドラへ渡す）。
+    def test_dictionary_is_shared_within_event
+      params = {}
+      handler = create_handler(params)
+      other = create_handler(params)
+      params[:tagging_dictionary] = Set['sentinel']
+
+      assert_same(params[:tagging_dictionary], handler.dictionary)
+      assert_same(handler.dictionary, other.dictionary)
+    end
+  end
+end


### PR DESCRIPTION
2026-08-02 のニチアサ実況（#4464）で残った投稿レイテンシ 1.1 秒の内訳を削る。

Closes #4494
Closes #4482

## 何が起きていたか

**1 投稿あたり `TaggingDictionary` が 6 回作られていた。**

| 原因 | 詳細 |
| --- | --- |
| #4494 | `TagHandler#handle_pre_toot` が `addition_tags` / `removal_tags` を**それぞれ 3 回ずつ**評価。`result.push(addition_tags:)` の短縮記法は同名のローカルが無ければメソッド呼び出しになるため、`if` の分と合わせて 3 回 |
| #4482 | `dictionary_tag` と `remote_tag` が**それぞれ独立に**辞書を構築（3 × 2 = 6） |

`addition_tags` は純粋な getter ではなく、**Redis GET + `Marshal.load`（実辞書 725KB）+ 全語スイープ**を伴う。

## 変更

1. **1 回だけ評価してローカルに束ねる**（`tag_handler.rb`）。`addition_tags` の全実装（dictionary / remote / user / group / media / default / removal_rule）を確認したが、いずれも payload・アカウント・設定から値を作るだけで、複数回呼ばれることに依存した副作用は無い
2. **`TaggingDictionary` をイベント内で共有する**（`Handler#dictionary`）。`Event#handlers` が全ハンドラへ同じ `params` を渡すので、そこにメモ化すればスコープは 1 イベント＝1 投稿に閉じる
3. **`RemoteTagHandler` は照会が発生する投稿でだけ辞書を作る**。辞書はリモートから返ってきたタグの絞り込みにしか使わないのに、無条件に構築していた。キュアスタ！では設定の 2 件が「自分自身（自己スキップ）」か「本文に一致しない」のどちらかなので、**常に全額無駄**だった

## 見込み

08-02 実況の実測（ハンドラ平均秒）からの試算:

| handler | 現状 | 見込み |
| --- | --- | --- |
| dictionary_tag | 0.457 | 約 0.15（3 回 → 1 回） |
| remote_tag | 0.454 | ほぼ 0（辞書を作らない） |
| user_tag | 0.073 | 約 0.024 |
| group_tag | 0.006 | 約 0.002 |

**合計 0.99 秒 → 0.18 秒程度**。実測は次のニチアサ（08-09）に計装で確認する。

## テスト

新規 `test/unit/handler/tag_handler_evaluation.rb`。修正前の実装に戻すと `test_handle_pre_toot_evaluates_tags_once` が `<1> expected but was <3>` で落ちることを確認済み。

⚠ **ファイル名を `_handler` で終わらせていない。** `TestCase.load` は `*_handler` のケースを `Handler.create(name).disable?` でゲートしており、`Handler.create` は DB 不在だと nil を返すため、**DB の無い CI ではファイルごと読み込まれず黙って走らなくなる**。理由はファイル冒頭にも書いた。

- `bundle exec rake lint` 通過
- `bundle exec rake test` **812 tests, 1088 assertions, 0 failures, 0 errors**（追加分 4 件が CI でも走る）
