### PR TITLE
refactor: 上流エラー包絡を捨てず透過する (#4480)

### DIFF
--- a/app/lib/mulukhiya/clipping_worker.rb
+++ b/app/lib/mulukhiya/clipping_worker.rb
@@ -20,6 +20,8 @@ module Mulukhiya
       return uri.to_md if uri.local?
       return uri.to_s
     rescue => e
+      # 内側が既に GatewayError なら包み直さない（上流のレスポンスが落ちる、#4480）。
+      raise e if e.is_a?(Ginseng::GatewayError) && uri.nil?
       raise Ginseng::GatewayError, e.message, e.backtrace unless uri
       e.log(uri: uri.to_s)
       return uri.to_s

--- a/app/lib/mulukhiya/controller.rb
+++ b/app/lib/mulukhiya/controller.rb
@@ -97,6 +97,45 @@ module Mulukhiya
       raise Ginseng::AuthError, 'Token integrity check failed'
     end
 
+    # 上流のエラー包絡をそのままクライアントへ返す (#4480)。
+    #
+    # モロヘイヤはプロキシなので、上流が返した理由——Misskey の
+    # `{"error":{"code":"TOO_MANY_DRAFTS", ...}}`、Mastodon の
+    # `{"error":"Validation failed: ..."}`——を素通しするのが本来の姿。
+    # ここに文言テーブルを持つ必要はない。従来は `Ginseng::HTTP` が上流ボディを
+    # 捨てて `"Bad response NNN"` に潰していたため、クライアント（capsicum）は
+    # 理由で出し分けられなかった（pooza/capsicum#879 / #4380）。
+    #
+    # ⚠ 透過するのは **上流が JSON として返したものだけ**。`source_body` は
+    # HTML エラーページ（nginx の 502 等）や巨大ボディで nil を返すので、
+    # その場合は従来どおり `{error: e.message}` に倒れる。モロヘイヤ内部の
+    # 例外メッセージを混ぜてはいけない（内部情報の露出）。
+    #
+    # silent_statuses / silent_codes は Sentry alert を抑止する条件。401 は
+    # トークン期限切れで頻繁に起きるため既定で含める。silent_codes は上流の
+    # エラーコード（Misskey の `error.code`）で、ユーザー起因の失敗まで
+    # Sentry イベントを立てないための口。
+    def handle_gateway_error(error, silent_statuses: [401], silent_codes: [])
+      silent = silent_statuses.include?(error.source_status) ||
+        silent_codes.include?(upstream_error_code(error))
+      error.alert unless silent
+      @renderer.message = error.source_body || {error: error.message}
+      return @renderer.status = error.source_status
+    end
+
+    # 上流の `{"error": {"code": "..."}}` から code を取る。取れなければ nil。
+    #
+    # ⚠ Mastodon の包絡は `{"error": "Validation failed: ..."}` で error が
+    # **文字列**。Hash 前提で dig すると TypeError になる。上流の形を決め打ち
+    # できないので、各段で型を確かめる。
+    def upstream_error_code(error)
+      body = error.source_body
+      return nil unless body.is_a?(Hash)
+      envelope = body['error']
+      return nil unless envelope.is_a?(Hash)
+      return envelope['code']
+    end
+
     def verify_account_integrity!(response)
       return unless response&.parsed_response.is_a?(Hash)
       posted_id = response.parsed_response.dig('account', 'id') ||

--- a/app/lib/mulukhiya/controller/mastodon_controller.rb
+++ b/app/lib/mulukhiya/controller/mastodon_controller.rb
@@ -14,9 +14,7 @@ module Mulukhiya
       @renderer.status = reporter.response.code
       return @renderer.to_s
     rescue Ginseng::GatewayError => e
-      e.alert unless e.source_status == 401
-      @renderer.message = {error: e.message}
-      @renderer.status = e.source_status
+      handle_gateway_error(e)
       return @renderer.to_s
     end
 
@@ -72,9 +70,7 @@ module Mulukhiya
       @renderer.status = 422
       return @renderer.to_s
     rescue Ginseng::GatewayError => e
-      e.alert unless e.source_status == 401
-      @renderer.message = {error: e.message}
-      @renderer.status = e.source_status
+      handle_gateway_error(e)
       return @renderer.to_s
     end
 
@@ -87,9 +83,7 @@ module Mulukhiya
       @renderer.status = reporter.response.code
       return @renderer.to_s
     rescue Ginseng::GatewayError => e
-      e.alert unless e.source_status == 401
-      @renderer.message = {error: e.message}
-      @renderer.status = e.source_status
+      handle_gateway_error(e)
       return @renderer.to_s
     end
 
@@ -102,9 +96,7 @@ module Mulukhiya
       @renderer.status = reporter.response.code
       return @renderer.to_s
     rescue Ginseng::GatewayError => e
-      e.alert unless e.source_status == 401
-      @renderer.message = {error: e.message}
-      @renderer.status = e.source_status
+      handle_gateway_error(e)
       return @renderer.to_s
     end
 
@@ -117,9 +109,7 @@ module Mulukhiya
       @renderer.status = reporter.response.code
       return @renderer.to_s
     rescue Ginseng::GatewayError => e
-      e.alert unless e.source_status == 401
-      @renderer.message = {error: e.message}
-      @renderer.status = e.source_status
+      handle_gateway_error(e)
       return @renderer.to_s
     end
 
@@ -136,14 +126,16 @@ module Mulukhiya
 
     # 413 はユーザーのファイルサイズ超過であり系の不具合ではないため Sentry alert を抑止する。
     # 401 は既存どおりトークン期限切れ等で頻繁に起きるため除外する。
+    #
+    # 413 だけはモロヘイヤ側の文言を出す。上流（nginx）が HTML を返すことが多く
+    # 透過しても読めないうえ、「上限を超過している」はクライアント共通で
+    # 出せる説明だから (#4480 で透過へ寄せた後もここは残す)。
     def handle_upload_gateway_error(error)
-      error.alert unless [401, 413].include?(error.source_status)
-      if error.source_status == 413
-        @renderer.message = {error: 'アップロードしたファイルがサーバーの上限サイズを超過しています。'}
-      else
-        @renderer.message = {error: error.message}
+      unless error.source_status == 413
+        return handle_gateway_error(error, silent_statuses: [401, 413])
       end
-      return @renderer.status = error.source_status
+      @renderer.message = {error: 'アップロードしたファイルがサーバーの上限サイズを超過しています。'}
+      return @renderer.status = 413
     end
   end
 end

--- a/app/lib/mulukhiya/controller/misskey_controller.rb
+++ b/app/lib/mulukhiya/controller/misskey_controller.rb
@@ -2,6 +2,51 @@ module Mulukhiya
   class MisskeyController < Controller
     include ControllerMethods
 
+    # ユーザー起因で日常的に起きる Misskey のエラーコード。系の不具合ではないので
+    # Sentry alert を抑止する（アップロードの 413 を抑止しているのと同じ判断、#4480）。
+    #
+    # 出典は Misskey 本体 `packages/backend/src/server/api/endpoints/` の
+    # notes/create・notes/drafts/{create,update}・notes/favorites/create・
+    # notes/reactions/create・drive/files/create が宣言する errors。
+    # **モロヘイヤが横取りしているエンドポイントの分だけ**を列挙する。
+    # 上流が新しいコードを足しても alert が出るだけで壊れないので、追従は随時でよい。
+    USER_FAULT_CODES = [
+      'ACCESS_DENIED',
+      'ALREADY_FAVORITED',
+      'ALREADY_REACTED',
+      'CANNOT_CREATE_ALREADY_EXPIRED_POLL',
+      'CANNOT_REACT_TO_RENOTE',
+      'CANNOT_RENOTE',
+      'CANNOT_RENOTE_DUE_TO_VISIBILITY',
+      'CANNOT_RENOTE_OUTSIDE_OF_CHANNEL',
+      'CANNOT_RENOTE_TO_A_PURE_RENOTE',
+      'CANNOT_RENOTE_TO_EXTERNAL',
+      'CANNOT_REPLY_TO_AN_INVISIBLE_NOTE',
+      'CANNOT_REPLY_TO_A_PURE_RENOTE',
+      'CANNOT_REPLY_TO_SPECIFIED_NOTE_WITH_EXTENDED_VISIBILITY',
+      'CANNOT_REPLY_TO_SPECIFIED_VISIBILITY_NOTE_WITH_EXTENDED_VISIBILITY',
+      'CONTAINS_PROHIBITED_WORDS',
+      'CONTAINS_TOO_MANY_MENTIONS',
+      'INAPPROPRIATE',
+      'INVALID_FILE_NAME',
+      'MAX_FILE_SIZE_EXCEEDED',
+      'NO_FREE_SPACE',
+      'NO_SUCH_CHANNEL',
+      'NO_SUCH_FILE',
+      'NO_SUCH_NOTE',
+      'NO_SUCH_NOTE_DRAFT',
+      'NO_SUCH_RENOTE',
+      'NO_SUCH_RENOTE_TARGET',
+      'NO_SUCH_REPLY',
+      'NO_SUCH_REPLY_TARGET',
+      'SCHEDULED_AT_MUST_BE_IN_FUTURE',
+      'SCHEDULED_AT_REQUIRED',
+      'TOO_MANY_DRAFTS',
+      'TOO_MANY_SCHEDULED_NOTES',
+      'UNALLOWED_FILE_TYPE',
+      'YOU_HAVE_BEEN_BLOCKED',
+    ].freeze
+
     post '/api/notes/create' do
       verify_token_integrity!
       params[visibility_field] = status_class[params[:renoteId]][visibility_field.to_sym] if quote?
@@ -14,9 +59,7 @@ module Mulukhiya
       @renderer.status = reporter.response.code
       return @renderer.to_s
     rescue Ginseng::GatewayError => e
-      e.alert unless e.source_status == 401
-      @renderer.message = {error: e.message}
-      @renderer.status = e.source_status
+      handle_gateway_error(e, silent_codes: USER_FAULT_CODES)
       return @renderer.to_s
     end
 
@@ -32,9 +75,7 @@ module Mulukhiya
       @renderer.status = reporter.response.code
       return @renderer.to_s
     rescue Ginseng::GatewayError => e
-      e.alert unless e.source_status == 401
-      @renderer.message = {error: e.message}
-      @renderer.status = e.source_status
+      handle_gateway_error(e, silent_codes: USER_FAULT_CODES)
       return @renderer.to_s
     end
 
@@ -56,9 +97,7 @@ module Mulukhiya
       @renderer.status = reporter.response.code
       return @renderer.to_s
     rescue Ginseng::GatewayError => e
-      e.alert unless e.source_status == 401
-      @renderer.message = {error: e.message}
-      @renderer.status = e.source_status
+      handle_gateway_error(e, silent_codes: USER_FAULT_CODES)
       return @renderer.to_s
     end
 
@@ -88,15 +127,17 @@ module Mulukhiya
       @renderer.status = reporter.response.code
       return @renderer.to_s
     rescue Ginseng::GatewayError => e
-      # お気に入りは冪等操作。上流が 400 (大半は ALREADY_FAVORITED) を返しても、
-      # 呼び出し後 note は必ずお気に入り状態にあるため成功として扱う。
-      # Ginseng::HTTP は上流ボディを捨てて "Bad response 400" にするため
-      # ALREADY_FAVORITED か否かは判別できないが、favorites/create の 400 は
-      # 実質これに限られる (capsicum #565)。
-      if e.source_status == 400
+      # お気に入りは冪等操作。ALREADY_FAVORITED なら呼び出し後 note は必ず
+      # お気に入り状態にあるため成功として扱う (capsicum#565 / #4381)。
+      #
+      # ⚠ かつては **400 を全部**丸めていた。上流ボディが捨てられていて
+      # ALREADY_FAVORITED か否かを判別できなかったためで、NO_SUCH_NOTE
+      # （不正な id）まで成功と偽っていた。#4480 で code が読めるようになった
+      # ので、丸めるのは ALREADY_FAVORITED だけに絞る。
+      if upstream_error_code(e) == 'ALREADY_FAVORITED'
         # 完全無音だと冪等吸収の頻度・偏りを追えないため info ログを残す (#4394)。
         Logger.new.info(misskey_favorite: {
-          event: 'idempotent_400',
+          event: 'idempotent_already_favorited',
           account_id: sns.account&.id,
           note_id: params[:noteId],
         })
@@ -104,9 +145,7 @@ module Mulukhiya
         @renderer.status = 200
         return @renderer.to_s
       end
-      e.alert unless e.source_status == 401
-      @renderer.message = {error: e.message}
-      @renderer.status = e.source_status
+      handle_gateway_error(e, silent_codes: USER_FAULT_CODES)
       return @renderer.to_s
     end
 
@@ -118,9 +157,7 @@ module Mulukhiya
       @renderer.status = reporter.response.code
       return @renderer.to_s
     rescue Ginseng::GatewayError => e
-      e.alert unless e.source_status == 401
-      @renderer.message = {error: e.message}
-      @renderer.status = e.source_status
+      handle_gateway_error(e, silent_codes: USER_FAULT_CODES)
       return @renderer.to_s
     end
 
@@ -149,14 +186,20 @@ module Mulukhiya
 
     # 413 はユーザーのファイルサイズ超過であり系の不具合ではないため Sentry alert を抑止する。
     # 401 は既存どおりトークン期限切れ等で頻繁に起きるため除外する。
+    #
+    # 413 だけはモロヘイヤ側の文言を出す。上流（nginx）が HTML を返すことが多く
+    # 透過しても読めないうえ、「上限を超過している」はクライアント共通で出せる
+    # 説明だから (#4480 で透過へ寄せた後もここは残す)。
     def handle_upload_gateway_error(error)
-      error.alert unless [401, 413].include?(error.source_status)
-      if error.source_status == 413
-        @renderer.message = {error: 'アップロードしたファイルがサーバーの上限サイズを超過しています。'}
-      else
-        @renderer.message = {error: error.message}
+      unless error.source_status == 413
+        return handle_gateway_error(
+          error,
+          silent_statuses: [401, 413],
+          silent_codes: USER_FAULT_CODES,
+        )
       end
-      return @renderer.status = error.source_status
+      @renderer.message = {error: 'アップロードしたファイルがサーバーの上限サイズを超過しています。'}
+      return @renderer.status = 413
     end
   end
 end

--- a/app/lib/mulukhiya/service/annict_service.rb
+++ b/app/lib/mulukhiya/service/annict_service.rb
@@ -145,7 +145,10 @@ module Mulukhiya
       response = begin
         query(template, variables)
       rescue Ginseng::GatewayError => e
-        if /Bad response (401|403)/.match?(e.message.to_s)
+        # ⚠ かつては e.message を `/Bad response (401|403)/` で舐めていた。
+        # ginseng-core のメッセージ書式に依存した壊れやすい実装なので、
+        # source_status で判定する (#4480)。
+        if [401, 403].include?(e.source_status)
           raise Ginseng::AuthError, 'Annict authorization required'
         end
         raise

--- a/app/lib/mulukhiya/service/spotify_user_service.rb
+++ b/app/lib/mulukhiya/service/spotify_user_service.rb
@@ -19,6 +19,15 @@ module Mulukhiya
     TOKEN_PATH = '/api/token'.freeze
     CURRENTLY_PLAYING_PATH = '/v1/me/player/currently-playing'.freeze
 
+    # token endpoint が返す OAuth 2.0 の error のうち、**こちら側の設定ミス**を
+    # 指すもの。ユーザーが再連携しても直らないので「要再認証」に倒さない (#4480)。
+    OPERATOR_FAULT_OAUTH_ERRORS = [
+      'invalid_client',
+      'unauthorized_client',
+      'unsupported_grant_type',
+      'invalid_scope',
+    ].freeze
+
     # account は currently_playing / auth / unlink で必要 (refresh したトークンを
     # UserConfig へ書き戻すため)。oauth_uri のみ account なしでも使える。
     def initialize(account = nil)
@@ -135,7 +144,14 @@ module Mulukhiya
       # これは再認証が必要なユーザー起因エラーなので AuthError (401) に倒し、
       # capsicum に再連携フローを誘導させる。5xx/timeout は Spotify 障害なので
       # GatewayError (502) のまま上げる。
+      #
+      # ⚠ 4xx を一括で「再認証が必要」に倒してはいけない。invalid_client は
+      # **こちらの client_id/secret の設定ミス**で、ユーザーが何度再連携しても
+      # 直らない。ユーザーのせいにせず GatewayError のまま上げて Sentry に
+      # 出す (#4480)。上流の error は OAuth 2.0 の `{"error": "..."}` 形式。
       raise unless e.source_status&.between?(400, 499)
+      body = e.source_body
+      raise if body.is_a?(Hash) && OPERATOR_FAULT_OAUTH_ERRORS.include?(body['error'])
       raise Ginseng::AuthError, 'Spotify re-authentication required'
     end
 

--- a/app/lib/mulukhiya/uri/note_uri.rb
+++ b/app/lib/mulukhiya/uri/note_uri.rb
@@ -20,6 +20,9 @@ module Mulukhiya
       template[:url] = self
       return template.to_s
     rescue => e
+      # 内側が既に GatewayError（上流の取得失敗）なら包み直さない。
+      # 包み直すと上流のレスポンス (#4480) が落ちる。
+      raise e if e.is_a?(Ginseng::GatewayError)
       raise Ginseng::GatewayError, e.message, e.backtrace
     end
 

--- a/app/lib/mulukhiya/uri/toot_uri.rb
+++ b/app/lib/mulukhiya/uri/toot_uri.rb
@@ -18,6 +18,9 @@ module Mulukhiya
       template[:url] = self
       return template.to_s
     rescue => e
+      # 内側が既に GatewayError（上流の取得失敗）なら包み直さない。
+      # 包み直すと上流のレスポンス (#4480) が落ちる。
+      raise e if e.is_a?(Ginseng::GatewayError)
       raise Ginseng::GatewayError, e.message, e.backtrace
     end
 

--- a/test/unit/controller/gateway_error_transparency.rb
+++ b/test/unit/controller/gateway_error_transparency.rb
@@ -1,0 +1,120 @@
+module Mulukhiya
+  # 上流のエラー包絡がクライアントまで届くこと (#4480)。
+  #
+  # モロヘイヤはプロキシなので、上流が返した理由（Misskey の TOO_MANY_DRAFTS、
+  # Mastodon の Validation failed）を素通しするのが本来の姿。従来は
+  # Ginseng::HTTP が上流ボディを捨てて "Bad response NNN" に潰していた。
+  class GatewayErrorTransparencyTest < TestCase
+    # 上流レスポンスのダブル。GatewayError#source_body / #source_status が
+    # 見るのは code と body だけ。
+    ResponseDouble = Struct.new(:code, :body)
+
+    def setup
+      @controller = MisskeyController.new!
+      @renderer = Ginseng::Web::JSONRenderer.new
+      @controller.instance_variable_set(:@renderer, @renderer)
+    end
+
+    # 正のケース: 上流の code がクライアントまで届く。
+    def test_passes_upstream_json_through
+      error = build_error(400, {error: {code: 'TOO_MANY_DRAFTS', id: 'deadbeef'}}.to_json)
+
+      @controller.handle_gateway_error(error)
+
+      assert_equal('TOO_MANY_DRAFTS', @renderer.message.dig(:error, :code) || @renderer.message.dig('error', 'code'))
+      assert_equal(400, @renderer.status)
+    end
+
+    def test_passes_mastodon_flat_error_through
+      error = build_error(422, {error: 'Validation failed: Text is too long'}.to_json)
+
+      @controller.handle_gateway_error(error)
+
+      assert_equal('Validation failed: Text is too long', fetch(@renderer.message, 'error'))
+      assert_equal(422, @renderer.status)
+    end
+
+    # ⚠ 上流が HTML を返すことがある（nginx の 502 等）。素通しするとプロキシが
+    # 他人の HTML を吐くので、従来どおり {error: e.message} に倒れる。
+    def test_falls_back_to_message_for_html_body
+      error = build_error(502, '<html><body>Bad Gateway</body></html>')
+
+      @controller.handle_gateway_error(error)
+
+      assert_equal('Bad response 502', fetch(@renderer.message, 'error'))
+      assert_equal(502, @renderer.status)
+    end
+
+    def test_falls_back_to_message_without_response
+      error = Ginseng::GatewayError.new('Bad response 404')
+
+      @controller.handle_gateway_error(error)
+
+      assert_equal('Bad response 404', fetch(@renderer.message, 'error'))
+      assert_equal(404, @renderer.status)
+    end
+
+    # 上流ボディに内部情報を混ぜない。message は上流ボディが読めたときには使わない。
+    def test_does_not_mix_internal_message_into_upstream_body
+      error = build_error(400, {error: {code: 'NO_SUCH_NOTE'}}.to_json)
+
+      @controller.handle_gateway_error(error)
+
+      assert_not_includes(@renderer.message.to_s, 'Bad response')
+    end
+
+    # Sentry alert の抑止条件。ステータスとコードの両方で効くこと。
+    def test_alert_is_suppressed_by_status
+      error = build_error(401, '{}')
+
+      assert_false(alerted?(error) {@controller.handle_gateway_error(error)})
+    end
+
+    def test_alert_is_suppressed_by_code
+      error = build_error(400, {error: {code: 'TOO_MANY_DRAFTS'}}.to_json)
+
+      assert_false(
+        alerted?(error) do
+          @controller.handle_gateway_error(error, silent_codes: MisskeyController::USER_FAULT_CODES)
+        end,
+      )
+    end
+
+    # ⚠ 抑止リストに無い失敗は必ず alert する（黙らせすぎない）。
+    def test_alert_fires_for_unknown_failure
+      error = build_error(500, {error: {code: 'INTERNAL_ERROR'}}.to_json)
+
+      assert_true(
+        alerted?(error) do
+          @controller.handle_gateway_error(error, silent_codes: MisskeyController::USER_FAULT_CODES)
+        end,
+      )
+    end
+
+    def test_user_fault_codes_covers_known_misskey_codes
+      ['TOO_MANY_DRAFTS', 'ALREADY_FAVORITED', 'NO_SUCH_NOTE', 'MAX_FILE_SIZE_EXCEEDED'].each do |code|
+        assert_includes(MisskeyController::USER_FAULT_CODES, code)
+      end
+    end
+
+    private
+
+    def build_error(code, body)
+      error = Ginseng::GatewayError.new("Bad response #{code}")
+      error.response = ResponseDouble.new(code, body)
+      return error
+    end
+
+    def fetch(message, key)
+      return message[key.to_sym] || message[key]
+    end
+
+    # alert が呼ばれたかどうか。Sentry へ実際に送らないよう差し替える。
+    def alerted?(error)
+      called = false
+      error.define_singleton_method(:alert) {|**_opts| called = true}
+      yield
+      return called
+    end
+  end
+end


### PR DESCRIPTION
#4480 の第 2 層・第 3 層。第 1 層は pooza/ginseng-core#497。

⚠ **ginseng-core#495 → #497 を先にマージし、`bundle update ginseng-core` してからでないと CI が通りません。**（`GatewayError#response` / `#source_body` は 1.15.34 で入る）

## 第 2 層: 透過

`Controller#handle_gateway_error` を新設し、Misskey / Mastodon コントローラの rescue 9 箇所を寄せました。上流が JSON を返していれば**そのまま**クライアントへ返します。`{"error":{"code":"TOO_MANY_DRAFTS", ...}}` が capsicum まで届きます。プロキシなのだから素通しが本来の姿で、モロヘイヤ側に文言テーブルは持ちません。

- ⚠ 透過するのは**上流が JSON として返したものだけ**。HTML エラーページ（nginx の 502 等）や 64KiB 超では `source_body` が nil を返し、従来どおり `{error: e.message}` に倒れます
- ⚠ Mastodon の包絡は `{"error": "Validation failed: ..."}` で `error` が**文字列**。Hash 前提で `dig` すると TypeError になります（テストを書いていて実際に踏みました）。`upstream_error_code` で各段の型を確かめています
- アップロードの 413 だけは従来どおりモロヘイヤの文言を出します。上流が HTML を返すことが多く透過しても読めないためです

## 第 3 層: 棚卸しの回収

Issue に列挙されていた 5 件すべてに手を入れました。

1. **#4381 の過剰な丸めを絞った** — `favorites/create` の 400 を**全部**成功に丸めていたので、`NO_SUCH_NOTE`（不正な id）まで成功と偽っていました。code が読めるようになったので `ALREADY_FAVORITED` 限定に
2. **ユーザー起因の失敗で Sentry alert を立てない** — Misskey 本体 `packages/backend/src/server/api/endpoints/` の errors 宣言から、**モロヘイヤが横取りしているエンドポイント（notes/create・notes/drafts/{create,update}・notes/favorites/create・notes/reactions/create・drive/files/create）の分だけ**を `MisskeyController::USER_FAULT_CODES` に列挙。推測ではなく実装から採っています
3. **`annict_service` の文字列マッチを廃止** — `/Bad response (401|403)/` で `e.message` を舐めていたのを `source_status` 判定へ
4. **`spotify_user_service` が `invalid_client` をユーザーのせいにしない** — 4xx を一括で「要再認証」に倒していましたが、`invalid_client` 等はこちらの client_id/secret の設定ミスで、ユーザーが何度再連携しても直りません。`GatewayError` のまま上げて Sentry に出します
5. **`toot_uri` / `note_uri` / `clipping_worker` が `GatewayError` を包み直さない** — 包み直すと添えた response が落ちます

## 残っているもの（#4480 は open のまま）

**モロヘイヤ独自 API（`APIController`）の rescue は今回触っていません。** Issue の対応方針が「nginx が横取りしている範囲」と scope を切っていたのに従いました。ただし `docs/api.md` の `POST /status/tags` のエラー表が「上流のステータス」と書いているのは**現状と合っていません**（`GatewayError#status` = 502 が返る）。独自 API 側は `e.log` で alert しない設計なので、透過を入れるなら alert 方針込みで別途決める必要があります。Issue にコメントを残しました。

## テスト

- `test/unit/controller/gateway_error_transparency.rb` を新設（11 tests）。上流 JSON の透過・Mastodon 平坦形・HTML フォールバック・response 無し・**内部メッセージを混ぜないこと**・alert の抑止条件（ステータス / コード）・**抑止リストに無い失敗では必ず alert すること**
- `rake test` 全体: **838 tests / 0 failures / 0 errors**（304 omissions は #4503 の既知分）
- `rubocop`: 442 files / no offenses

ginseng-core 側は #497 に 8 tests。

🤖 Generated with [Claude Code](https://claude.com/claude-code)