### PR TITLE
security: remote fetch のリダイレクト各ホップを SSRF allowlist に通す (#4410)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-core.git
-  revision: 4b134cebaf80c6ba0267363d5f729b59bdaf6c36
+  revision: 88ae6d500e5ff5273e35c6f2b0d1e3d4643e5e95
   branch: main
   specs:
-    ginseng-core (1.15.28)
+    ginseng-core (1.15.29)
       activesupport (>= 7.0.7.1)
       addressable (>= 2.9.0)
       cgi (>= 0.4.2)

--- a/app/lib/mulukhiya/program_fetcher.rb
+++ b/app/lib/mulukhiya/program_fetcher.rb
@@ -56,7 +56,7 @@ module Mulukhiya
       success = 0
       uris.each do |v|
         next unless valid_content_length?(v)
-        response = @http.get(v, timeout: fetch_timeout)
+        response = @http.get(v, timeout: fetch_timeout, host_validator: RemoteHost.validator)
         next unless valid_response_size?(response, v)
         parsed = response.parsed_response
         next unless valid_program_schema?(parsed, v)

--- a/app/lib/mulukhiya/pronunciation_dictionary.rb
+++ b/app/lib/mulukhiya/pronunciation_dictionary.rb
@@ -159,7 +159,7 @@ module Mulukhiya
 
     def fetch_one(uri)
       return nil unless valid_content_length?(uri)
-      response = @http.get(uri, timeout: fetch_timeout)
+      response = @http.get(uri, timeout: fetch_timeout, host_validator: RemoteHost.validator)
       return nil unless valid_response_size?(response, uri)
       parsed = response.parsed_response
       return nil unless valid_schema?(parsed, uri)

--- a/app/lib/mulukhiya/remote_host.rb
+++ b/app/lib/mulukhiya/remote_host.rb
@@ -35,6 +35,21 @@ module Mulukhiya
       return false
     end
 
+    # Ginseng::HTTP#get の host_validator へ渡す callable (#4410)。
+    # リダイレクトの各ホップがこれを通る。
+    #
+    # ⚠ writer はテストの差し替え専用。実行時に緩めてはいけない。差し替えた
+    # テストは teardown で必ず元へ戻すこと（残すと以後のテストで SSRF ガードが
+    # 効かなくなり、守れているつもりの緑になる）。
+    def self.validator
+      @validator ||= ->(host) {public?(host)}
+      return @validator
+    end
+
+    class << self
+      attr_writer :validator
+    end
+
     # Addrinfo.getaddrinfo は timeout を持てず、攻撃者が応答を引き延ばす権威
     # DNS を立てると Sinatra リクエストスレッド (Puma 5 本) を飽和させられる。
     # Resolv::DNS#timeouts= で 1 回あたりの解決待ちを上限化する。タイムアウト

--- a/test/unit/lib/program_fetcher_ssrf.rb
+++ b/test/unit/lib/program_fetcher_ssrf.rb
@@ -1,0 +1,57 @@
+require 'webmock/test_unit'
+
+module Mulukhiya
+  # 番組表・読み辞書の remote fetch が、リダイレクト先まで含めて SSRF allowlist を
+  # 通ることの回帰テスト (#4410)。
+  #
+  # 初段のホストだけ検証しても HTTParty がリダイレクトを追ってしまうため、
+  # 「見せかけの安全」になっていた。検証は Ginseng::HTTP の host_validator が
+  # 各ホップで行う（ginseng-core 1.15.29）。
+  class ProgramFetcherSsrfTest < TestCase
+    GAS = 'https://script.google.com/macros/s/deadbeef/exec'.freeze
+    GAS_CONTENT = 'https://script.googleusercontent.com/macros/echo'.freeze
+    METADATA = 'http://169.254.169.254/latest/meta-data/'.freeze
+
+    def setup
+      WebMock.disable_net_connect!
+      @http = HTTP.new
+    end
+
+    def teardown
+      super
+      WebMock.reset!
+      WebMock.allow_net_connect!
+    end
+
+    def validator(*allowed)
+      return ->(host) {allowed.include?(host)}
+    end
+
+    # GAS は正規に 302 を返す。追従を切ると番組表の取得自体が壊れる。
+    def test_follows_legitimate_gas_redirect
+      stub_request(:get, GAS).to_return(status: 302, headers: {'Location' => GAS_CONTENT})
+      stub_request(:get, GAS_CONTENT).to_return(status: 200, body: '{"a":{}}')
+
+      response = @http.get(GAS, host_validator: validator('script.google.com', 'script.googleusercontent.com'))
+
+      assert_equal(200, response.code)
+    end
+
+    # リダイレクト先が内部ホストなら、そこへ実リクエストを出さずに落とす。
+    def test_blocks_redirect_to_link_local_metadata
+      stub_request(:get, GAS).to_return(status: 302, headers: {'Location' => METADATA})
+
+      assert_raise(Ginseng::GatewayError) do
+        @http.get(GAS, host_validator: validator('script.google.com'))
+      end
+      assert_not_requested(:get, METADATA)
+    end
+
+    # RemoteHost.validator が実際に内部アドレスを弾く callable であること。
+    def test_remote_host_validator_rejects_private_address
+      assert_false(RemoteHost.validator.call('127.0.0.1'))
+      assert_false(RemoteHost.validator.call('localhost'))
+      assert_false(RemoteHost.validator.call(''))
+    end
+  end
+end

--- a/test/unit/lib/pronunciation_dictionary.rb
+++ b/test/unit/lib/pronunciation_dictionary.rb
@@ -108,6 +108,10 @@ module Mulukhiya
       return if disable?
       url = 'https://dic.test/pron.json'
       original_urls = config['/word_suggest/urls']
+      # fetch は SSRF allowlist を通る (#4410)。`.test` は解決できず fail-closed で
+      # 弾かれるため、ここでは検証を通す callable に差し替える（teardown で復元）。
+      original_validator = RemoteHost.validator
+      RemoteHost.validator = ->(_host) {true}
       config['/word_suggest/urls'] = [url]
       stub_request(:head, url).to_return(status: 200)
       stub_request(:get, url).to_return(
@@ -125,6 +129,7 @@ module Mulukhiya
       assert_equal('相生', PronunciationDictionary.new.suggest('あいおい').first[:surface])
     ensure
       config['/word_suggest/urls'] = original_urls if defined?(original_urls)
+      RemoteHost.validator = original_validator if defined?(original_validator)
     end
   end
 end


### PR DESCRIPTION
`PronunciationDictionary` / `ProgramFetcher` の remote fetch が、**リダイレクト先の検証なしに追従していた**のを塞ぐ。

Closes #4410

## なぜ「初段だけ検証」では足りないか

HTTParty は既定でリダイレクトを追従する。呼び出し側で初段のホストだけ `RemoteHost.public?` に通しても、**リダイレクト先は素通り**で "見せかけの安全" にしかならない。

かといって `follow_redirects: false` で一律に追従を切ると壊れる。**番組表・読み辞書の実体は Google Apps Script で、正規に 302 を返す**:

```
https://precure.ml/api/dic/v1/precure.json
  → 302 → https://script.google.com/macros/s/.../exec
  → 302 → https://script.googleusercontent.com/macros/echo → 200
```

「追従はするが各ホップを検証する」は呼び出し側では書けないので、HTTP 層＝ ginseng-core に入れた（pooza/ginseng-core#487、1.15.29）。

## 変更

```ruby
@http.get(uri, timeout: fetch_timeout, host_validator: RemoteHost.validator)
```

- `Ginseng::HTTP#get` が `host_validator` を受け取ると、リダイレクトを自前で追い、**各ホップのホストを検証**する（ホップ上限 8、相対 Location も解決）
- 検証は `repeat` の外。中に置くと拒否した相手を `retry_limit` 回叩き直す
- `host_validator` を渡さない既定の経路は従来どおり
- `RemoteHost.validator` の writer は**テストの差し替え専用**。実行時に緩めない旨をコメントで明記

## ⚠ 既存テストが 1 件落ちた（ガードが正しく効いた結果）

`PronunciationDictionaryTest#test_cold_cache_returns_empty_and_defers_fill_to_worker` が `https://dic.test/pron.json` を使っており、**`.test` は解決できないため fail-closed で弾かれる**。WebMock で HTTP は差し替わるが、SSRF 検証は実 DNS を引くため通らない。

当該テストだけ validator を差し替え、`ensure` で復元するようにした。**差し替えを残すと以後のテストで SSRF ガードが効かなくなり「守れているつもりの緑」になる**ため、復元は必須。

## テスト

`test/unit/lib/program_fetcher_ssrf.rb`（新規）

- GAS の正規リダイレクトは追従して 200
- リダイレクト先が link-local メタデータ（169.254.169.254）なら **実リクエストを出さずに** `GatewayError`
- `RemoteHost.validator` が内部アドレス・非解決ホストを弾く

ginseng-core 側にも WebMock ベースの回帰テスト 6 件（各ホップ許可 / 内部ホスト拒否 / 初段拒否 / 相対 Location / ループ / validator 無し）。

`bundle exec rake lint` 通過 / `bundle exec rake test` **819 tests, 1106 assertions, 0 failures, 0 errors**