### PR TITLE
chore: ginseng-* の修正を取り込む（core 1.15.31 / fediverse 1.8.26 / redis 2.0.5）

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,10 +65,10 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-redis.git
-  revision: 91e9a516451b3001e4b65ed36132390343f9e9bc
+  revision: ce1d0bf17380f9e7a563745bfe635c233a121904
   branch: main
   specs:
-    ginseng-redis (2.0.4)
+    ginseng-redis (2.0.5)
       redis-client
 
 GIT

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-core.git
-  revision: 8853a7139cc4bb1499c3d2203bcb13b5413c40cd
+  revision: edaa47a69e21ccb5645b785fe46515510f376974
   branch: main
   specs:
-    ginseng-core (1.15.30)
+    ginseng-core (1.15.31)
       activesupport (>= 7.0.7.1)
       addressable (>= 2.9.0)
       cgi (>= 0.4.2)
@@ -42,10 +42,10 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-fediverse.git
-  revision: 60a38dae2e80096734e408ced2d322b994e4c624
+  revision: 442c49d486cbf87ea89848f0abd6ccde21edca44
   branch: main
   specs:
-    ginseng-fediverse (1.8.25)
+    ginseng-fediverse (1.8.26)
 
 GIT
   remote: https://github.com/pooza/ginseng-piefed.git


### PR DESCRIPTION
ginseng-* の open Issue 6 件を潰した結果を mulukhiya へ取り込む。

| gem | 版 | 内容 |
|---|---|---|
| ginseng-core | 1.15.31 | pooza/ginseng-core#478 `Logger#mask` の破壊的変更 / #479 `Environment.type` が RACK_ENV を見ない / #480 `RBENV_VERSION` の引き継ぎ / Ruby 4 frozen string 起因の 2 件 |
| ginseng-fediverse | 1.8.26 | pooza/ginseng-fediverse#238 nodeinfo の contact_account nil / #243 numeric_ap_id の publicize |
| ginseng-redis | 2.0.5 | pooza/ginseng-redis#51 `create_key` の破壊的変更 |

## mulukhiya への影響

- **`Logger#mask`**: これまで**文字列キーの Hash ではマスクが効いておらず素の値がログに出ていた**のが直る。空値のキーがログから落ちるようになる（`reject` の本来の意図どおり）。`Controller#scrub_log_params` の `deep_dup` は logger 対策ではなく `[FILTERED]` 差し替え用なのでそのまま残す。
- **`Environment.type`**: mulukhiya は独自の `Mulukhiya::Environment.type`（config のみ参照）を持つため直接の影響はない。本番 4 台 + dev25 は config も rc.d も `production` で一致していることを確認済み。
- **`create_key`**: `rake test` で多発していた `literal string will be frozen in the future` 警告が消える。Ruby 4 で frozen literal が既定になったときの **Redis アクセス全滅**を先回りで回避。

## 検証

`rake lint` no offenses / `rake test` 822 tests, 0 failures, 0 errors（304 omissions は #4503 の既知＝アカウント未供給で実行されないテスト）。