### PR TITLE
fix: 次回放送日の入力欄でカレンダーが開かない (#4373)

### DIFF
--- a/views/default.sass
+++ b/views/default.sass
@@ -556,11 +556,25 @@ section.disabled h3::after
     margin: 0
     height: 2em
   // 次回放送日 (#4373)。放送時間などの数値欄と同じ見た目に揃える。
+  // ⚠ padding を一括指定してはいけない。Pico はカレンダーアイコンの領域を
+  // padding-right で確保し、そこへ透明な ::-webkit-calendar-picker-indicator を
+  // 重ねている。右パディングを潰すとアイコンごと枠外へ出てピッカーが開かなくなる。
   input[type='date']
     width: 10em
-    padding: 0 0.5em
+    padding:
+      top: 0
+      bottom: 0
+      left: 0.5em
     margin: 0
     height: 2em
+    font:
+      family: $serif
+      size: 1rem
+    // Chrome の日付入力は内側の疑似要素が本文を持つので、そちらにも指定する。
+    &::-webkit-datetime-edit
+      font:
+        family: $serif
+        size: 1rem
   input[type='search']
     width: 30em
     padding: 0 0.5em

--- a/views/program.slim
+++ b/views/program.slim
@@ -86,7 +86,7 @@ html lang='ja' data-theme='light'
             label
               span 次回放送日
               input type='date' v-model='form.values.next_on' title='空欄なら毎日。日付を入れるとその日に1回だけ通知し、過ぎたら止まります'
-            small.field-note 空欄＝毎日。ウィークリー枠は日付を入れる（「次回」ボタンで自動的に1週進みます）。
+            small.field-note 空欄＝毎日。ウィークリー枠は日付を入れる（一覧の話数欄にある ＋ ボタンで、話数と一緒に1週進みます）。
           .field-container
             label
               span 追加タグ
@@ -144,7 +144,7 @@ html lang='ja' data-theme='light'
                 td
                   span v-if='entry.episode'
                     | {{entry.episode}}{{entry.episode_suffix || '話'}}
-                  button.small @click.stop='incrementEpisode(key)' v-if='editable' v-tooltip.top="'次回'"
+                  button.small @click.stop='incrementEpisode(key)' v-if='editable' v-tooltip.top="'次回（話数を1つ、次回放送日を1週進める）'"
                     i class='fa fa-plus'
                 td
                   code v-if='entry.annict_episode_id'


### PR DESCRIPTION
#4530 で入れた `input[type='date']` の見た目調整の後始末。

## 1. カレンダーが開かない（#4530 のリグレッション）

Pico はカレンダーアイコンを `background-image` で描き、その領域を `padding-right: calc(1rem + 0.75rem)` で確保したうえに透明な `::-webkit-calendar-picker-indicator` を重ねている。

```css
input:not(...):is([type=date], ...) {
  padding-right: calc(var(--pico-icon-width) + var(--pico-icon-position));
  background-image: var(--pico-icon-date);
}
[type=date]::-webkit-calendar-picker-indicator {
  width: var(--pico-icon-width);
  margin-right: calc(var(--pico-icon-width) * -1);
  margin-left: var(--pico-icon-position);
  opacity: 0;
}
```

#4530 の `padding: 0 0.5em` がこの `padding-right` を潰したため、indicator が枠外へ出てクリックできなくなっていた。上下左だけを指定し、右は Pico の値に任せる。

## 2. 書体

内側テキストが他の欄と揃うよう、`font-family` / `font-size` を明示。Chrome は日付入力の本文を `::-webkit-datetime-edit` が持つので、そちらにも同じ指定を入れる。

## 3. 「次回」ボタンが説明から辿れない

補足文の「「次回」ボタン」が一覧の ＋ アイコン（ツールチップのみ「次回」）を指しており、文言だけでは所在が分からなかった。補足文を「一覧の話数欄にある ＋ ボタン」に改め、ツールチップも「次回（話数を1つ、次回放送日を1週進める）」に具体化した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)