### PR TITLE
fix: 次回放送日の「毎日」に v-else が展開されずテキスト化していた (#4373)

### DIFF
--- a/views/default.sass
+++ b/views/default.sass
@@ -555,6 +555,12 @@ section.disabled h3::after
     padding: 0 0.5em
     margin: 0
     height: 2em
+  // 次回放送日 (#4373)。放送時間などの数値欄と同じ見た目に揃える。
+  input[type='date']
+    width: 10em
+    padding: 0 0.5em
+    margin: 0
+    height: 2em
   input[type='search']
     width: 30em
     padding: 0 0.5em

--- a/views/program.slim
+++ b/views/program.slim
@@ -163,7 +163,7 @@ html lang='ja' data-theme='light'
                     span.tag.stale v-if='isStaleNextOn(entry)' v-tooltip.top="'次回放送日が過ぎています。通知は止まっています'"
                       i class='fa fa-circle-exclamation' aria-hidden='true'
                       span.sr-only 次回放送日が過去
-                  small.muted v-else 毎日
+                  small.muted v-else='' 毎日
                 td
                   small v-if='entry.minutes'
                     | {{entry.minutes}}分


### PR DESCRIPTION
## 概要

番組表エディタの一覧表で、次回放送日の列に常時グレーで `v-else 毎日` と表示される（#4373 のモンキーテストで発覚）。

## 原因

Slim は値のない属性を本文テキストとして扱うため、

```slim
small.muted v-else 毎日
```

が `<small class="muted">v-else 毎日</small>` になっていた。Vue のディレクティブとして解釈されないので、`next_on` を持つエントリでも常に「毎日」が併記される。

## 修正

他の view と同じ `v-else=''` 表記に揃える。

```
$ ruby -e 'require "slim"; puts Slim::Template.new { "small.muted v-else 毎日\n" }.render'
<small class="muted">v-else 毎日</small>
$ ruby -e "require 'slim'; puts Slim::Template.new { %q{small.muted v-else='' 毎日\n} }.render"
<small class="muted" v-else="">毎日</small>
```

同種の記述漏れが他に無いことは views 全体の grep で確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)