### PR TITLE
feat: 番組表エディタの一覧に「有効」トグルを付ける (#4484)

### DIFF
--- a/app/lib/mulukhiya/model/access_token_methods.rb
+++ b/app/lib/mulukhiya/model/access_token_methods.rb
@@ -2,8 +2,10 @@ module Mulukhiya
   module AccessTokenMethods
     include SNSMethods
 
+    # 空白だけのトークンも無効とする。`empty?` だと素通りして webhook_digest
+    # (空トークンで ConfigError) まで到達する (#4487)。
     def valid?
-      return false if to_s.empty?
+      return false if to_s.blank?
       return false unless account
       return true
     end

--- a/app/lib/mulukhiya/model/mastodon/access_token.rb
+++ b/app/lib/mulukhiya/model/mastodon/access_token.rb
@@ -8,8 +8,9 @@ module Mulukhiya
       many_to_one :user, key: :resource_owner_id
       many_to_one :application
 
+      # 空白だけのトークンも無効とする（AccessTokenMethods#valid? と同じ理由、#4487）。
       def valid?
-        return false if to_s.empty?
+        return false if to_s.blank?
         return false unless user.account
         return false if expires_in.present?
         return false if revoked_at.present?

--- a/app/lib/mulukhiya/webhook.rb
+++ b/app/lib/mulukhiya/webhook.rb
@@ -106,11 +106,19 @@ module Mulukhiya
         .each(&block)
     end
 
+    # ⚠ 1 行の失敗でループを抜けてはいけない。
+    #
+    # webhook_digest は空トークンで ConfigError を投げる (#4487)。valid? は
+    # `to_s.empty?` しか見ないので、空白だけのトークン行はここまで到達する。
+    # 例外がループの外へ出ると Webhook.create の rescue が nil を返し、
+    # **その行より後ろにある正しい webhook URL が「見つからない」ことになる**。
+    # 壊れた行は次へ送るだけにして、走査自体は最後まで続ける (#4487 / PR #4522)。
     def self.find_token_by_digest(digest)
       Postgres.exec(:webhook_tokens).each do |row|
         token = Environment.access_token_class[row[:id]] rescue next
         next unless token.valid?
-        return token if token.webhook_digest == digest
+        token_digest = token.webhook_digest rescue next
+        return token if token_digest == digest
       end
       return nil
     end

--- a/docs/api.md
+++ b/docs/api.md
@@ -885,10 +885,15 @@ Web Push サブスクリプションを解除する。
 | 状況 | ステータス | body |
 |---|---|---|
 | 認証なし・トークン不正 | **403** | `{"error":"Unauthorized"}` |
-| 他人の投稿・存在しない ID | **404** | `{"package":"ginseng-core","class":"Ginseng::NotFoundError","message":"Resource /mulukhiya/api/status/tags not found."}` |
+| **他人の投稿**（ID は存在するが所有者が違う） | **403** | `{"error":"Unauthorized"}` |
+| 存在しない ID | **404** | `{"package":"ginseng-core","class":"Ginseng::NotFoundError","message":"Resource /mulukhiya/api/status/tags not found."}` |
 | `/{controller}/capabilities/repost` が false | **404** | 同上 |
 | `tags` 未指定・不正 | **422** | `{"errors":{"tags":["空欄です。"]}}` |
 | 上流 SNS のエラー | 上流のステータス | `{"error":"Bad response NNN"}`（#4480 で改善予定） |
+
+  ⚠ **所有者違いは 404 ではなく 403。**ルートは先に status を引いてから
+  `status.updatable_by?(sns.account)` を見るので、**存在する他人の投稿は「無い」ではなく
+  「権限が無い」になる**。クライアントは 404 を「消えた」、403 を「触れない」として扱ってよい。
 
   ⚠ **404 の body だけ他と形が違う。**コントローラは `{"error":"Not Found"}` を組み立てているが、
   Sinatra の `not_found` ハンドラがステータス 404 を見て body を差し替えるため、個別のメッセージが

--- a/test/contract/program_entry_update_contract.rb
+++ b/test/contract/program_entry_update_contract.rb
@@ -22,6 +22,15 @@ module Mulukhiya
       assert_empty(errors)
     end
 
+    # 一覧の「有効」トグルは enable だけを送る (#4484)。false も通ること。
+    def test_partial_enable_only
+      [true, false].each do |value|
+        errors = @contract.call(enable: value).errors
+
+        assert_empty(errors, "enable=#{value} を拒否している")
+      end
+    end
+
     def test_series_when_provided_must_not_be_empty
       errors = @contract.call(series: '').errors
 

--- a/test/unit/model/program.rb
+++ b/test/unit/model/program.rb
@@ -138,6 +138,21 @@ module Mulukhiya
       @program.save(original) if original
     end
 
+    # ⚠ 一覧の「有効」トグル (#4484) は enable だけを送る。false は blank_value?
+    # ではないので、キーごと消えず false として残らなければならない。
+    def test_update_entry_keeps_false_enable
+      key = "test_enable_#{Time.now.to_i}"
+      original = @program.data
+      @program.save(key => {'series' => 'A', 'enable' => true})
+      entry = @program.update_entry(key, 'enable' => false)
+
+      assert_includes(entry.keys, 'enable')
+      assert_false(entry['enable'])
+      assert_true(@program.update_entry(key, 'enable' => true)['enable'])
+    ensure
+      @program.save(original) if original
+    end
+
     def test_update_entry_raises_when_missing
       original = @program.data
 

--- a/test/unit/model/webhook_token_guard.rb
+++ b/test/unit/model/webhook_token_guard.rb
@@ -9,6 +9,21 @@ module Mulukhiya
   #
   # DB を必要としないよう、UserConfig ではなく sns.token を直接差し替えて検証する。
   class WebhookTokenGuardTest < TestCase
+    # valid? / webhook_digest だけを持つ AccessToken のダブル。
+    #
+    # valid? は **是正前の `to_s.empty?`** を敢えて再現する。blank? に直した実装
+    # (#4487) が将来また緩んでも、find_token_by_digest 側の堅牢化だけで走査が
+    # 続くことをこのテストで担保するため。
+    TokenDouble = Struct.new(:token) do
+      def valid?
+        return !token.to_s.empty?
+      end
+
+      def webhook_digest
+        return Webhook.create_digest(Ginseng::URI.parse('https://example.com'), token)
+      end
+    end
+
     # UserConfig も SNS サービスも DB を引くので、digest / uri が必要とする
     # token / uri / create_uri だけを持つダブルを使う。
     SNSDouble = Struct.new(:token) do
@@ -69,7 +84,46 @@ module Mulukhiya
       assert_kind_of(Ginseng::URI, hook.uri)
     end
 
+    # ⚠ ガードの副作用で「正しい webhook URL が見つからなくなる」ことがあってはならない。
+    #
+    # webhook_digest は空トークンで raise するので、壊れた行が走査の途中にあると
+    # 例外が each の外へ出て、その行より**後ろ**の正しい行に辿り着けなくなる。
+    # 壊れた行は next で送り、走査は最後まで続ける（PR #4522 への Codex P2 指摘）。
+    def test_find_token_by_digest_skips_broken_row_and_keeps_scanning
+      good = TokenDouble.new('valid_token')
+      rows = [{id: 1}, {id: 2}]
+      # 1 行目は valid? を通るのに webhook_digest で落ちる行（空白トークン等）。
+      tokens = {1 => TokenDouble.new('   '), 2 => good}
+
+      with_webhook_tokens(rows, tokens) do
+        assert_equal(good, Webhook.find_token_by_digest(good.webhook_digest))
+      end
+    end
+
+    def test_find_token_by_digest_returns_nil_when_nothing_matches
+      rows = [{id: 1}]
+      tokens = {1 => TokenDouble.new('   ')}
+
+      with_webhook_tokens(rows, tokens) do
+        assert_nil(Webhook.find_token_by_digest('deadbeef'))
+      end
+    end
+
     private
+
+    def with_webhook_tokens(rows, tokens)
+      Postgres.singleton_class.alias_method(:exec_without_stub, :exec)
+      Environment.singleton_class.alias_method(:access_token_class_without_stub, :access_token_class)
+      Postgres.define_singleton_method(:exec) {|name, _params = {}| name == :webhook_tokens ? rows : []}
+      token_class = Class.new do
+        define_singleton_method(:[]) {|id| tokens[id]}
+      end
+      Environment.define_singleton_method(:access_token_class) {token_class}
+      yield
+    ensure
+      Postgres.singleton_class.alias_method(:exec, :exec_without_stub)
+      Environment.singleton_class.alias_method(:access_token_class, :access_token_class_without_stub)
+    end
 
     def build_webhook(token)
       hook = Webhook.allocate

--- a/views/default.sass
+++ b/views/default.sass
@@ -23,6 +23,20 @@ $monospace: Inconsolata, monospace
 [v-cloak]
   display: none
 
+// アイコンだけのセル・ボタンに添える、目に見えないラベル。
+// Font Awesome のグリフは private-use なのでアクセシビリティツリーに何も残らず、
+// スクリーンリーダーや FA 未読み込み時に真偽が区別できなくなる (PR #4498 の Codex 指摘)。
+.sr-only
+  position: absolute
+  width: 1px
+  height: 1px
+  margin: -1px
+  padding: 0
+  overflow: hidden
+  white-space: nowrap
+  border: 0
+  clip-path: inset(50%)
+
 body
   font:
     family: $serif

--- a/views/default.sass
+++ b/views/default.sass
@@ -592,6 +592,15 @@ section.disabled h3::after
           background-color: papayawhip !important
     td.actions
       text-align: right
+    // 一覧上で有効/無効をその場で切り替えるトグル (#4484)。
+    // 無効側は「押していない」ことが色でも分かるよう淡く落とす。
+    button.enable-toggle
+      &.off
+        background:
+          color: transparent
+        border:
+          color: gray
+        color: gray
 
 nav.search-form-container
   display: block

--- a/views/program.slim
+++ b/views/program.slim
@@ -162,7 +162,11 @@ html lang='ja' data-theme='light'
                     i class='fa fa-check' aria-hidden='true'
                     span.sr-only 実況対象
                 td
-                  span.tag.enable v-if='entry.enable'
+                  button.small.enable-toggle :class="{off: !entry.enable}" @click.stop='toggleEnable(key, entry)' v-if='editable' :aria-pressed="entry.enable ? 'true' : 'false'" v-tooltip.top="entry.enable ? '無効にする' : '有効にする'"
+                    i class='fa' :class="entry.enable ? 'fa-check' : 'fa-xmark'" aria-hidden='true'
+                    span.sr-only
+                      | {{entry.enable ? '有効' : '無効'}}
+                  span.tag.enable v-else-if='entry.enable'
                     i class='fa fa-check' aria-hidden='true'
                     span.sr-only 有効
                 td.actions
@@ -289,6 +293,22 @@ html lang='ja' data-theme='light'
                       this.loadEntries()
                     })
                     .catch(e => Swal.fire({text: this.methods.createErrorMessage(e), icon: 'error'}))
+                })
+            },
+            toggleEnable (key, entry) {
+              const next = !entry.enable
+              // 楽観更新。放送前後にまとめて切り替えるので、往復を待たずに
+              // 行の見た目 (disabled クラス) が追従するほうが手数が減る (#4484)。
+              // 失敗したら loadEntries() でサーバーの値へ巻き戻す。
+              entry.enable = next
+              this.methods.updateProgramEntry(key, {enable: next})
+                .then(_ => {
+                  Swal.fire({title: next ? '有効にしました。' : '無効にしました。', toast: true, position: 'top-end', icon: 'success', showConfirmButton: false, timer: 2000})
+                  this.loadEntries()
+                })
+                .catch(e => {
+                  entry.enable = !next
+                  Swal.fire({text: this.methods.createErrorMessage(e), icon: 'error'})
                 })
             },
             incrementEpisode (key) {

--- a/views/program.slim
+++ b/views/program.slim
@@ -155,13 +155,16 @@ html lang='ja' data-theme='light'
                     | {{entry.minutes}}分
                 td
                   span.tag.air v-if='entry.air'
-                    i class='fa fa-check'
+                    i class='fa fa-check' aria-hidden='true'
+                    span.sr-only エア番組
                 td
                   span.tag.livecure v-if='entry.livecure'
-                    i class='fa fa-check'
+                    i class='fa fa-check' aria-hidden='true'
+                    span.sr-only 実況対象
                 td
                   span.tag.enable v-if='entry.enable'
-                    i class='fa fa-check'
+                    i class='fa fa-check' aria-hidden='true'
+                    span.sr-only 有効
                 td.actions
                   button.small.danger @click.stop='deleteEntry(key)' v-if='editable' v-tooltip.top="'削除'"
                     i class='fa fa-trash'


### PR DESCRIPTION
Closes #4484

⚠ **PR #4525 の上に積んでいます。**（`.sr-only` クラスと `views/program.slim` の同じセルを触るため）。#4525 を先にマージしてください。

## 変更

- エントリ一覧の「有効」列を、`editable` のときトグルボタンにする。非 `editable`（`/program/auto_update` が true）のときは従来のチェック表示のまま
- 送るのは `enable` だけ（`PUT /admin/program/entry/:key`）。専用エンドポイントは起こさず、既存の部分更新に載せた
- 押下時は**楽観更新**してから API を呼び、失敗したら元へ戻す。行の `:class="{disabled: !entry.enable}"` が往復を待たずに追従するので、まとめて切り替えるときに待たされない
- `aria-pressed` と `.sr-only` ラベル（有効 / 無効）を持たせ、アイコンだけの状態にしない
- 無効側は枠線・文字をグレーに落として、押していないことが色でも分かるようにした

## enable: false が消えないこと

`Program#update_entry` は `blank_value?` の値をキーごと削除する。該当するのは **nil と空白だけの文字列**で `false` は含まれないため、`enable: false` は `false` として残る。ここが崩れると「無効にしたのに有効に戻る」になるので、`test/unit/model/program.rb` に回帰テストを足した。

## テスト

- `test/contract/program_entry_update_contract.rb` — `enable` 単独（true / false）が通ること。**21 tests / 0 failures**
- `test/unit/model/program.rb` — `enable: false` がキーごと消えないこと。⚠ `ProgramTest` は `livecure?` が false の環境では omit されるため、手元では実行されていない（#4503 と同根）

`slim-lint` は既存の LineLength 警告のみでエラー 0、`rubocop` クリーン。

## モンキーテスト

WebUI の変更なので、キュアスタ！の番組表エディタで実際にトグルを押して確認してからクローズしてください（`feedback_issue-close-by-monkey-test`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)