### PR TITLE
fix: トークン未設定のアカウントで webhook URL を生成しない (#4487)

### DIFF
--- a/app/lib/mulukhiya/webhook.rb
+++ b/app/lib/mulukhiya/webhook.rb
@@ -5,7 +5,14 @@ module Mulukhiya
 
     attr_reader :sns, :reporter
 
+    # ⚠ トークンが無いまま digest を作ってはいけない (#4487)。
+    # {sns:, token: nil, salt:} の SHA256 は「URL の形をしているのに誰のものでもない」
+    # 幽霊 webhook URL になる。find_token_by_digest は oauth_access_tokens を舐めて
+    # token.webhook_digest（＝トークン文字列から作った値）と突き合わせるので、
+    # nil から作った値に一致するレコードは存在しない。設定はできたのに何も起きない、
+    # という静かな失敗になるため、URL を出す前に落とす。
     def digest
+      raise Ginseng::ConfigError, 'token not found' if sns.token.blank?
       return self.class.create_digest(sns.uri, sns.token)
     end
 
@@ -14,6 +21,12 @@ module Mulukhiya
     rescue => e
       e.log
       return parser_class.visibility_name(:public)
+    end
+
+    # digest / uri を取れる状態か。トークンを持たないアカウントでも
+    # Account#webhook は Webhook を返すので、呼び出し側はこれで判定する (#4487)。
+    def available?
+      return sns.token.present?
     end
 
     def uri
@@ -61,7 +74,11 @@ module Mulukhiya
     # /crypt/salt は #4083 で廃止済みだが、本番サーバーの過半数で
     # /crypt/salt と /crypt/password が異なる値を持っており、
     # Crypt.password に統一すると digest が変化する。(#4106)
+    #
+    # 空トークンの拒否は digest 側と二重に持つ。ここは webhook_digest（AccessToken 側）
+    # からも呼ばれる入口なので、値の計算に入る前に止める (#4487)。
     def self.create_digest(uri, token)
+      raise Ginseng::ConfigError, 'token not found' if token.blank?
       return {
         sns: uri.to_s,
         token:,
@@ -78,9 +95,15 @@ module Mulukhiya
       return nil
     end
 
+    # トークンを持たないアカウントの「幽霊 webhook」は列挙しない (#4487)。
+    # 混ざっていると digest / uri を呼んだ時点で落ちるうえ、そもそも照合できないので
+    # webhook として意味を持たない。
     def self.all(&block)
       return enum_for(__method__) unless block
-      controller_class.webhook_entries.filter_map {|v| v[:account]&.webhook}.each(&block)
+      controller_class.webhook_entries
+        .filter_map {|v| v[:account]&.webhook}
+        .select(&:available?)
+        .each(&block)
     end
 
     def self.find_token_by_digest(digest)

--- a/test/unit/model/webhook_token_guard.rb
+++ b/test/unit/model/webhook_token_guard.rb
@@ -1,0 +1,80 @@
+module Mulukhiya
+  # トークンを持たないアカウントから webhook URL が出ないこと (#4487)。
+  #
+  # {sns:, token: nil, salt:} の SHA256 は「URL の形をしているのに誰のものでもない」
+  # 幽霊 URL になる。find_token_by_digest は oauth_access_tokens を舐めて
+  # token.webhook_digest（トークン文字列から作った値）と突き合わせるので、nil から
+  # 作った値に一致するレコードは存在しない。**設定はできたのに何も起きない**という
+  # 静かな失敗になるため、URL を出す前に落とす。
+  #
+  # DB を必要としないよう、UserConfig ではなく sns.token を直接差し替えて検証する。
+  class WebhookTokenGuardTest < TestCase
+    # UserConfig も SNS サービスも DB を引くので、digest / uri が必要とする
+    # token / uri / create_uri だけを持つダブルを使う。
+    SNSDouble = Struct.new(:token) do
+      def uri
+        return Ginseng::URI.parse('https://example.com')
+      end
+
+      def create_uri(path)
+        return Ginseng::URI.parse("https://example.com#{path}")
+      end
+    end
+
+    def setup
+      @uri = Ginseng::URI.parse('https://example.com')
+    end
+
+    # 実際にブロックすること（正のケース）。
+    def test_create_digest_rejects_blank_token
+      [nil, '', '   '].each do |token|
+        assert_raise(Ginseng::ConfigError, "token=#{token.inspect} を拒否していない") do
+          Webhook.create_digest(@uri, token)
+        end
+      end
+    end
+
+    def test_create_digest_accepts_token
+      digest = Webhook.create_digest(@uri, 'valid_token')
+
+      assert_match(/\A[0-9a-f]{64}\z/, digest)
+    end
+
+    # ⚠ digest の値そのものは webhook URL の一部なので、ガードの追加で変わっては
+    # いけない（変わると tomato-shrieker 等の外部連携が全部切れる）。
+    def test_guard_does_not_change_digest_value
+      token = 'test_token_for_digest_stability'
+      expected = {
+        sns: @uri.to_s,
+        token:,
+        salt: (Config.instance['/crypt/salt'] rescue Crypt.password),
+      }.to_json.sha256
+
+      assert_equal(expected, Webhook.create_digest(@uri, token))
+    end
+
+    def test_digest_rejects_blank_token
+      hook = build_webhook(nil)
+
+      assert_not_predicate(hook, :available?)
+      assert_raise(Ginseng::ConfigError) {hook.digest}
+      assert_raise(Ginseng::ConfigError) {hook.uri}
+    end
+
+    def test_digest_accepts_token
+      hook = build_webhook('valid_token')
+
+      assert_predicate(hook, :available?)
+      assert_match(/\A[0-9a-f]{64}\z/, hook.digest)
+      assert_kind_of(Ginseng::URI, hook.uri)
+    end
+
+    private
+
+    def build_webhook(token)
+      hook = Webhook.allocate
+      hook.instance_variable_set(:@sns, SNSDouble.new(token))
+      return hook
+    end
+  end
+end


### PR DESCRIPTION
Fixes #4487

## 問題

`Webhook#digest` は `user_config` のトークンから作るが、**トークンが未設定でも digest が返る**。`{sns:, token: nil, salt:}` の SHA256 が出るためで、「URL の形をしているのに誰のものでもない」幽霊 webhook URL になる。

`find_token_by_digest` は `oauth_access_tokens` を舐めて `token.webhook_digest`（＝トークン**文字列**から作った値）と突き合わせるので、`nil` から作った値に一致するレコードは存在しない。**設定はできたのに何も起きない**という静かな失敗になる。

## 変更

- **`digest` と `create_digest` の両方で空トークンを拒否**（`Ginseng::ConfigError`）。`create_digest` は `AccessToken#webhook_digest` からも呼ばれる入口なので二重に持つ
- **`available?` を追加**し、`Webhook.all` が幽霊を列挙しないようにした。混ざっていると `digest` / `uri` を呼んだ時点で落ちるうえ、そもそも照合できないので webhook として意味を持たない
- 判定は `to_s.empty?` ではなく **`blank?`**。空白だけのトークンも弾く（最初 `to_s.empty?` で書いてテストに落とされた）

`Account#webhook` が nil を返す案は採らなかった。呼び出し元（`api_controller` の `/config`）が `.uri.to_s` を直接叩いていて `NoMethodError` になるため、Issue の推奨どおり **`digest` で止めて例外にする**形にしている。

## テスト

`test/unit/model/webhook_token_guard.rb` を追加。Issue が求めていた「**トークンを持たないアカウントで webhook URL が得られないこと**」を正のケースとして書いた。

- `nil` / `''` / `'   '` を拒否すること
- `available?` が false であること、`digest` / `uri` が `ConfigError` を投げること
- 正常なトークンでは従来どおり digest / URI が得られること
- 🔴 **ガード追加で digest の値が変わらないこと。**digest は webhook URL の一部なので、変わると tomato-shrieker 等の外部連携が全部切れる（#4106 の経緯）。期待値を独立に計算して固定した

DB を引かないよう、`UserConfig` や SNS サービスではなく `token` / `uri` / `create_uri` だけを持つダブルで組み立てている。

**ガードを 2 つとも外すと実際に落ちる**ことを確認済み:

```
Failure: test_create_digest_rejects_blank_token: <Ginseng::ConfigError> exception was expected but none was thrown.
Failure: test_digest_rejects_blank_token: <Ginseng::ConfigError> exception was expected but none was thrown.
```

## 検証

829 tests / 1120 assertions / 0 failures / 0 errors、lint green。

## スコープ外にしたもの

- `WebhookImageHandler#disable?` の `sns.account&.webhook` は**常に truthy** なので実質ガードになっていない。`available?` を使えば意味を持つが、webhook 受信時は digest 経由でトークンが解決済みなので実害が無く、挙動を変える判断が要るため触っていない
- `Webhook.create` がトークン不整合のアカウントに対して「使えない Webhook」を返す点も同様。現状は上流 POST が 401 で失敗する

🤖 Generated with [Claude Code](https://claude.com/claude-code)