### PR TITLE
fix: 5.30.0 リリース前レビューの赤近い黄 2 件をインライン是正

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,9 +107,9 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (8.1.3)
-      actionview (= 8.1.3)
-      activesupport (= 8.1.3)
+    actionpack (8.1.3.1)
+      actionview (= 8.1.3.1)
+      activesupport (= 8.1.3.1)
       nokogiri (>= 1.8.5)
       rack (>= 2.2.4)
       rack-session (>= 1.0.1)
@@ -117,13 +117,13 @@ GEM
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
       useragent (~> 0.16)
-    actionview (8.1.3)
-      activesupport (= 8.1.3)
+    actionview (8.1.3.1)
+      activesupport (= 8.1.3.1)
       builder (~> 3.1)
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    activesupport (8.1.3)
+    activesupport (8.1.3.1)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
@@ -197,7 +197,7 @@ GEM
       zeitwerk (~> 2.6)
     erb (6.0.6)
     erubi (1.13.1)
-    et-orbi (1.4.0)
+    et-orbi (1.4.1)
       tzinfo
     etc (1.4.6)
     eventmachine (1.2.7)
@@ -230,7 +230,7 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
-    icalendar (2.12.3)
+    icalendar (2.12.4)
       base64
       ice_cube (~> 0.16)
       logger
@@ -408,7 +408,7 @@ GEM
     sentry-sidekiq (6.6.2)
       sentry-ruby (~> 6.6.2)
       sidekiq (>= 5.0)
-    sequel (5.106.0)
+    sequel (5.107.0)
       bigdecimal
     set (1.1.3)
     sidekiq (8.1.6)
@@ -430,7 +430,7 @@ GEM
     slim (5.2.2)
       temple (~> 0.10.0)
       tilt (>= 2.1.0)
-    slim_lint (0.35.0)
+    slim_lint (0.36.0)
       rexml (~> 3.2)
       rubocop (>= 1.0, < 2.0)
       slim (>= 3.0, < 6.0)
@@ -455,7 +455,7 @@ GEM
     unicode-emoji (4.2.0)
     uri (1.1.1)
     useragent (0.16.11)
-    version_gem (1.1.14)
+    version_gem (1.1.15)
     webmock (3.26.2)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)

--- a/app/lib/mulukhiya/compose_template_container.rb
+++ b/app/lib/mulukhiya/compose_template_container.rb
@@ -109,11 +109,15 @@ module Mulukhiya
     # UserConfig#update は書き込み失敗を自前で alert して握りつぶすため、read-back
     # 由来の GatewayError と合わせると Redis の一過性障害 1 回で alert が 2 発飛ぶ。
     # ここは alert しない update! を使い、GatewayError に包み直して通知を controller
-    # の 1 本にまとめる。根因の例外は Exception#cause として Sentry に残る (#4461)。
+    # の 1 本にまとめる。
+    #
+    # メッセージには例外クラス名を混ぜない（read-back 失敗時と同じ文言に揃え、
+    # 内部実装をクライアントへ出さない）。根因は Exception#cause として Sentry に
+    # 残るので、切り分けはそちらで行う (#4461)。
     def persist(templates)
       user_config.update!(compose: {templates: templates})
-    rescue => e
-      raise Ginseng::GatewayError, "テンプレートを保存できませんでした。(#{e.class})"
+    rescue
+      raise Ginseng::GatewayError, 'テンプレートを保存できませんでした。'
     end
   end
 end

--- a/app/lib/mulukhiya/worker/startup_notification_worker.rb
+++ b/app/lib/mulukhiya/worker/startup_notification_worker.rb
@@ -11,6 +11,12 @@ module Mulukhiya
     end
 
     def perform(params = {})
+      # sidekiq-scheduler は Sidekiq::Client.push を直叩きするため Worker.perform_async
+      # 側の disable? gate を通らない。info agent が無いサーバーでも schedule
+      # (every: 5m) 経由で perform が起動するので、ここでも短絡する (#4343)。
+      # これを欠くと send_notification が nil を叩き、下の deadman が 5 分ごとに
+      # alert する。
+      return if disable?
       notify(Environment.health)
       clear_failure
     rescue => e

--- a/views/default.sass
+++ b/views/default.sass
@@ -1013,8 +1013,13 @@ a:hover
   input.short
     width: 10em
   // 幅を与えたうえで縮小を止める。上の `input, select` が flex-grow: 1 を
-  // 付けているためチェックボックスも flex item になり、幅指定なしで
-  // flex-shrink: 1 だと行が詰まったときに 0 幅まで潰れて消える (#4483)。
+  // 付けているためチェックボックスも flex item になり、幅指定なしだと行が
+  // 詰まったときに潰れうる。
+  //
+  // ⚠ これは #4483（一覧の ✔ が見えない）の原因ではなかった。真因は素の
+  // U+2714 が Linux の絵文字フォント環境で描画されないことで、program.slim
+  // 側を Font Awesome の fa-check に置き換えて解決している。ここは整合のための
+  // 予防的な指定として残しているだけ。
   input[type="checkbox"]
     margin:
       left: 0.5em


### PR DESCRIPTION
5.30.0 リリース前レビュー（5 観点）で検出した、**本リリースの変更が原因で顕在化する** 2 件をインライン是正する。

## 1. StartupNotificationWorker が perform で disable? を短絡していない

Refs #4506

sidekiq-scheduler は `Sidekiq::Client.push` を直叩きするため `Worker.perform_async` 側の `disable?` gate を通らない（#4343 で MediaCatalogUpdateWorker について判明済み）。この worker は `disable?`（info agent が無ければ true）を持つが `perform` で短絡していないため、info agent 未設定のサーバーでも 5 分おきに本体が走り `send_notification` が nil を叩く。

構造自体は従来からあるが、**同リリースの #4461 で `rescue => e; e.log` をデッドマン（連続失敗の 1 回目だけ alert）に変えたため、放置すると 5 分ごとに alert が飛ぶ**。ここだけ先行して是正する。

残る 7 本の定期 worker（annict_polling / announcement / feed_update / program_update / tagging_dictionary_update / decoration_initialize / user_tag_initialize）も同じ構造だが、実害は worker ごとに異なり 1 本ずつ確認が要るため #4506 として 5.31.0 へ送る。

## 2. 保存失敗メッセージに例外クラス名が混ざる

#4461 で `persist` の失敗を `GatewayError` に包み直したとき、メッセージに例外クラス名を足していた。この文字列は `@renderer.message = {error: e.message}` でそのままクライアントへ返るため、**内部の例外クラス名が capsicum のエラー表示に出る**。read-back 失敗時と同じ文言に揃え、根因は `Exception#cause` 経由で Sentry から追う形にした。

## 検証

`rake lint` no offenses / `rake test` 822 tests, 0 failures, 0 errors。
