### PR TITLE
test: 実行されていないテストを omission として可視化 (#4503)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-core.git
-  revision: 88ae6d500e5ff5273e35c6f2b0d1e3d4643e5e95
+  revision: 8853a7139cc4bb1499c3d2203bcb13b5413c40cd
   branch: main
   specs:
-    ginseng-core (1.15.29)
+    ginseng-core (1.15.30)
       activesupport (>= 7.0.7.1)
       addressable (>= 2.9.0)
       cgi (>= 0.4.2)


### PR DESCRIPTION
Refs #4503

ginseng-core 1.15.30（pooza/ginseng-core#489）を取り込む。`disable?` でスキップしたテストが pass ではなく omission として集計されるようになる。

## 効果

```
変更前: 822 tests, 1106 assertions, 0 failures, 0 errors,   5 omissions  → 100% passed
変更後: 822 tests, 1106 assertions, 0 failures, 0 errors, 304 omissions  → 100% passed
```

**822 件中 304 件（37%）が一度も実行されていなかった。** 主にアカウント（`/agent/test/token` → `Account.get(token:)`）を要するテストで、手元・CI ともに同数（CI も 1106 assertions で手元と完全一致）。

これは報告の是正だけで、環境の是正（テスト用アカウント/トークンの供給）は #4503 に残る。5.30.0 のリリース前レビューでは、この 304 件の範囲を CI の緑で担保できないことを前提に見る。