### PR TITLE
fix: 一覧表の ✔ を Font Awesome アイコンにする (#4483)

### DIFF
--- a/views/program.slim
+++ b/views/program.slim
@@ -154,11 +154,14 @@ html lang='ja' data-theme='light'
                   small v-if='entry.minutes'
                     | {{entry.minutes}}分
                 td
-                  span.tag.air v-if='entry.air' ✔
+                  span.tag.air v-if='entry.air'
+                    i class='fa fa-check'
                 td
-                  span.tag.livecure v-if='entry.livecure' ✔
+                  span.tag.livecure v-if='entry.livecure'
+                    i class='fa fa-check'
                 td
-                  span.tag.enable v-if='entry.enable' ✔
+                  span.tag.enable v-if='entry.enable'
+                    i class='fa fa-check'
                 td.actions
                   button.small.danger @click.stop='deleteEntry(key)' v-if='editable' v-tooltip.top="'削除'"
                     i class='fa fa-trash'


### PR DESCRIPTION
番組表エディタの一覧表で「エア番組」「実況」「有効」の ✔ が出ない環境がある。素の U+2714 (HEAVY CHECK MARK) を UI の状態表示に使っていたのが原因。

Closes #4483

## 切り分け

**サーバー側は白**。以下を実測で確認した。

- HTML に `<span class="tag air" v-if="entry.air">✔</span>` が正しく入っている（本番 gomander / dev25 の双方）
- API は真偽値を正しく返す（`"air":false,"livecure":true,"enable":true`）
- CSS / JS は公開 URL 経由でも全て 200（nginx 経路も白）
- `.tag` にはどのスタイルも当たっていない（`.status nav.footer-navigations .tag` にスコープ済み）。Pico にも Font Awesome にも `.tag` の規則は無い
- `views/program.slim` は 2026-06-09 以降変更なし。CDN の Pico も 2.1.1（2025-03 公開）で動いていない

**同じサーバー・同じバージョンで、Mac では出るが Debian のブラウザでは出ない**ことをユーザーが確認。原因はクライアント側のグリフ選択にある。

Debian 13 側の状況（実機調査）:

- U+2714 を持つフォントは 136 個あり、fontconfig 自体は `DejaVu Sans` を選ぶ
- `fonts-noto-color-emoji` 2.051 が導入済み。新しい Noto Color Emoji は COLRv1 で、U+2714 のような「絵文字にもなれる記号」がそちらへ回ると描画されず空白になりうる

## 対応

番組表エディタは既に Font Awesome を読み込んでいる（`fa-plus` / `fa-calendar` / `fa-copy` / `fa-trash`）。同じ webfont に寄せればプラットフォームに依存しない。

```diff
-span.tag.air v-if='entry.air' ✔
+span.tag.air v-if='entry.air'
+  i class='fa fa-check'
```

環境側（fontconfig で U+2714 を DejaVu Sans に固定）でも回避できるが、番組表エディタは Mac からも開かれるため、**アプリ側で確実に描くほうを採った**。

## 検証

dev25 に載せて、**症状が出ていた当の Debian 機で正常表示を確認済み**（ユーザー確認）。

## 補足

`views/default.sass` の `.inline-field-container input[type="checkbox"]`（`width` + `flex-shrink: 0`、PR #4496）は当初この症状の原因と見立てて入れたものだが、**原因ではなかった**。同 sass 内の他 2 箇所と揃える整合修正としては妥当なので残す。