### PR TITLE
docs: POST /mulukhiya/api/status/tags のレスポンス仕様を明記する (#4491)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -855,6 +855,45 @@ Web Push サブスクリプションを解除する。
 | `id` | string | 必須 | 投稿 ID |
 | `tags` | string[] | 必須 | タグの配列 |
 
+- **レスポンス（成功時 200）**: **SNS 本体の投稿 API のレスポンスをそのまま返す。**モロヘイヤ独自のラップは無い。
+  したがって**形は SNS 種別で異なる**（#4491）。
+
+| controller | 形 | 新しい投稿の ID |
+|---|---|---|
+| Mastodon | `POST /api/v1/statuses` と同じ status オブジェクト（トップレベルがそのまま status） | `id` |
+| Misskey | `POST /api/notes/create` と同じ `{"createdNote": {...}}` | `createdNote.id` |
+
+  **本文・添付・可視性を含む完全なオブジェクトが返る**ので、クライアントは再取得なしにタイムラインへ反映できる。
+  元の投稿は削除済みで、返るのは**新しく作られた投稿**（ID は元と異なる）。
+
+```jsonc
+// Mastodon
+{"id": "117039311685380513", "created_at": "...", "content": "<p>本文</p><p><a ...>#<span>tag1</span></a></p>",
+ "visibility": "direct", "account": {...}, "media_attachments": [], ...}
+
+// Misskey
+{"createdNote": {"id": "apiq4gr6k0", "createdAt": "...", "text": "本文\n\n#tag1 #tag2",
+                 "tags": ["tag1", "tag2"], "user": {...}, ...}}
+```
+
+- **削除と再投稿の順序が SNS で逆**なので、失敗時に残るものが違う。
+  - **Mastodon**: 削除 → 投稿。投稿側で失敗すると**元の投稿は消えたまま**になる
+  - **Misskey**: 投稿 → 削除。削除側で失敗すると**新旧が両方残る**
+
+- **エラー**:
+
+| 状況 | ステータス | body |
+|---|---|---|
+| 認証なし・トークン不正 | **403** | `{"error":"Unauthorized"}` |
+| 他人の投稿・存在しない ID | **404** | `{"package":"ginseng-core","class":"Ginseng::NotFoundError","message":"Resource /mulukhiya/api/status/tags not found."}` |
+| `/{controller}/capabilities/repost` が false | **404** | 同上 |
+| `tags` 未指定・不正 | **422** | `{"errors":{"tags":["空欄です。"]}}` |
+| 上流 SNS のエラー | 上流のステータス | `{"error":"Bad response NNN"}`（#4480 で改善予定） |
+
+  ⚠ **404 の body だけ他と形が違う。**コントローラは `{"error":"Not Found"}` を組み立てているが、
+  Sinatra の `not_found` ハンドラがステータス 404 を見て body を差し替えるため、個別のメッセージが
+  失われる。**`error` キーを持たないので、クライアントは `error` の有無で分岐してはいけない**（#4520）。
+
 #### GET /mulukhiya/api/media
 
 メディアカタログを取得する。


### PR DESCRIPTION
Fixes #4491

capsicum#909 が本仕様の確定待ちで on-hold になっていたので、**ステージング (dev25 / dev27) で実際に叩いて確認**した内容を記載する。コードの読みだけでは誤る箇所が実際にあった（下記）。

## 依頼された 3 点への回答

### 1. 再投稿された status がそのまま返るか

**返る。モロヘイヤ独自のラップは無い。**ただし **SNS 種別で形が違う。**

| controller | 形 | 新しい投稿の ID |
|---|---|---|
| Mastodon | `POST /api/v1/statuses` と同じ status オブジェクト（トップレベルがそのまま status） | `id` |
| Misskey | `POST /api/notes/create` と同じ `{"createdNote": {...}}` | `createdNote.id` |

実測値（値は一部省略）:

```jsonc
// Mastodon (st2.precure.ml)
{"id": "117039311685380513", "created_at": "...",
 "content": "<p>本文</p><p><a ...>#<span>test4491</span></a> ...</p>",
 "visibility": "direct", "account": {...}, "media_attachments": [], ...}

// Misskey (st2.misskey.delmulin.com)
{"createdNote": {"id": "apiq4gr6k0", "createdAt": "...",
                 "text": "本文\n\n#test4491 #delmulin",
                 "tags": ["test4491", "delmulin"], "user": {...}, ...}}
```

### 2. id だけか、本文を持たないのか

**本文・添付・可視性を含む完全なオブジェクトが返る。** capsicum は再取得なしに TL へ挿せる。元の投稿は削除済みで、返るのは新しく作られた投稿（ID は元と異なる）。

### 3. 失敗時の形

| 状況 | ステータス | body |
|---|---|---|
| 認証なし・トークン不正 | **403** | `{"error":"Unauthorized"}` |
| 他人の投稿・存在しない ID | **404** | `{"package":"ginseng-core","class":"Ginseng::NotFoundError","message":"Resource ... not found."}` |
| `capabilities/repost` が false | **404** | 同上 |
| `tags` 未指定・不正 | **422** | `{"errors":{"tags":["空欄です。"]}}` |
| 上流 SNS のエラー | 上流のステータス | `{"error":"Bad response NNN"}`（#4480 で改善予定） |

## 実機で叩かないと分からなかった 2 点

- **401 ではなく 403。**`raise Ginseng::AuthError, 'Unauthorized'` と書いてあるので 401 だと読めるが、`AuthError#status` は 403
- 🔴 **404 の body だけ形が違う。**コントローラは `{"error":"Not Found"}` を組み立てているが、**Sinatra の `not_found` ハンドラがステータス 404 を見て body を差し替える**ため個別のメッセージが失われる。`error` キーを持たないので、**クライアントは `error` の有無で分岐してはいけない**。これは `APIController` 全体に効く実バグなので **#4520** として起票し、docs には**現状の挙動のまま**書いた

## 併せて記載した運用上の注意

**削除と再投稿の順序が SNS で逆**なので、失敗時に残るものが違う。capsicum のエラー処理に効く。

- **Mastodon**: 削除 → 投稿。投稿側で失敗すると**元の投稿は消えたまま**
- **Misskey**: 投稿 → 削除。削除側で失敗すると**新旧が両方残る**

## 検証

ステージングに実際に投稿し、タグ付けを行い、レスポンスを取得したうえで**テスト投稿は両系とも削除済み**（Mastodon 200 / Misskey 204）。lint green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)