### PR TITLE
fix: 番組表エディタのチェックボックスが潰れて消える (#4483)

### DIFF
--- a/views/default.sass
+++ b/views/default.sass
@@ -1012,10 +1012,14 @@ a:hover
     margin: 0
   input.short
     width: 10em
+  // 幅を与えたうえで縮小を止める。上の `input, select` が flex-grow: 1 を
+  // 付けているためチェックボックスも flex item になり、幅指定なしで
+  // flex-shrink: 1 だと行が詰まったときに 0 幅まで潰れて消える (#4483)。
   input[type="checkbox"]
     margin:
       left: 0.5em
-    flex-shrink: 1
+    width: 1.5em
+    flex-shrink: 0
   label
     display: flex
     gap: 0.5em


### PR DESCRIPTION
`.inline-field-container` の `input[type="checkbox"]` だけ幅指定が無いまま `flex-shrink: 1` が付いている。同じセレクタ配下の `input, select` が `flex-grow: 1` を与えるためチェックボックスも flex item になり、行が詰まると 0 幅まで潰れて消える。

同 sass 内の他 2 箇所（`:873`、`:970`）のチェックボックス指定は `width: 1.5em` を持っていて潰れない。**この非対称が退行の出どころ**という #4483 の見立てに沿って、幅を与えたうえで `flex-shrink: 0` にした。

Refs #4483

## ⚠ 目視確認は未了

CSS の退行なので自動テストでは検出できない。**ステージング (dev25) の番組表エディタで「エア番組」「実況対象」「有効」が実際に表示されることを確認するまで #4483 は open のままにする**（5.30.0 のステージング検証で踏む）。確認できたらクローズする。