### PR TITLE
style: 次回放送日の入力欄を等幅フォントに揃える (#4373)

### DIFF
--- a/views/default.sass
+++ b/views/default.sass
@@ -567,14 +567,6 @@ section.disabled h3::after
       left: 0.5em
     margin: 0
     height: 2em
-    font:
-      family: $serif
-      size: 1rem
-    // Chrome の日付入力は内側の疑似要素が本文を持つので、そちらにも指定する。
-    &::-webkit-datetime-edit
-      font:
-        family: $serif
-        size: 1rem
   input[type='search']
     width: 30em
     padding: 0 0.5em
@@ -789,7 +781,13 @@ nav.search-form-container
       border:
         radius: 3px
 
-input[type='search'],input[type='number'],input[type='text'],input[type='password']
+input[type='search'],input[type='number'],input[type='text'],input[type='password'],input[type='date']
+  font:
+    family: $monospace
+
+// 日付は数字しか入らないので、他の入力欄と同じ等幅で揃える (#4373)。
+// Chrome は日付入力の本文を内側の疑似要素が持つため、そちらにも指定が要る。
+input[type='date']::-webkit-datetime-edit
   font:
     family: $monospace
 


### PR DESCRIPTION
入力欄の等幅指定は

```sass
input[type='search'],input[type='number'],input[type='text'],input[type='password']
  font:
    family: $monospace
```

というセレクタ群で行っており、`input[type='date']` だけが漏れていた。そのため body の `serif` を継いで、放送時間などの欄から浮いていた（日付は数字しか入らないので等幅が適切）。

- セレクタ群に `input[type='date']` を追加
- Chrome は日付入力の本文を `::-webkit-datetime-edit` が持つので、そちらにも同じ指定を追加
- #4531 で `.program-editor` 側に入れていた `font-family: $serif` は不要になったので削除（そちらが勝つと等幅指定が効かないため、残してはいけない）

`padding-right` を Pico に任せる #4531 の修正はそのまま。

🤖 Generated with [Claude Code](https://claude.com/claude-code)