### PR TITLE
fix: disable? を持つ worker が perform でも短絡するようにする (#4506)

### DIFF
--- a/app/lib/mulukhiya/worker.rb
+++ b/app/lib/mulukhiya/worker.rb
@@ -4,6 +4,19 @@ module Mulukhiya
     include Package
     include SNSMethods
 
+    # 🔴 disable? を override した worker は、**perform 冒頭でも `return if disable?`
+    # を書くこと** (#4343 / #4506)。
+    #
+    # 下の Worker.perform_async は disable? を見て enqueue を止めるが、
+    # **sidekiq-scheduler は perform_async を介さず Sidekiq::Client.push を直叩きする**
+    # ため、schedule 経由の起動はこの gate を一切通らない。schedule を持つ worker で
+    # perform 側の短絡を欠くと、機能を無効にしたサーバーでも本体が 1〜10 分おきに走る。
+    #
+    # 基底側で perform を一律ラップする案もあるが、disable? の中身は worker ごとに
+    # DB / 外部 API を叩くものがあり（例: FeedUpdateWorker の CustomFeed.all）、
+    # 全 worker の毎回の起動でその評価コストを払うことになるので採らない。
+    # 代わりに test/unit/worker/disable_gate.rb が「disable? を override している
+    # 全 worker が perform で短絡すること」を機械的に検査する。
     def disable?
       return false
     end

--- a/app/lib/mulukhiya/worker/annict_polling_worker.rb
+++ b/app/lib/mulukhiya/worker/annict_polling_worker.rb
@@ -8,6 +8,9 @@ module Mulukhiya
     end
 
     def perform(params = {})
+      # every 1m。Annict 非対応サーバーでも AnnictService.accounts (DB) と
+      # crawl_all (Annict への外部 HTTP) が毎分走ってしまう (#4506)。
+      return if disable?
       log(accounts: AnnictService.accounts.count)
       AnnictService.crawl_all
     end

--- a/app/lib/mulukhiya/worker/announcement_worker.rb
+++ b/app/lib/mulukhiya/worker/announcement_worker.rb
@@ -8,6 +8,9 @@ module Mulukhiya
     end
 
     def perform(params = {})
+      # every 10m。info agent が無いサーバーでも Announcement#announce が走り、
+      # 通知先の無いまま告知処理を回してしまう (#4506)。
+      return if disable?
       announcement = Announcement.new
       announcement.announce
       log(cached: announcement.count)

--- a/app/lib/mulukhiya/worker/decoration_apply_worker.rb
+++ b/app/lib/mulukhiya/worker/decoration_apply_worker.rb
@@ -8,6 +8,9 @@ module Mulukhiya
     end
 
     def perform(params = {})
+      # schedule は無く enqueue 経路のみだが、perform_async 以外から呼ばれても
+      # 成立するよう他の worker と同じ形に揃える (#4506)。
+      return if disable?
       initialize_params(params)
       account = account_class[params[:account_id]]
       apply_decoration(account)

--- a/app/lib/mulukhiya/worker/decoration_initialize_worker.rb
+++ b/app/lib/mulukhiya/worker/decoration_initialize_worker.rb
@@ -8,6 +8,10 @@ module Mulukhiya
     end
 
     def perform(params = {})
+      # cron 2 3 * * *。Misskey 以外のサーバーでも decoration_owners を引いて
+      # Misskey 固有の update_account を全アカウント分呼び、rescue でログだけが
+      # 積み上がる (#4506)。
+      return if disable?
       initialize_params(params)
       if id = params[:account_id]
         log(mode: 'single')

--- a/app/lib/mulukhiya/worker/feed_update_worker.rb
+++ b/app/lib/mulukhiya/worker/feed_update_worker.rb
@@ -9,6 +9,9 @@ module Mulukhiya
     end
 
     def perform(params = {})
+      # every 5m。CustomFeed はサブプロセス (bin/*.rb) を起動するため、フィードを
+      # 持たないサーバーでも 5 分おきにプロセス生成と DB 接続を試みる (#4506)。
+      return if disable?
       CustomFeed.all(&:update)
       log(feeds: CustomFeed.count)
     end

--- a/app/lib/mulukhiya/worker/piefed_clipping_worker.rb
+++ b/app/lib/mulukhiya/worker/piefed_clipping_worker.rb
@@ -6,6 +6,9 @@ module Mulukhiya
     end
 
     def perform(params = {})
+      # schedule は無く enqueue 経路のみだが、perform_async 以外から呼ばれても
+      # 成立するよう他の worker と同じ形に揃える (#4506)。
+      return if disable?
       initialize_params(params)
       unless piefed = account_class[params[:account_id]]&.piefed
         raise Ginseng::ConfigError "Piefed undefined (Account #{params[:account_id]})"

--- a/app/lib/mulukhiya/worker/program_update_worker.rb
+++ b/app/lib/mulukhiya/worker/program_update_worker.rb
@@ -8,6 +8,9 @@ module Mulukhiya
     end
 
     def perform(params = {})
+      # every 1m。実況非対応サーバーでも Program#update が番組表の取得と保存を
+      # 毎分行ってしまう (#4506)。
+      return if disable?
       Program.instance.update
       log(programs: Program.instance.count)
     end

--- a/app/lib/mulukhiya/worker/tagging_dictionary_update_worker.rb
+++ b/app/lib/mulukhiya/worker/tagging_dictionary_update_worker.rb
@@ -8,6 +8,9 @@ module Mulukhiya
     end
 
     def perform(params = {})
+      # every 10m。辞書を 1 つも持たないサーバーでも TaggingDictionary#refresh が
+      # 外部の辞書 API を叩いてしまう (#4506)。
+      return if disable?
       dictionary = TaggingDictionary.new
       dictionary.refresh
       log(entries: dictionary.size)

--- a/app/lib/mulukhiya/worker/user_tag_initialize_worker.rb
+++ b/app/lib/mulukhiya/worker/user_tag_initialize_worker.rb
@@ -8,6 +8,10 @@ module Mulukhiya
     end
 
     def perform(params = {})
+      # cron 2 3 * * *。🔴 user_tag ハンドラを無効にしたサーバーでも
+      # clear_tags が走り、**利用者が設定済みのタグを毎日消してしまう**。
+      # 7 本のうち唯一データを破壊する (#4506)。
+      return if disable?
       initialize_params(params)
       if id = params[:account_id]
         log(mode: 'single')

--- a/test/unit/worker/disable_gate.rb
+++ b/test/unit/worker/disable_gate.rb
@@ -1,0 +1,51 @@
+module Mulukhiya
+  # disable? を override している worker が、perform でも短絡することを機械的に検査する。
+  #
+  # sidekiq-scheduler は Worker.perform_async を介さず Sidekiq::Client.push を直叩き
+  # するため、schedule 経由の起動は perform_async 側の disable? gate を通らない。
+  # 短絡を書き忘れると、機能を無効にしたサーバーでも本体が 1〜10 分おきに走る
+  # (#4343 / #4506)。個別の worker テストに任せると新しい worker で必ず忘れるので、
+  # 全 worker を列挙して一括で見る。
+  class WorkerDisableGateTest < TestCase
+    # perform を呼んだかどうかの判定に log を使う。対象 worker はいずれも perform 本体で
+    # log を呼ぶので、短絡していれば log は呼ばれない。本体が例外を投げた場合も
+    # （短絡していない証拠なので）テストは落ちる。
+    # ⚠ subclasses は直接の子しか返さない。PiefedClippingWorker のように
+    # ClippingWorker を挟む worker を取りこぼすので descendants を使う。
+    def gated_workers
+      return Worker.descendants.select do |klass|
+        klass.instance_method(:disable?).owner == klass
+      end
+    end
+
+    def test_gated_workers_detected
+      # 列挙そのものが壊れると検査が空振りするので、下限を押さえておく。
+      assert_operator(gated_workers.size, :>=, 11, 'disable? を持つ worker が検出できていない')
+      assert_include(gated_workers, PiefedClippingWorker, '孫クラスを取りこぼしている')
+    end
+
+    def test_disabled_workers_do_not_run_perform
+      offenders = gated_workers.reject {|klass| short_circuits?(klass)}
+
+      assert_empty(
+        offenders.map(&:to_s).sort,
+        'disable? が true でも perform 本体が走る worker がある。' \
+          'perform 冒頭に `return if disable?` を書くこと (#4506)',
+      )
+    end
+
+    private
+
+    def short_circuits?(klass)
+      worker = klass.new
+      worker.define_singleton_method(:disable?) {true}
+      called = false
+      worker.define_singleton_method(:log) {|_message| called = true}
+      worker.perform({})
+      return !called
+    rescue StandardError
+      # 本体が走って落ちた＝短絡していない
+      return false
+    end
+  end
+end


### PR DESCRIPTION
Fixes #4506

## 問題

sidekiq-scheduler は `Worker.perform_async` を介さず `Sidekiq::Client.push` を直叩きするため、**schedule 経由の起動は `perform_async` 側の `disable?` gate を一切通らない**。機能を無効にしたサーバーでも worker の本体が 1〜10 分おきに走っていた。

## 1 本ずつ確認した実害

Issue の指示どおり、`disable?` が true のときに perform 本体が何をしてしまうかを確認した。

| worker | schedule | disable? が true のとき起きること |
|---|---|---|
| **UserTagInitializeWorker** | cron 2 3 * * * | 🔴 **利用者が設定済みのタグを毎日消す。9 本で唯一データを破壊する** |
| DecorationInitializeWorker | cron 2 3 * * * | Misskey 以外でも decoration_owners を引き、Misskey 固有の `update_account` を全アカウント分呼ぶ。rescue でログだけが積み上がる |
| AnnictPollingWorker | every 1m | Annict 非対応サーバーでも DB + Annict への外部 HTTP が**毎分** |
| ProgramUpdateWorker | every 1m | 実況非対応サーバーでも番組表の取得と保存が**毎分** |
| FeedUpdateWorker | every 5m | フィードを持たないサーバーでも 5 分おきにサブプロセス生成と DB 接続 |
| AnnouncementWorker | every 10m | info agent が無いサーバーでも告知処理が走る |
| TaggingDictionaryUpdateWorker | every 10m | 辞書ゼロのサーバーでも外部の辞書 API を叩く |
| DecorationApplyWorker | なし | enqueue 経路のみ。形を揃えるため追加 |
| PiefedClippingWorker | なし | 同上 |

## Issue の一覧との差分

- **`PronunciationDictionaryUpdateWorker`（every 10m）は Issue の一覧に無かったが、#4405 で既に短絡済み**だった。対処不要
- 逆に Issue が「影響は限定的」としていた `DecorationApplyWorker` / `PiefedClippingWorker` も、下記のテストが検出したので揃えた

## 基底側での一律ラップは採らなかった

Issue の「Worker 基底側で一律に短絡できないか」について。**採りません。**

`disable?` の中身は worker ごとに DB / 外部 API を叩くものがあり（例: `FeedUpdateWorker#disable?` の `CustomFeed.all.present?`、`TaggingDictionaryUpdateWorker#disable?` の `Handler.create(:dictionary_tag).all`）、全 worker の毎回の起動でその評価コストを払うことになる。Issue でも「`disable?` の評価コストが毎回乗る点は要確認」と書かれていた点です。

代わりに **`test/unit/worker/disable_gate.rb`** を追加し、`disable?` を override している全 worker が perform で短絡することを機械的に検査する。次に worker を足した人が忘れても CI が落ちます。

判定は「perform 本体が `log` を呼んだか」で行う。対象 worker はいずれも perform 本体で `log` を呼ぶので、短絡していれば呼ばれない。本体が例外を投げた場合も短絡していない証拠なので落ちる。

⚠ 列挙には `descendants` を使う。**`subclasses` は直接の子しか返さず、`ClippingWorker` を挟む `PiefedClippingWorker` を取りこぼす**（実際に取りこぼして 1 本見逃しかけた）。テストでその点も明示的に押さえている。

## 検証

- **824 tests / 1109 assertions / 0 failures / 0 errors**、lint も green
- **guard を 1 本外すと実際に落ちる**ことを確認済み:

```
Failure: test_disabled_workers_do_not_run_perform(Mulukhiya::WorkerDisableGateTest):
  disable? が true でも perform 本体が走る worker がある。perform 冒頭に `return if disable?` を書くこと (#4506).
  <["Mulukhiya::UserTagInitializeWorker"]> was expected to be empty.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)