### PR TITLE
fix: 壊れた行で webhook token の走査を止めない・アイコンに代替テキストを添える

### DIFF
--- a/app/lib/mulukhiya/model/access_token_methods.rb
+++ b/app/lib/mulukhiya/model/access_token_methods.rb
@@ -2,8 +2,10 @@ module Mulukhiya
   module AccessTokenMethods
     include SNSMethods
 
+    # 空白だけのトークンも無効とする。`empty?` だと素通りして webhook_digest
+    # (空トークンで ConfigError) まで到達する (#4487)。
     def valid?
-      return false if to_s.empty?
+      return false if to_s.blank?
       return false unless account
       return true
     end

--- a/app/lib/mulukhiya/model/mastodon/access_token.rb
+++ b/app/lib/mulukhiya/model/mastodon/access_token.rb
@@ -8,8 +8,9 @@ module Mulukhiya
       many_to_one :user, key: :resource_owner_id
       many_to_one :application
 
+      # 空白だけのトークンも無効とする（AccessTokenMethods#valid? と同じ理由、#4487）。
       def valid?
-        return false if to_s.empty?
+        return false if to_s.blank?
         return false unless user.account
         return false if expires_in.present?
         return false if revoked_at.present?

--- a/app/lib/mulukhiya/webhook.rb
+++ b/app/lib/mulukhiya/webhook.rb
@@ -106,11 +106,19 @@ module Mulukhiya
         .each(&block)
     end
 
+    # ⚠ 1 行の失敗でループを抜けてはいけない。
+    #
+    # webhook_digest は空トークンで ConfigError を投げる (#4487)。valid? は
+    # `to_s.empty?` しか見ないので、空白だけのトークン行はここまで到達する。
+    # 例外がループの外へ出ると Webhook.create の rescue が nil を返し、
+    # **その行より後ろにある正しい webhook URL が「見つからない」ことになる**。
+    # 壊れた行は次へ送るだけにして、走査自体は最後まで続ける (#4487 / PR #4522)。
     def self.find_token_by_digest(digest)
       Postgres.exec(:webhook_tokens).each do |row|
         token = Environment.access_token_class[row[:id]] rescue next
         next unless token.valid?
-        return token if token.webhook_digest == digest
+        token_digest = token.webhook_digest rescue next
+        return token if token_digest == digest
       end
       return nil
     end

--- a/docs/api.md
+++ b/docs/api.md
@@ -885,10 +885,15 @@ Web Push サブスクリプションを解除する。
 | 状況 | ステータス | body |
 |---|---|---|
 | 認証なし・トークン不正 | **403** | `{"error":"Unauthorized"}` |
-| 他人の投稿・存在しない ID | **404** | `{"package":"ginseng-core","class":"Ginseng::NotFoundError","message":"Resource /mulukhiya/api/status/tags not found."}` |
+| **他人の投稿**（ID は存在するが所有者が違う） | **403** | `{"error":"Unauthorized"}` |
+| 存在しない ID | **404** | `{"package":"ginseng-core","class":"Ginseng::NotFoundError","message":"Resource /mulukhiya/api/status/tags not found."}` |
 | `/{controller}/capabilities/repost` が false | **404** | 同上 |
 | `tags` 未指定・不正 | **422** | `{"errors":{"tags":["空欄です。"]}}` |
 | 上流 SNS のエラー | 上流のステータス | `{"error":"Bad response NNN"}`（#4480 で改善予定） |
+
+  ⚠ **所有者違いは 404 ではなく 403。**ルートは先に status を引いてから
+  `status.updatable_by?(sns.account)` を見るので、**存在する他人の投稿は「無い」ではなく
+  「権限が無い」になる**。クライアントは 404 を「消えた」、403 を「触れない」として扱ってよい。
 
   ⚠ **404 の body だけ他と形が違う。**コントローラは `{"error":"Not Found"}` を組み立てているが、
   Sinatra の `not_found` ハンドラがステータス 404 を見て body を差し替えるため、個別のメッセージが

--- a/test/unit/model/webhook_token_guard.rb
+++ b/test/unit/model/webhook_token_guard.rb
@@ -9,6 +9,21 @@ module Mulukhiya
   #
   # DB を必要としないよう、UserConfig ではなく sns.token を直接差し替えて検証する。
   class WebhookTokenGuardTest < TestCase
+    # valid? / webhook_digest だけを持つ AccessToken のダブル。
+    #
+    # valid? は **是正前の `to_s.empty?`** を敢えて再現する。blank? に直した実装
+    # (#4487) が将来また緩んでも、find_token_by_digest 側の堅牢化だけで走査が
+    # 続くことをこのテストで担保するため。
+    TokenDouble = Struct.new(:token) do
+      def valid?
+        return !token.to_s.empty?
+      end
+
+      def webhook_digest
+        return Webhook.create_digest(Ginseng::URI.parse('https://example.com'), token)
+      end
+    end
+
     # UserConfig も SNS サービスも DB を引くので、digest / uri が必要とする
     # token / uri / create_uri だけを持つダブルを使う。
     SNSDouble = Struct.new(:token) do
@@ -69,7 +84,46 @@ module Mulukhiya
       assert_kind_of(Ginseng::URI, hook.uri)
     end
 
+    # ⚠ ガードの副作用で「正しい webhook URL が見つからなくなる」ことがあってはならない。
+    #
+    # webhook_digest は空トークンで raise するので、壊れた行が走査の途中にあると
+    # 例外が each の外へ出て、その行より**後ろ**の正しい行に辿り着けなくなる。
+    # 壊れた行は next で送り、走査は最後まで続ける（PR #4522 への Codex P2 指摘）。
+    def test_find_token_by_digest_skips_broken_row_and_keeps_scanning
+      good = TokenDouble.new('valid_token')
+      rows = [{id: 1}, {id: 2}]
+      # 1 行目は valid? を通るのに webhook_digest で落ちる行（空白トークン等）。
+      tokens = {1 => TokenDouble.new('   '), 2 => good}
+
+      with_webhook_tokens(rows, tokens) do
+        assert_equal(good, Webhook.find_token_by_digest(good.webhook_digest))
+      end
+    end
+
+    def test_find_token_by_digest_returns_nil_when_nothing_matches
+      rows = [{id: 1}]
+      tokens = {1 => TokenDouble.new('   ')}
+
+      with_webhook_tokens(rows, tokens) do
+        assert_nil(Webhook.find_token_by_digest('deadbeef'))
+      end
+    end
+
     private
+
+    def with_webhook_tokens(rows, tokens)
+      Postgres.singleton_class.alias_method(:exec_without_stub, :exec)
+      Environment.singleton_class.alias_method(:access_token_class_without_stub, :access_token_class)
+      Postgres.define_singleton_method(:exec) {|name, _params = {}| name == :webhook_tokens ? rows : []}
+      token_class = Class.new do
+        define_singleton_method(:[]) {|id| tokens[id]}
+      end
+      Environment.define_singleton_method(:access_token_class) {token_class}
+      yield
+    ensure
+      Postgres.singleton_class.alias_method(:exec, :exec_without_stub)
+      Environment.singleton_class.alias_method(:access_token_class, :access_token_class_without_stub)
+    end
 
     def build_webhook(token)
       hook = Webhook.allocate

--- a/views/default.sass
+++ b/views/default.sass
@@ -23,6 +23,20 @@ $monospace: Inconsolata, monospace
 [v-cloak]
   display: none
 
+// アイコンだけのセル・ボタンに添える、目に見えないラベル。
+// Font Awesome のグリフは private-use なのでアクセシビリティツリーに何も残らず、
+// スクリーンリーダーや FA 未読み込み時に真偽が区別できなくなる (PR #4498 の Codex 指摘)。
+.sr-only
+  position: absolute
+  width: 1px
+  height: 1px
+  margin: -1px
+  padding: 0
+  overflow: hidden
+  white-space: nowrap
+  border: 0
+  clip-path: inset(50%)
+
 body
   font:
     family: $serif

--- a/views/program.slim
+++ b/views/program.slim
@@ -155,13 +155,16 @@ html lang='ja' data-theme='light'
                     | {{entry.minutes}}分
                 td
                   span.tag.air v-if='entry.air'
-                    i class='fa fa-check'
+                    i class='fa fa-check' aria-hidden='true'
+                    span.sr-only エア番組
                 td
                   span.tag.livecure v-if='entry.livecure'
-                    i class='fa fa-check'
+                    i class='fa fa-check' aria-hidden='true'
+                    span.sr-only 実況対象
                 td
                   span.tag.enable v-if='entry.enable'
-                    i class='fa fa-check'
+                    i class='fa fa-check' aria-hidden='true'
+                    span.sr-only 有効
                 td.actions
                   button.small.danger @click.stop='deleteEntry(key)' v-if='editable' v-tooltip.top="'削除'"
                     i class='fa fa-trash'


### PR DESCRIPTION
セッション同期で拾った Codex レビュー指摘（PR #4522 / #4521 / #4498）の是正をまとめて。

## 1. `Webhook.find_token_by_digest` が 1 行の失敗で走査を止める（#4487 / P2）

#4522 で `webhook_digest` が空トークンで raise するようにしたが、`AccessToken#valid?` は
`to_s.empty?` しか見ないので**空白だけのトークン行は valid? を通って raise まで到達する**。
例外が `each` の外へ出ると `Webhook.create` の rescue が `nil` を返し、
**その行より後ろにある正しい webhook URL が「見つからない」ことになる。**

- 壊れた行は `next` で送り、走査は最後まで続ける
- あわせて `valid?` を `empty?` → `blank?` に。幽霊行が `webhook_entries` にも混ざらなくなる

回帰テストは「壊れた行の**後ろ**にある正しい行が引けること」を見る。是正前の実装では落ちる（確認済み）。

## 2. `POST /status/tags` の「他人の投稿」は 403（#4491 / P2）

ルートは `status_class[params[:id]]` で先に status を引き、その後 `updatable_by?` で
`Ginseng::AuthError` を投げる。**存在する他人の投稿は 404 ではなく 403 `{"error":"Unauthorized"}`。**
表で「他人の投稿・存在しない ID」を 1 行に束ねていたのを分けた。

## 3. 一覧表のチェックアイコンに代替テキスト（#4483 / P2）

`<i class="fa fa-check">` は中身が空で、可視のチェックは CSS の private-use グリフ。
スクリーンリーダー・FA 未読み込み時に**真と偽が区別できない**（以前の `✔` はツリーに残っていた）。
`aria-hidden` + `.sr-only` ラベル（エア番組 / 実況対象 / 有効）を添えた。

## 別 Issue へ送ったもの

PR #4501（#4410 の SSRF 対応）への P1 指摘 2 件は独立して扱う。

- **#4523** HEAD プリフライトが allowlist を通っていない → 別 PR（pooza/ginseng-core#495 待ち）
- **#4524** DNS リバインディング（名前で検証して名前で接続している）→ 5.32.0

## テスト

`webhook_token_guard` / `webhook` / `webhook_digest`: 22 tests, 0 failures, 0 errors（9 omissions は DB 前提の既存分）。rubocop クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)