### PR TITLE
security: HEAD プリフライトも SSRF allowlist に通す (#4523)

### DIFF
--- a/app/lib/mulukhiya/program_fetcher.rb
+++ b/app/lib/mulukhiya/program_fetcher.rb
@@ -77,8 +77,15 @@ module Mulukhiya
     # Content-Length が max を超えていれば GET せず弾く。Content-Length 不在や
     # HEAD 非対応 (GatewayError) の場合は判定不能としてそのまま GET へ進み、
     # 受信後の valid_response_size? を最終防衛線とする。
+    #
+    # host_validator は GET と同じものを渡す。プリフライトだけ無検証だと、GET 側の
+    # SSRF ガード (#4410) が「見せかけの安全」になる (#4523)。
     def valid_content_length?(uri)
-      length = @http.head(uri, timeout: fetch_timeout).headers['content-length']
+      length = @http.head(
+        uri,
+        timeout: fetch_timeout,
+        host_validator: RemoteHost.validator,
+      ).headers['content-length']
       return true if length.nil? || length.to_i <= fetch_max_bytes
       log_oversize(uri, length.to_i, 'program fetch content-length exceeded max bytes')
       return false

--- a/app/lib/mulukhiya/pronunciation_dictionary.rb
+++ b/app/lib/mulukhiya/pronunciation_dictionary.rb
@@ -188,8 +188,15 @@ module Mulukhiya
     # HTTParty が本文を丸ごとメモリへ読み込む前に、相手が申告した Content-Length が
     # max を超えていれば GET せず弾く。Content-Length 不在・HEAD 非対応の場合は判定
     # 不能としてそのまま GET へ進み、受信後の valid_response_size? を最終防衛線とする。
+    #
+    # host_validator は GET と同じものを渡す。プリフライトだけ無検証だと、GET 側の
+    # SSRF ガード (#4410) が「見せかけの安全」になる (#4523)。
     def valid_content_length?(uri)
-      length = @http.head(uri, timeout: fetch_timeout).headers['content-length']
+      length = @http.head(
+        uri,
+        timeout: fetch_timeout,
+        host_validator: RemoteHost.validator,
+      ).headers['content-length']
       return true if length.nil? || length.to_i <= fetch_max_bytes
       log_oversize(uri, length.to_i, 'word_suggest fetch content-length exceeded max bytes')
       return false

--- a/test/unit/lib/program_fetcher_ssrf.rb
+++ b/test/unit/lib/program_fetcher_ssrf.rb
@@ -53,5 +53,40 @@ module Mulukhiya
       assert_false(RemoteHost.validator.call('localhost'))
       assert_false(RemoteHost.validator.call(''))
     end
+
+    # Content-Length のプリフライト (HEAD) も同じ allowlist を通ること (#4523)。
+    # GET だけ守っても、その 1 行上で無検証の HEAD が飛ぶなら SSRF 対策にならない。
+    # 拒否されたホストへは **HEAD も GET も出ない**ことを、実リクエストの不在で見る。
+    def test_program_fetcher_blocks_head_preflight_to_internal_host
+      original = config['/program/urls']
+      config['/program/urls'] = [METADATA]
+
+      assert_nil(ProgramFetcher.new.fetch)
+      assert_not_requested(:head, METADATA)
+      assert_not_requested(:get, METADATA)
+    ensure
+      config['/program/urls'] = original if defined?(original)
+    end
+
+    def test_pronunciation_dictionary_blocks_head_preflight_to_internal_host
+      original = config['/word_suggest/urls']
+      config['/word_suggest/urls'] = [METADATA]
+
+      assert_nil(PronunciationDictionary.new.send(:fetch_remote))
+      assert_not_requested(:head, METADATA)
+      assert_not_requested(:get, METADATA)
+    ensure
+      config['/word_suggest/urls'] = original if defined?(original)
+    end
+
+    # HEAD のリダイレクト先が内部ホストでも、そこへは飛ばない。
+    def test_blocks_head_redirect_to_link_local_metadata
+      stub_request(:head, GAS).to_return(status: 302, headers: {'Location' => METADATA})
+
+      assert_raise(Ginseng::GatewayError) do
+        @http.head(GAS, host_validator: validator('script.google.com'))
+      end
+      assert_not_requested(:head, METADATA)
+    end
   end
 end


### PR DESCRIPTION
Closes #4523

⚠ **pooza/ginseng-core#495 を先にマージし、`bundle update ginseng-core`（1.15.33）してからでないと CI が通りません。**（`HTTP#head` の `host_validator` 対応がそこで入る）

## 変更

`ProgramFetcher#valid_content_length?` / `PronunciationDictionary#valid_content_length?` が Content-Length のプリフライトとして撃つ HEAD に `host_validator` を渡していませんでした。直後の GET だけ守っても、**同じ関数の 1 行上で同じホストへ無検証のリクエストが出ている**ので、#4410 の SSRF ガードが「見せかけの安全」になっていました。

- 設定 URL のホストが最初から内部アドレスでも HEAD は飛んでいた
- 公開ホストが HEAD を内部ホストへリダイレクトすると HTTParty が既定で追従していた

両者に `RemoteHost.validator` を渡します。

## 挙動

拒否されたホストでは `head` が `GatewayError("Rejected host ...")` を投げ、`valid_content_length?` の rescue が「判定不能」として `true` を返して GET へ進みます。その GET も同じ validator で拒否されるので、**実リクエストはどちらも出ません**。rescue の意味づけ（HEAD 非対応のホストは GET で再評価する）は変えていません。

## テスト

`test/unit/lib/program_fetcher_ssrf.rb` に 3 件追加。

- `ProgramFetcher#fetch` / `PronunciationDictionary#fetch_remote` を内部アドレス（`169.254.169.254`）に向けて、**HEAD も GET も実リクエストが出ない**ことを `assert_not_requested` で見る
- HEAD のリダイレクト先が内部ホストでも飛ばないこと

8 tests / 8 assertions / 0 failures（ginseng-core 1.15.33 をローカルで当てて確認）。`rubocop` クリーン。

## 出典

PR #4501（#4410 の実装）への Codex レビュー P1 指摘。もう 1 件（DNS リバインディング）は #4524 で 5.32.0 へ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)