### PR TITLE
obs/並行性: 5.29.0 レビュー黄まとめ 4 件を是正 (#4461)

### DIFF
--- a/app/lib/mulukhiya/compose_template_container.rb
+++ b/app/lib/mulukhiya/compose_template_container.rb
@@ -30,7 +30,7 @@ module Mulukhiya
     # 以下 3 メソッドは read-modify-write なので、多端末同時書き込みの lost update
     # を防ぐため account 単位のロックで直列化する（保持中は 409、#4457/#4460）。
     def create(attributes)
-      lock.synchronize(@account.id) do
+      synchronize do
         templates = all
         raise Ginseng::ConflictError, "テンプレートは最大 #{MAX_COUNT} 件までです。" if templates.size >= MAX_COUNT
         template = normalize(attributes).merge('id' => SecureRandom.uuid)
@@ -42,7 +42,7 @@ module Mulukhiya
     end
 
     def update(id, attributes)
-      lock.synchronize(@account.id) do
+      synchronize do
         templates = all
         index = templates.index {|v| v['id'].to_s == id.to_s}
         raise Ginseng::NotFoundError, "テンプレート '#{id}' が見つかりません。" unless index
@@ -56,7 +56,7 @@ module Mulukhiya
     end
 
     def delete(id)
-      lock.synchronize(@account.id) do
+      synchronize do
         templates = all
         target = templates.find {|v| v['id'].to_s == id.to_s}
         raise Ginseng::NotFoundError, "テンプレート '#{id}' が見つかりません。" unless target
@@ -68,12 +68,24 @@ module Mulukhiya
 
     private
 
+    # ロックを取り、その内側で user_config を読み直してから block を実行する。
+    # @account.user_config はメモ化された UserConfig（構築時点の値のスナップショット）
+    # を返すため、ロック取得前に誰かがそれを参照していると、古い値の上で
+    # read-modify-write することになり lost update が黙って復活する。ロック内で
+    # fresh read を強制して構造的に防ぐ (#4461)。
+    def synchronize
+      lock.synchronize(@account.id) do
+        @user_config = UserConfig.new(@account)
+        next yield
+      end
+    end
+
     def lock
       return @lock ||= ComposeTemplateLockStorage.new
     end
 
     def user_config
-      return @account.user_config
+      return @user_config ||= @account.user_config
     end
 
     def normalize(attributes)
@@ -94,8 +106,14 @@ module Mulukhiya
       return FIELDS.all? {|k| saved[k] == expected[k]}
     end
 
+    # UserConfig#update は書き込み失敗を自前で alert して握りつぶすため、read-back
+    # 由来の GatewayError と合わせると Redis の一過性障害 1 回で alert が 2 発飛ぶ。
+    # ここは alert しない update! を使い、GatewayError に包み直して通知を controller
+    # の 1 本にまとめる。根因の例外は Exception#cause として Sentry に残る (#4461)。
     def persist(templates)
-      user_config.update(compose: {templates: templates})
+      user_config.update!(compose: {templates: templates})
+    rescue => e
+      raise Ginseng::GatewayError, "テンプレートを保存できませんでした。(#{e.class})"
     end
   end
 end

--- a/app/lib/mulukhiya/storage/compose_template_lock_storage.rb
+++ b/app/lib/mulukhiya/storage/compose_template_lock_storage.rb
@@ -18,11 +18,17 @@ module Mulukhiya
       end
     LUA
 
-    # ロック保持の TTL 秒。テンプレ CRUD は一瞬で完了するため短くてよい。
+    # ロック保持の TTL 秒。テンプレ CRUD 自体は一瞬で終わるが、TTL は「処理時間の
+    # 見積り」ではなく「Ruby 側がストールしてもロックを失わない余裕」で決める。
+    # GC・Redis の応答遅延で RMW の途中に TTL が切れると、ロック無しで書き込む
+    # 別リクエストが現れて lost update が黙って復活するため（確率は低いが検知も
+    # できない）。CRUD は低頻度で、プロセスが死んでロックが残っても待たされるのは
+    # 当人だけなので、Annict 系ロック（既定 30 秒）と同水準に揃える (#4461)。
+    #
     # 定数にして config ルックアップを持たない（存在しないパスは ConfigError を
     # raise し、acquire の rescue に飲まれてロックが黙って無効化される footgun を
     # 避けるため。rescue は Redis 障害のみを対象に保つ）。
-    LOCK_TTL_SECONDS = 10
+    LOCK_TTL_SECONDS = 30
 
     # account 単位で block を直列化して実行する。保持中は ConflictError(409)。
     def synchronize(account_id)

--- a/app/lib/mulukhiya/user_config.rb
+++ b/app/lib/mulukhiya/user_config.rb
@@ -21,15 +21,27 @@ module Mulukhiya
       return @values[key]
     end
 
+    # 設定を更新する。書き込みに失敗しても例外は伝播させず、alert して nil を返す
+    # （呼び出し側の多くはハンドラ・ワーカーの途中で、ここで落とすと投稿処理ごと
+    # 巻き添えになるため）。
+    #
+    # ⚠ 成否を自前で検証して通知する呼び出し側は update! を使うこと。両方が通知
+    # すると Redis の一過性障害 1 回で alert が 2 発飛ぶ (#4461)。
     def update(values)
+      return update!(values)
+    rescue => e
+      e.alert
+      return nil
+    end
+
+    # 失敗の扱いを呼び出し側へ委ねる版。alert せずそのまま raise する。
+    def update!(values)
       values.deep_stringify_keys!
       handle_user_tags(values)
       handle_decorations(values)
       values = encrypt(values)
       @storage.update(@account.id, values)
       @values = @storage[@account.id]
-    rescue => e
-      e.alert
     end
 
     def token

--- a/app/lib/mulukhiya/worker/startup_notification_worker.rb
+++ b/app/lib/mulukhiya/worker/startup_notification_worker.rb
@@ -3,6 +3,7 @@ module Mulukhiya
     sidekiq_options retry: false
 
     FAIL_THRESHOLD = 2
+    FAILURE_COUNT_KEY = 'startup_notification_failure_count'.freeze
 
     def disable?
       return true unless info_agent_service
@@ -10,7 +11,15 @@ module Mulukhiya
     end
 
     def perform(params = {})
-      health = Environment.health
+      notify(Environment.health)
+      clear_failure
+    rescue => e
+      notify_failure(e)
+    end
+
+    private
+
+    def notify(health)
       observed = extract_status(health)
       if notified?
         reported = previous_status || {}
@@ -24,11 +33,29 @@ module Mulukhiya
         save_status(observed)
         redis['startup_notified_pid'] = sidekiq_pid
       end
+    end
+
+    # このワーカー自身の失敗を扱う。log 止めにすると、ロジックエラー（#4448 の
+    # redis.incr 未定義 NoMethodError 等）でヘルス通知が止まったこと自体が無音に
+    # なる＝異常を知らせる仕組みが黙って死ぬ。かといって 5 分毎に alert すると
+    # 障害中は Sentry がスパム化するので、連続失敗の 1 回目だけ alert し、成功で
+    # 解除するデッドマンにする (#4461)。
+    #
+    # カウンタ更新自体が落ちる（Redis 全断）場合は log へ倒す。Redis の死は
+    # health/redis 側で観測されるため、ここで二重に鳴らす価値がない。
+    def notify_failure(error)
+      count = redis.incr(FAILURE_COUNT_KEY).to_i
+      count <= 1 ? error.alert : error.log(failures: count)
     rescue => e
+      error.log
       e.log
     end
 
-    private
+    def clear_failure
+      redis.del(FAILURE_COUNT_KEY)
+    rescue => e
+      e.log
+    end
 
     def notified?
       return redis['startup_notified_pid'] == sidekiq_pid

--- a/test/unit/lib/compose_template_container.rb
+++ b/test/unit/lib/compose_template_container.rb
@@ -107,6 +107,37 @@ module Mulukhiya
       assert_predicate(@container.create(name: 'x', body: 'y')['id'], :present?)
     end
 
+    # ロック取得前にメモ化された user_config を掴んでいても、ロック内で読み直す
+    # ため他リクエストの書き込みを踏み潰さない (#4461)。
+    def test_write_reloads_user_config_inside_lock
+      # 古いスナップショットを掴ませる（@account.user_config はメモ化される）。
+      @container.all
+      other = ComposeTemplateContainer.new(account)
+      other.create(name: '別リクエスト', body: 'x')
+      @container.create(name: 'こちら', body: 'y')
+
+      names = ComposeTemplateContainer.new(account).all.map {|v| v['name']}
+
+      assert_equal(2, names.size)
+      assert_includes(names, '別リクエスト')
+      assert_includes(names, 'こちら')
+    end
+
+    # 保存失敗は UserConfig 側で alert させず GatewayError 一本に畳む（二重 alert
+    # を避ける）。呼び出し側から見た挙動＝5xx は従来どおり (#4461)。
+    def test_persist_failure_raises_gateway_error
+      container = ComposeTemplateContainer.new(account)
+      stub = UserConfig.new(account)
+      stub.define_singleton_method(:update!) {|*| raise 'boom'}
+      # alert する側 (update) を踏まないこと自体を検証する。
+      stub.define_singleton_method(:update) {|*| raise '二重 alert になる update を呼んでいる'}
+      container.instance_variable_set(:@user_config, stub)
+
+      assert_raise(Ginseng::GatewayError) do
+        container.send(:persist, [])
+      end
+    end
+
     def test_max_count
       templates = Array.new(ComposeTemplateContainer::MAX_COUNT) do |i|
         {'id' => SecureRandom.uuid, 'name' => "t#{i}", 'body' => 'x'}

--- a/test/unit/lib/user_config.rb
+++ b/test/unit/lib/user_config.rb
@@ -51,6 +51,18 @@ module Mulukhiya
       assert_equal('bbb', values.dig('sample', 'password').decrypt)
     end
 
+    # update は失敗を alert して握りつぶすが、update! は呼び出し側へ委ねる。
+    # read-back で成否を検証する呼び出し側（ComposeTemplateContainer）が二重に
+    # alert しないための入口 (#4461)。
+    def test_update_bang_propagates_error
+      storage = @user_config.instance_variable_get(:@storage)
+      storage.define_singleton_method(:update) {|*| raise 'boom'}
+
+      assert_raise(RuntimeError) do
+        @user_config.update!(@key1 => {@key2 => '焼きのり'})
+      end
+    end
+
     def test_disable?
       assert_false(@user_config.disable?('yakinori'))
       assert_boolean(@user_config.disable?('you_tube_url_nowplaying'))

--- a/test/unit/worker/startup_notification_worker.rb
+++ b/test/unit/worker/startup_notification_worker.rb
@@ -133,6 +133,28 @@ module Mulukhiya
       @worker&.send(:reset_ng_count, :postgres)
     end
 
+    # 自エラーは log 止めにせず、連続失敗の 1 回目だけ alert する。5 分毎に走る
+    # ワーカーなので毎回 alert すると Sentry がスパム化する (#4461)。
+    def test_notify_failure_alerts_once_per_streak
+      return if disable?
+      calls = []
+      error = RuntimeError.new('boom')
+      error.define_singleton_method(:alert) {|**| calls.push(:alert)}
+      error.define_singleton_method(:log) {|**| calls.push(:log)}
+      @worker.send(:clear_failure)
+      3.times {@worker.send(:notify_failure, error)}
+
+      assert_equal([:alert, :log, :log], calls)
+
+      # 成功したら解除され、次の失敗で再び alert される（デッドマン）。
+      @worker.send(:clear_failure)
+      @worker.send(:notify_failure, error)
+
+      assert_equal([:alert, :log, :log, :alert], calls)
+    ensure
+      @worker&.send(:clear_failure)
+    end
+
     def test_apply_hysteresis_warn_passes_through
       return if disable?
       observed = {redis: 'OK', postgres: 'WARN'}


### PR DESCRIPTION
5.29.0 リリース前 5観点レビューで黄（余力対応）として送りにした 4 件を是正する。Closes #4461

## 1. 保存の二重 alert

`UserConfig#update` は書き込み失敗を自前で `e.alert` して握りつぶす。一方 `ComposeTemplateContainer` は read-back で永続化を検証し失敗時に `GatewayError` を上げ、controller が 5xx を alert する。結果、Redis の一過性障害 1 回で alert が 2 発飛んでいた。

- `UserConfig#update!`（alert せず raise する版）を追加し、`update` はそれを呼んで失敗時に alert する薄いラッパへ。**既存の呼び出し元の挙動は不変**。
- `ComposeTemplateContainer#persist` は `update!` を使い、`GatewayError` に包み直して通知を controller の 1 本にまとめる。根因の例外は `Exception#cause` として Sentry に残る。

controller 側の alert を落とす案は採らなかった。「例外なしのデータ不整合（deep_compact 欠落等）」の検知＝このエンドポイントを専用に切った主目的なので、そちらを消してはいけない。

## 2. StartupNotificationWorker の rescue デッドマン

`perform` の `rescue => e; e.log` は、ヘルス通知を出す仕組み自体が壊れたこと（#4448 の `redis.incr` 未定義 NoMethodError のような沈黙）を無音にする。5 分毎に走るため毎回 alert すると Sentry がスパム化するので、**連続失敗の 1 回目だけ alert し、成功で解除する**デッドマンにした。カウンタ更新自体が落ちる（Redis 全断）場合は log へ倒す — Redis の死は health/redis 側で観測されるので二重に鳴らす価値がない。

## 3. RMW の fresh read 強制

`ComposeTemplateContainer` が読む `@account.user_config` はメモ化された UserConfig（構築時点のスナップショット）。現状は `synchronize` ブロック内が初回参照になるため偶然安全だが、ロック取得前に user_config を参照するコードが将来入ると lost update が黙って復活する。ロック取得直後に読み直す `synchronize` を挟んで構造的に防いだ。

## 4. ロック TTL 10s → 30s

TTL は「処理時間の見積り」ではなく「Ruby 側がストールしてもロックを失わない余裕」で決めるもの。Annict 系ロック（既定 30 秒）と同水準に揃え、根拠をコメントに書いた。

## 検証

- `rake lint` no offenses / `rake test` 822 tests, 0 failures, 0 errors。
- ⚠ **新規テストのうち account 依存の 3 件（container 2 件・user_config 1 件）は、手元にも dev25 にも有効なテストアカウントが無いため実際には走っていない。** `Ginseng::TestCase#run_test` は `disable?` のとき本体を実行しないが、結果は「.」＝ pass として集計されるため見かけ上は緑になる。dev25 でも `/agent/test/token` が現存アカウントに解決せず（0 assertions で確認）、この半分は常時スキップされている。別途 Issue にする。