### PR TITLE
fix: json-schema を Gemfile に明示する（RACK_ENV=production で起動不能）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,11 @@ gem 'ginseng-redis', github: 'pooza/ginseng-redis', branch: 'main', require: 'gi
 gem 'ginseng-web', github: 'pooza/ginseng-web', branch: 'main', require: 'ginseng/web'
 gem 'ginseng-youtube', github: 'pooza/ginseng-youtube', branch: 'main', require: 'ginseng/you_tube'
 gem 'icalendar'
+# JSON::Validator を app/lib/mulukhiya.rb で直に使う。ginseng-core の推移依存で
+# 入ってはいるが、Bundler.require が読むのは Gemfile に書いた gem だけで、
+# ginseng-core 側は Ginseng::Config が autoload された副作用で require していた。
+# その副作用に頼ると、Config を触らない起動経路で NameError になる (#4509)。
+gem 'json-schema'
 gem 'marcel'
 gem 'optparse'
 gem 'parallel', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -488,6 +488,7 @@ DEPENDENCIES
   ginseng-web!
   ginseng-youtube!
   icalendar
+  json-schema
   marcel
   optparse
   ostruct


### PR DESCRIPTION
Closes #4509

**5.30.0 のステージング検証（dev24）で検出。本番へ出していたら 4 台とも起動不能になっていた。**

`app/lib/mulukhiya.rb:112` は `Bundler.require` の直後に `JSON::Validator.use_multi_json = false` を実行するが、**`json-schema` は Gemfile に無く `Bundler.require` の対象外**（ginseng-core の推移依存）。これまで動いていたのは、`ginseng.rb#setup_debug` が `Environment.development?` → `Config.instance` を参照 → Zeitwerk が `Ginseng::Config` を autoload → その先頭の `require 'json-schema'` が走る、という**副作用**のおかげだった。

ginseng-core 1.15.31（pooza/ginseng-core#479）で `Environment.type` が `ENV['RACK_ENV']` を先に見るようになり、**RACK_ENV があるときは `Config.instance` を触らずに return する**。結果 `json-schema` が読まれず NameError になる。本番・staging とも rc.d が `RACK_ENV=production` で起動するため全台が該当した。

`#479` 自体は正しい修正で、mulukhiya 側にあった潜在的な脆さが露出しただけ。**直接使う gem は Gemfile に書く**のが正しい対処（tomato-shrieker は既にそうなっている）。

## 検証

```
$ RACK_ENV=production bundle exec ruby -Iapp/lib -e 'require "mulukhiya"; puts Mulukhiya::Package.version'
5.30.0     # 修正前は NameError
```

`rake lint` no offenses / `rake test` 822 tests, 0 failures, 0 errors。

⚠ `rake test` も CI も RACK_ENV を立てないため、この不具合は緑のまま通過していた。ステージング検証（省略不可）が効いた 2 例目。