### PR TITLE
config: URL クエリのマスク対象を application.yaml に明示する (#4511)

### DIFF
--- a/config/application.yaml
+++ b/config/application.yaml
@@ -297,6 +297,7 @@ iceshrimp:
   display_name: Iceshrimp
   sns_type: misskey
 logger:
+  # ログに出す Hash の「キー名」で落とすもの
   mask_fields:
     - auth
     - endpoint
@@ -304,6 +305,29 @@ logger:
     - publickey
     - secret
     - token
+  # URL のクエリに現れたら [FILTERED] へ落とす「パラメータ名」(#4511)。
+  # mask_fields はキー名でしか判定できないため、`url: "...?access_token=xxx"` の
+  # ように値の文字列へ埋まった資格情報はこちらで落とす。
+  #
+  # ⚠ `i` は Misskey のトークンパラメータ。汎用名だが、判定は URL のクエリに
+  #   限られる（ginseng-core 側の実装）ので Hash のキー `i` は巻き込まない。
+  # ⚠ 未設定なら ginseng-core の既定リストへ倒れる（マスクしない方向へは倒れない）。
+  #   ここに書くのは、増減させたいときの編集点を明示するため。
+  mask_query_params:
+    - access_token
+    - api_key
+    - apikey
+    - client_secret
+    - code
+    - i
+    - key
+    - password
+    - refresh_token
+    - secret
+    - token
+    # 辞書 API (Google Apps Script) のリダイレクト先に付く capability key。
+    # 本番のログに実際に出ている。
+    - user_content_key
 mastodon:
   attachment:
     types:


### PR DESCRIPTION
## 概要

pooza/ginseng-core#493 で入った `/logger/mask_query_params` を、モロヘイヤの `config/application.yaml` に明示する。

ginseng-core 側に既定リストがあるので未設定でも動くが、**増減させたいときの編集点が gem の中では見つけられない**。`mask_fields` と並べて置いておく。

## 併せて `user_content_key` を追加

辞書 API (Google Apps Script) のリダイレクト先に付く capability key。**本番 (sweep) のログに実際に出ている**ので落とす。

```
"url":"https://script.googleusercontent.com/macros/echo?user_content_key=AUkAhnTw9EHp...&lib=MU9YGs..."
```

なお Google Apps Script の**デプロイ ID は `/macros/s/AKfycb.../exec` とパス側**なので、クエリの scrub では落ちない。こちらは別途の判断が要る（本 PR のスコープ外）。

## 実挙動

```
{"url":"wss://precure.ml/api/v1/streaming?access_token=[FILTERED]&stream=user"}
{"url":"https://misskey.delmulin.com/streaming?i=[FILTERED]"}
{"url":"https://script.googleusercontent.com/macros/echo?user_content_key=[FILTERED]&lib=MU9YGs"}
{"url":"https://precure.ml/api/v1/timelines/public?local=true"}
{"url":"https://example.com/x?api=1&lib=2"}
```

無関係なクエリ（`?local=true`）と、`i` に似た名前（`api=` / `lib=`）は素通し。

## ⚠ 前のコメントの訂正

#4511 で「モロヘイヤでは `ConfigError` になって既定リストへ倒れる」と書いたが、**あれは `Ginseng::Logger` で試したための誤り**。`Ginseng::Logger` は `Ginseng::Config` を見るので application.yaml を読まない。

実行時に使われるのは `Mulukhiya::Logger`（`Mulukhiya::Package#logger` が返す）で、これは `Mulukhiya::Config` を見るため **application.yaml の設定がそのまま効く**。上の実挙動はすべて `Mulukhiya::Logger` で取り直したもの。

## 検証

822 tests / 1106 assertions / 0 failures / 0 errors、lint も green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)