### PR TITLE
feat: health に Ruby ランタイム情報を含める (#4466)

### DIFF
--- a/app/lib/mulukhiya/environment.rb
+++ b/app/lib/mulukhiya/environment.rb
@@ -188,9 +188,44 @@ module Mulukhiya
       values[dbms_name.to_sym] = "Mulukhiya::#{dbms_name.camelize}".constantize.health
       values[:streaming] = ListenerDaemon.health if daemon_classes.member?(ListenerDaemon)
       values[:misskey_redis] = MisskeyService.sns_redis_health if misskey_type?
+      values[:ruby] = ruby_health
       values[:status] = 503 if values.values.any? {|v| v[:status] == 'NG'}
       values[:status] ||= 200
       return values
+    end
+
+    # ランタイムの能力欠落を検知する (#4466)。YJIT は Rust の無い環境では
+    # ビルド時に黙って外れ、エラーにならないまま 24〜25% 遅いサーバーが
+    # 出来上がる。全台の /health を叩く運用が既にあるので、そこへ出す。
+    def self.ruby_health
+      enabled = yjit_enabled?
+      return {
+        version: RUBY_VERSION,
+        yjit_available: defined?(RubyVM::YJIT) ? true : false,
+        yjit_enabled: enabled,
+        status: ruby_status(enabled),
+      }
+    end
+
+    def self.yjit_enabled?
+      return false unless defined?(RubyVM::YJIT)
+      return RubyVM::YJIT.enabled? == true
+    end
+
+    # 既定では情報として出すだけで NG にしない。能力の欠落は障害ではなく、
+    # health が 503 になるとサーバーが「停止」扱いになるため。
+    # 確実に検知したいサーバーは /runtime/require_yjit で opt-in する。
+    #
+    # config の参照を rescue で握り潰さないこと。既定値は application.yaml が
+    # 必ず持つので、引けない状態は設定の破損であり黙って無効化してはいけない
+    # (MEMORY feedback_fail-open-guard-footgun)。
+    def self.ruby_status(yjit_enabled)
+      return 'NG' if require_yjit? && !yjit_enabled
+      return 'OK'
+    end
+
+    def self.require_yjit?
+      return config['/runtime/require_yjit'] == true
     end
   end
 end

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -506,6 +506,10 @@ redis:
   retry:
     limit: 3
     seconds: 1
+runtime:
+  # true にすると YJIT が有効でないサーバーの /health を NG (503) にする (#4466)。
+  # 既定は false ＝ health には情報として出すだけ。
+  require_yjit: false
 sentry:
   dsn: null
   traces_sample_rate: 0

--- a/config/schema/base.yaml
+++ b/config/schema/base.yaml
@@ -374,6 +374,13 @@ properties:
       schedule:
         type: object
     type: object
+  runtime:
+    properties:
+      require_yjit:
+        type: boolean
+    required:
+      - require_yjit
+    type: object
   sentry:
     properties:
       dsn:

--- a/docs/api.md
+++ b/docs/api.md
@@ -437,9 +437,14 @@ Web Push サブスクリプションを解除する。
   "sidekiq": {"status": "OK"},
   "streaming": {"status": "OK"},
   "postgres": {"status": "OK"},
+  "ruby": {"version": "4.0.6", "yjit_available": true, "yjit_enabled": true, "status": "OK"},
   "status": 200
 }
 ```
+
+**`ruby` は構成乖離の検知用** (#4466)。YJIT は Rust の無い環境ではビルド時に黙って外れ、エラーにならないまま 24〜25% 遅いサーバーが出来上がるため、能力を可視化する。
+
+**既定では `status` が `NG` になることはない**（能力の欠落は障害ではなく、health が 503 になるとサーバーが「停止」扱いになるため）。確実に検知したいサーバーは `/runtime/require_yjit` を `true` にすると、YJIT が有効でない場合に `NG`（＝全体 503）になる。
 
 **WARN を含むレスポンス例**（プール枯渇を検出した場合）:
 

--- a/test/unit/lib/environment_runtime.rb
+++ b/test/unit/lib/environment_runtime.rb
@@ -1,0 +1,40 @@
+module Mulukhiya
+  # ランタイムの能力欠落を health で検知する (#4466)。
+  #
+  # ガードが「実際に NG を返す」ことを正のテストで押さえる。config を
+  # rescue で握り潰す実装だとアサーションが黙って無効化されるため
+  # (MEMORY feedback_fail-open-guard-footgun)。
+  class EnvironmentRuntimeTest < TestCase
+    def teardown
+      super
+      config.reload
+    end
+
+    def test_ruby_health_shape
+      health = Environment.ruby_health
+
+      assert_equal(RUBY_VERSION, health[:version])
+      assert_boolean(health[:yjit_available])
+      assert_boolean(health[:yjit_enabled])
+      assert_include(['OK', 'NG'], health[:status])
+    end
+
+    # 既定は情報として出すだけ。能力の欠落で health を 503 にはしない。
+    def test_ruby_status_is_informational_by_default
+      config['/runtime/require_yjit'] = false
+
+      assert_equal('OK', Environment.ruby_status(false))
+      assert_equal('OK', Environment.ruby_status(true))
+      assert_false(Environment.require_yjit?)
+    end
+
+    # opt-in したサーバーでは実際に NG になる。
+    def test_ruby_status_is_ng_when_yjit_required_but_missing
+      config['/runtime/require_yjit'] = true
+
+      assert_true(Environment.require_yjit?)
+      assert_equal('NG', Environment.ruby_status(false))
+      assert_equal('OK', Environment.ruby_status(true))
+    end
+  end
+end


### PR DESCRIPTION
サーバーごとにランタイムの能力が食い違っていても誰も気づけない状態を解消する。

Closes #4466

## 背景

**YJIT は Rust がないとビルド時に黙って外れる。**エラーにならないので、能力を欠いたサーバーが完成し、そのまま本番投入されうる。2026-07-20 の調査では gomander がまさにその状態になりかけていた（`raw_cpu` で 24〜25% の差）。

全台の `/health` を叩く運用が既にあるので、そこへ出せば一目で分かる。

## レスポンス

```json
{
  "redis": {"status": "OK"},
  "sidekiq": {"status": "OK"},
  "postgres": {"status": "OK"},
  "ruby": {"version": "4.0.6", "yjit_available": true, "yjit_enabled": true, "status": "OK"},
  "status": 200
}
```

## 設計

**既定では NG にしない。** 能力の欠落は障害ではなく、health が 503 になるとサーバーが「停止」扱いになる。確実に検知したいサーバーは `/runtime/require_yjit: true` で opt-in すると、YJIT が有効でない場合に `NG`（＝全体 503）になる。

**config 参照を fail-open にしていない。** 既定値は `config/application.yaml` が必ず持つので、引けない状態は設定の破損であり、`rescue` で握り潰すとアサーションが黙って無効化される（MEMORY `feedback_fail-open-guard-footgun` と同じ罠）。判定は `Environment.ruby_status(yjit_enabled)` に切り出し、**「実際に NG を返す」正のテスト**を置いた。

## Issue からの変更点

Issue の案は判定条件を `yjit_available` にしていたが、**`yjit_enabled` を見るようにした**。運用上の関心は「積まれているか」ではなく「実際に効いているか」で、enabled は available を含意するため判定としては強い側になる。

## テスト

`test/unit/lib/environment_runtime.rb`（新規）

- レスポンスの形
- 既定では `require_yjit?` が false で、YJIT 無しでも `OK`
- opt-in すると YJIT 無しで **`NG` を返す**（ガードが実際にブロックすることの正テスト）

`bundle exec rake lint` 通過 / `bundle exec rake test` **816 tests, 1101 assertions, 0 failures, 0 errors**

## 発展（本 PR のスコープ外）

`StartupNotificationWorker` にも載せれば起動時点で気づける。chubo2#69 は rbenv レシピ側で Rust を前提化してビルド直後にアサートする対応で、2026-07-31 にクローズ済み。