### PR TITLE
fix: リリース前 5 観点レビューの赤を是正する (5.31.0)

### DIFF
--- a/app/lib/mulukhiya/controller.rb
+++ b/app/lib/mulukhiya/controller.rb
@@ -12,7 +12,11 @@ module Mulukhiya
     SCRUBBED_LOG_PARAMS = [
       'status', 'text', 'body', 'comment', 'spoiler_text', 'cw',
       'q', 'title', 'artist', 'album', # word/suggest・nowplaying のユーザー入力 (#4394)
-      'code' # OAuth 認可コード (spotify/auth・annict/auth)。短命だが資格情報なので伏せる
+      'code', # OAuth 認可コード (spotify/auth・annict/auth)。短命だが資格情報なので伏せる
+      # ⚠ アクセストークン本体。`i` は Misskey がボディで渡す（MisskeyController#token
+      #   のフォールバック）。/logger/mask_query_params は URL のクエリにしか効かない
+      #   ので、ボディ側はここで落とす。両方揃って #4511 の掃討が完成する。
+      'i', 'access_token'
     ].freeze
 
     set :root, Environment.dir
@@ -118,7 +122,9 @@ module Mulukhiya
     def handle_gateway_error(error, silent_statuses: [401], silent_codes: [])
       silent = silent_statuses.include?(error.source_status) ||
         silent_codes.include?(upstream_error_code(error))
-      error.alert unless silent
+      # ⚠ 抑止するのは Sentry だけ。silent でも syslog には残す。完全に無音だと
+      # 「上流の仕様変更で全投稿が弾かれる」ような事故の頻度・偏りを追えない。
+      silent ? error.log : error.alert
       @renderer.message = error.source_body || {error: error.message}
       return @renderer.status = error.source_status
     end

--- a/app/lib/mulukhiya/controller/api_controller.rb
+++ b/app/lib/mulukhiya/controller/api_controller.rb
@@ -447,6 +447,13 @@ module Mulukhiya
         @renderer.message = StatusTagAddService.new(sns).call(status, params[:tags])
       end
       return @renderer.to_s
+    rescue Ginseng::GatewayError => e
+      # 上流の 4xx を 502 に潰さない。潰すと capsicum が「本文が長すぎる」と
+      # 「SNS が落ちている」を区別できない (#4491 の docs 記述に実装を揃える)。
+      e.log
+      @renderer.status = e.respond_to?(:source_status) ? e.source_status : 502
+      @renderer.message = {error: e.message}
+      return @renderer.to_s
     rescue => e
       e.log
       @renderer.status = e.status

--- a/app/lib/mulukhiya/program.rb
+++ b/app/lib/mulukhiya/program.rb
@@ -168,9 +168,11 @@ module Mulukhiya
       return unless entry['next_on'].is_a?(String) && entry['next_on'].present?
       entry['next_on'] = (Date.strptime(entry['next_on'], '%Y-%m-%d') + NEXT_ON_INTERVAL_DAYS)
         .strftime('%Y-%m-%d')
+      return entry['next_on']
     rescue Date::Error
       # 不正値は触らずそのまま残す。話数の +1 まで巻き添えで落とさない。
       logger.error(message: 'program next_on invalid', next_on: entry['next_on'])
+      return entry['next_on']
     end
 
     # ⚠ YAML を手書きすると、クォートを付け忘れたスカラーが意図しない型で入る。

--- a/app/lib/mulukhiya/program_calendar.rb
+++ b/app/lib/mulukhiya/program_calendar.rb
@@ -13,6 +13,7 @@ module Mulukhiya
   #
   #   next_on 未設定 → 毎日扱い。今日 (放送中なら今日) か明日の start_time
   #   next_on あり   → その日の start_time に 1 件だけ。**過ぎたら出力しない**
+  #   next_on 不正   → **出力しない**。毎日扱いへ倒すと古い話数で毎日鳴る
   #
   # ⚠ 曜日ルール (frequency + weekday) は採らなかった。ズレを検出できないうえ
   # fail-open で、**古い話数のまま毎週誤発火する**。価値が話数である以上、
@@ -91,7 +92,12 @@ module Mulukhiya
     def next_occurrence(entry, duration_minutes)
       now_jst = @now.getlocal(TZ_OFFSET)
       hour, minute = entry['start_time'].split(':').map(&:to_i)
-      if (date = scheduled_date(entry))
+      if entry['next_on'].present?
+        # ⚠ 値がある以上、解釈できなければ毎日扱いへ倒さず黙る (fail-closed)。
+        # 倒すと「日付を間違えた」が「古い話数で毎日鳴る」に化ける。曜日ルールを
+        # 却下した理由 (冒頭コメント) が、そのまま不正値の経路にも効く。
+        date = scheduled_date(entry)
+        return nil unless date
         # next_on 指定あり: その日に 1 回だけ。終了済みなら翌日へ送らず消す。
         candidate = Time.new(date.year, date.month, date.day, hour, minute, 0, TZ_OFFSET)
         return nil if (candidate + (duration_minutes * 60)) <= now_jst
@@ -102,11 +108,15 @@ module Mulukhiya
       return candidate
     end
 
-    # next_on を Date で返す。未設定・不正値は nil (= 従来の毎日扱いへ倒す)。
+    # next_on を Date で返す。不正値は nil (呼び出し側がイベントごと落とす)。
     # 不正値で番組表全体を落とさない。
     def scheduled_date(entry)
       value = entry['next_on']
-      return nil unless value.is_a?(String) && value.present?
+      unless value.is_a?(String)
+        # YAML の手編集で `next_on: 20260808` と書くと Integer で入る。
+        logger.error(message: 'program next_on invalid', next_on: value)
+        return nil
+      end
       return Date.strptime(value, '%Y-%m-%d')
     rescue Date::Error
       logger.error(message: 'program next_on invalid', next_on: value)

--- a/app/lib/mulukhiya/webhook.rb
+++ b/app/lib/mulukhiya/webhook.rb
@@ -113,14 +113,23 @@ module Mulukhiya
     # 例外がループの外へ出ると Webhook.create の rescue が nil を返し、
     # **その行より後ろにある正しい webhook URL が「見つからない」ことになる**。
     # 壊れた行は次へ送るだけにして、走査自体は最後まで続ける (#4487 / PR #4522)。
+    # ⚠ ただし黙ってスキップもしない。DB 断や /crypt/salt の設定崩れは全行を
+    # 落とすので、無音だと「全 webhook が 404」だけが症状になる。
     def self.find_token_by_digest(digest)
       Postgres.exec(:webhook_tokens).each do |row|
-        token = Environment.access_token_class[row[:id]] rescue next
-        next unless token.valid?
-        token_digest = token.webhook_digest rescue next
-        return token if token_digest == digest
+        token = find_valid_token(row)
+        return token if token && token.webhook_digest == digest
+      rescue => e
+        e.log(id: row[:id])
+        next
       end
       return nil
+    end
+
+    def self.find_valid_token(row)
+      token = Environment.access_token_class[row[:id]]
+      return nil unless token&.valid?
+      return token
     end
 
     private

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -311,6 +311,8 @@ logger:
   #
   # ⚠ `i` は Misskey のトークンパラメータ。汎用名だが、判定は URL のクエリに
   #   限られる（ginseng-core 側の実装）ので Hash のキー `i` は巻き込まない。
+  #   裏を返すと**ボディのキー `i` はここでは落ちない**。Misskey はトークンを
+  #   ボディで渡すので、そちらは Controller::SCRUBBED_LOG_PARAMS が担当する。
   # ⚠ 未設定なら ginseng-core の既定リストへ倒れる（マスクしない方向へは倒れない）。
   #   ここに書くのは、増減させたいときの編集点を明示するため。
   mask_query_params:

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -261,12 +261,12 @@ GitHub マイルストーン作成・割り当て済み。**スコープは 2026
 - **#4511** — dev24-27 のログに生トークン 0 件、`access_token=[FILTERED]` / `i=[FILTERED]` を確認
 - **#4487** — dev25 で `Webhook.all` が全て `available?`、nil / 空白トークンを `ConfigError` で拒否
 
-残りは目視のモンキーテスト（#4474 / #4484 / #4373 の UI / #4487 の実アカウント経路）。
+残りは目視のモンキーテスト（#4474 / #4484 / #4373 の WebUI / #4487 の実アカウント経路）。
 
 ### 1. 重篤な不具合（主軸）
 
 - **#4474 nginx が `X-Mulukhiya-Purpose` 付きの PUT を 405 で弾く** — ✅ **本番3台 + ステージングで復旧済み（2026-08-05）**。サンプル vhost（#4475）・docs（#4517）も着地。capsicum から実際に ALT 編集して通ったらクローズ（モンキーテスト待ちで open）
-- **#4511 security/obs: listener が streaming URL をアクセストークン付きで平文ログに書く（size:M）** — ✅ コード着地（ginseng-core 1.15.32 + application.yaml の `mask_query_params`、#4518）。**デプロイ後にログの再掃除が要る**
+- **#4511 security/obs: listener が streaming URL をアクセストークン付きで平文ログに書く（size:M）** — ✅ コード着地（ginseng-core 1.15.32 + `config/application.yaml` の `/logger/mask_query_params`、#4518）。**デプロイ後にログの再掃除が要る**
 - **#4506 並行性: `disable?` を持つ定期 worker 7 本が perform で短絡していない** — ✅ クローズ済み（#4519）
 - **#4487 bug: トークン未設定のアカウントでも webhook URL が生成される（size:S）** — ✅ #4522 で着地、Codex P2（壊れた行で走査が止まる）を #4525 で追加是正
 - **#4523 security: リモート取得の HEAD プリフライトが SSRF allowlist を通っていない** — ✅ #4528 + pooza/ginseng-core#495（1.15.33）。#4410 で GET は塞いだが、**その 1 行上の HEAD が素通り**していた。Codex レビューの取り残しから発見（[[feedback_codex-review-window-too-narrow]]）
@@ -307,7 +307,7 @@ GitHub マイルストーン作成・割り当て済み。**スコープは 2026
 - **#4503 test: アカウント依存のテスト 304 件が CI・手元のいずれでも実行されていない** — `/agent/test/token` が現存アカウントに解決しない。**5.30.0 のリリース判断でも、この範囲は CI の緑を根拠にできなかった**
 - **#4508 chore: sinatra 4.2 系 / mustermann 4.0 / tilt 2.8 への更新** — 全リクエストが通る層のメジャー更新なのに、#4503 のせいでコントローラ層のテストが CI で 1 件も走らず**緑を検証根拠にできない**。5.32.0 で **#4503 → #4508 の順**に土台テーマとして扱う
 - **#4516 test/bug: media seed の追加で露見した 2 件** — catalog の戻り値がキャッシュ経路で形違い・`MediaFeedRenderer` の omit ガードが実描画条件と不一致。#4503 でテストが動くようになってから扱うのが自然なので同じマイルストーン
-- **#4524 security: SSRF allowlist が DNS リバインディングを防げない** — 2026-08-06 起票。`RemoteHost.public?` が**名前で検証して名前で接続する**構造。検証したIPで接続する（pinning）のが本筋で `Ginseng::HTTP` 側の変更になる。到達には管理者が設定した URL のホスト（またはリダイレクト先）の DNS を握る必要があり外部からの直撃はできないが、番組表 URL は外部ドメイン（GAS 等）なので前提が崩れうる
+- **#4524 security: SSRF allowlist が DNS リバインディングを防げない** — 2026-08-06 起票。`RemoteHost.public?` が**名前で検証して名前で接続する**構造。検証した IP アドレスで接続する（pinning）のが本筋で `Ginseng::HTTP` 側の変更になる。到達には管理者が設定した URL のホスト（またはリダイレクト先）の DNS を握る必要があり外部からの直撃はできないが、番組表 URL は外部ドメイン（GAS 等）なので前提が崩れうる
 
 ### マイルストーン外の繰越（着手条件待ち）
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -72,9 +72,24 @@ capsicum 等のクライアントアプリが、モロヘイヤ固有の機能�
 
 SNS 本体への転送が失敗した場合、SNS が返したステータスコードをそのまま返す。
 
-```json
-{"error": "エラーメッセージ"}
-```
+**⚠ 5.31.0 (#4480) から、上流が返した包絡をそのまま透過する。`error` の型が SNS 種別で変わる。**
+従来はどの上流でも `{"error": "Bad response NNN"}`（`error` は文字列）に潰れていた。
+
+| 上流 | ボディ | 例 |
+|---|---|---|
+| Misskey | `error` は**オブジェクト** | `{"error":{"code":"TOO_MANY_DRAFTS","message":"...","id":"...","kind":"client"}}` |
+| Mastodon | `error` は**文字列** | `{"error":"Validation failed: Text is too long"}` |
+
+クライアントは `error` の型を確かめてから読むこと。以下の場合は従来どおり
+`{"error": "Bad response NNN"}`（文字列）に倒れる。
+
+- 上流が JSON を返さない（nginx の HTML 502 等）
+- 上流ボディが 65,536 バイトを超える
+- **413（アップロード上限超過）** — 透過せずモロヘイヤの文言を返す。上流（nginx）が HTML を返すことが多く、そのまま出しても利用者に伝わらないため
+
+**⚠ 上流が 404 を返した場合は透過が効かない。** Sinatra の `not_found` ハンドラが
+ボディを差し替えるため、`{"package":"ginseng-core","class":"Ginseng::NotFoundError",...}`
+になる（#4520）。「モロヘイヤのルートが無い」という意味ではない点に注意。
 
 ### 機能フラグ
 
@@ -228,7 +243,7 @@ URL 正規化、短縮 URL 展開、NowPlaying URL 展開（iTunes/Spotify/YouTu
 | `/api/notes/favorites/create` | POST | お気に入り（SNS → post_bookmark） |
 | `/api/notes/reactions/create` | POST | リアクション（SNS → post_reaction） |
 
-> **`favorites/create` の冪等挙動（#4380 / #4383）**: お気に入りは冪等操作のため、上流 Misskey が 400（大半は `ALREADY_FAVORITED`）を返した場合も成功（200・空ボディ）として扱う。**この冪等成功パスでは `post_bookmark` 副作用（PieFed ミラー `piefed_bookmark` / `result_notification`）を発火しない**。PieFed ミラーは `piefed.clip` が呼び出しごとに新規投稿を作る非冪等操作で、再お気に入りのたびに dispatch すると PieFed 重複投稿・重複通知を生むため。副作用は初回お気に入り（上流 200）時にのみ走る。mulukhiya を経由せず（直接 Misskey 等で）先にお気に入り済みの note は PieFed ミラー対象外となる。
+> **`favorites/create` の冪等挙動（#4380 / #4383 / #4480）**: お気に入りは冪等操作のため、上流 Misskey が `ALREADY_FAVORITED`（既にお気に入り済み）を返した場合は成功（200・空ボディ `{}`）として扱う。**⚠ 5.31.0 から条件が「400 のすべて」ではなく `error.code == "ALREADY_FAVORITED"` に絞られた。** それ以外の 400（`NO_SUCH_NOTE` 等）は上流の包絡をそのまま透過する（従来は成功に丸めており、不正な `noteId` が 200 で返っていた）。**この冪等成功パスでは `post_bookmark` 副作用（PieFed ミラー `piefed_bookmark` / `result_notification`）を発火しない**。PieFed ミラーは `piefed.clip` が呼び出しごとに新規投稿を作る非冪等操作で、再お気に入りのたびに dispatch すると PieFed 重複投稿・重複通知を生むため。副作用は初回お気に入り（上流 200）時にのみ走る。mulukhiya を経由せず（直接 Misskey 等で）先にお気に入り済みの note は PieFed ミラー対象外となる。
 
 ### クライアント側での制御
 
@@ -889,7 +904,7 @@ Web Push サブスクリプションを解除する。
 | 存在しない ID | **404** | `{"package":"ginseng-core","class":"Ginseng::NotFoundError","message":"Resource /mulukhiya/api/status/tags not found."}` |
 | `/{controller}/capabilities/repost` が false | **404** | 同上 |
 | `tags` 未指定・不正 | **422** | `{"errors":{"tags":["空欄です。"]}}` |
-| 上流 SNS のエラー | 上流のステータス | `{"error":"Bad response NNN"}`（#4480 で改善予定） |
+| 上流 SNS のエラー | **上流のステータス**（422・400 等） | `{"error":"Bad response NNN"}` |
 
   ⚠ **所有者違いは 404 ではなく 403。**ルートは先に status を引いてから
   `status.updatable_by?(sns.account)` を見るので、**存在する他人の投稿は「無い」ではなく
@@ -1072,12 +1087,15 @@ Spotify 連携を解除する（保管トークンを削除）。
 
 | `next_on` | `DTSTART` | 用途 |
 |---|---|---|
-| 未設定 | 今日の `start_time`。終了時刻を過ぎていれば翌日 | デイリー枠（毎晩の実況など） |
+| 未設定（空欄） | 今日の `start_time`。終了時刻を過ぎていれば翌日 | デイリー枠（毎晩の実況など） |
 | 日付あり | その日の `start_time`。**終了時刻を過ぎたら VEVENT を出力しない** | ウィークリー枠・不定枠 |
+| **不正な値** | **VEVENT を出力しない** | `2026-02-31`・`2026/08/08` 等。毎日扱いへは倒さない |
 
 放送中（開始済みかつ終了前）は当日のイベントを残す。放送開始分ちょうどに取得しても当日イベントが欠落せず、通知を取り逃さないため（#4287）。
 
-`next_on` が過ぎたエントリは**黙って出力から消える**（翌日へ送らない）。日付を進めるのは「次回」ボタン（`POST .../episode/increment`）で、番組表エディタは過去日のエントリに警告バッジを出す。
+`next_on` が過ぎたエントリは**黙って出力から消える**（翌日へ送らない）。日付を進めるのは「次回」ボタン（`POST .../episode/increment`。番組表エディタの一覧で話数欄にある ＋ ボタン）で、番組表エディタは過去日のエントリに警告バッジを出す。**⚠ 進むのは保存値 +7 日なので、2 週以上放置したエントリは 1 回押しても過去日のまま。その場合は日付を直接編集する。**
+
+**不正な値も同じく出力しない**（fail-closed）。書き込み API は contract が弾くので、これに該当するのは `var/program.yaml` の手編集と外部データソース由来のもの。毎日扱いへ倒すと「日付を間違えた」が「古い話数で毎日鳴る」に化けるため、黙るほうを選んでいる。番組表エディタは過去日とは別の**不正バッジ**（橙）で出す。
 
 - **⚠ 繰り返し（`RRULE`）は出力しない。** 話数は動的値で未来分が確定せず、先々までイベントを出しても中身を埋められないため。**Google カレンダー等への購読リマインダー用途は非対応**（取得ラグに加え、話数を載せられない）。用途は tomato-shrieker のような高頻度ポーリングによる直前/開始通知に限定される
 

--- a/test/unit/controller/log_scrub.rb
+++ b/test/unit/controller/log_scrub.rb
@@ -1,0 +1,46 @@
+module Mulukhiya
+  # request ログに資格情報を書かないこと (#4511)。
+  #
+  # ⚠ /logger/mask_query_params は **URL のクエリ**にしか効かない。Misskey は
+  # トークンをリクエストボディのキー `i` で渡す (MisskeyController#token の
+  # フォールバック) ので、ボディ側は SCRUBBED_LOG_PARAMS で落とす必要がある。
+  # 両方揃わないと、掃除した端からログが再汚染される。
+  class LogScrubTest < TestCase
+    def setup
+      @controller = MisskeyController.new!
+    end
+
+    def scrub(params)
+      return @controller.send(:scrub_log_params, Sinatra::IndifferentHash[params])
+    end
+
+    # ⚠ ここが本体。Misskey のアクセストークンはボディのキー `i` で来る。
+    def test_scrubs_misskey_token
+      assert_equal('[FILTERED]', scrub('i' => 'SECRET', 'noteId' => 'abc')['i'])
+    end
+
+    def test_scrubs_access_token
+      assert_equal('[FILTERED]', scrub('access_token' => 'SECRET')['access_token'])
+    end
+
+    def test_scrubs_post_body
+      scrubbed = scrub('text' => '本文', 'cw' => '注釈')
+
+      assert_equal('[FILTERED]', scrubbed['text'])
+      assert_equal('[FILTERED]', scrubbed['cw'])
+    end
+
+    # マスク対象外は素通しする (ログが役に立たなくなるため)。
+    def test_keeps_other_params
+      assert_equal('abc', scrub('i' => 'SECRET', 'noteId' => 'abc')['noteId'])
+    end
+
+    # 処理に使う @params を壊さない (ログ用の複製だけを書き換える)。
+    def test_does_not_mutate_source
+      params = Sinatra::IndifferentHash['i' => 'SECRET']
+      @controller.send(:scrub_log_params, params)
+
+      assert_equal('SECRET', params['i'])
+    end
+  end
+end

--- a/test/unit/lib/program_calendar.rb
+++ b/test/unit/lib/program_calendar.rb
@@ -169,17 +169,42 @@ module Mulukhiya
       assert_match(/DTSTART:20260530T233000Z/, result) # aired 08:30 翌日
     end
 
-    # 不正な日付で番組表全体を落とさない。毎日扱いへ倒す。
-    def test_invalid_next_on_falls_back_to_daily
+    # ⚠ 不正な日付は**毎日扱いへ倒さない**。倒すと「日付を間違えた」が
+    # 「古い話数で毎日鳴る」に化け、曜日ルールを却下した理由がそのまま当たる。
+    # 番組表全体は落とさず、そのエントリだけ黙る。
+    def test_invalid_next_on_emits_nothing
       result = ics(weekly('2026-02-31', start_time: '23:00'))
 
-      assert_match(/DTSTART:20260530T140000Z/, result)
+      assert_no_match(/program-weekly/, result)
     end
 
+    # 書式違い（YAML 手編集で `2026/08/08` と書く等）も同じく黙る。
+    def test_malformed_next_on_emits_nothing
+      result = ics(weekly('2026/08/08', start_time: '23:00'))
+
+      assert_no_match(/program-weekly/, result)
+    end
+
+    # 文字列ですらない値（`next_on: 20260808` は Integer で入る）も黙る。
+    def test_non_string_next_on_emits_nothing
+      result = ics(weekly(20_260_808, start_time: '23:00'))
+
+      assert_no_match(/program-weekly/, result)
+    end
+
+    # 空文字は「未設定」と同じ。日付を消す操作を毎日扱いへ戻すため。
     def test_blank_next_on_falls_back_to_daily
       result = ics(weekly('', start_time: '23:00'))
 
       assert_match(/DTSTART:20260530T140000Z/, result)
+    end
+
+    # 番組表全体を巻き込まないこと（不正エントリ以外は従来どおり出る）。
+    def test_invalid_next_on_keeps_other_entries
+      result = ics(@data.merge(weekly('2026-02-31', start_time: '23:00')))
+
+      assert_no_match(/program-weekly/, result)
+      assert_match(/DTSTART:20260530T233000Z/, result) # aired 08:30 翌日
     end
   end
 end

--- a/views/default.sass
+++ b/views/default.sass
@@ -618,10 +618,20 @@ section.disabled h3::after
         decoration: line-through
     small.muted
       color: gray
+    // 日付として読めない next_on。過去日とは別物として出す (fail-closed で
+    // 通知は止まっているが、直し方が違う)。
+    small.invalid
+      color: darkorange
+      text:
+        decoration: none
     .tag.stale
       color: firebrick
       border:
         color: firebrick
+    .tag.invalid
+      color: darkorange
+      border:
+        color: darkorange
     // 一覧上で有効/無効をその場で切り替えるトグル (#4484)。
     // 無効側は「押していない」ことが色でも分かるよう淡く落とす。
     button.enable-toggle

--- a/views/program.slim
+++ b/views/program.slim
@@ -144,7 +144,7 @@ html lang='ja' data-theme='light'
                 td
                   span v-if='entry.episode'
                     | {{entry.episode}}{{entry.episode_suffix || '話'}}
-                  button.small @click.stop='incrementEpisode(key)' v-if='editable' v-tooltip.top="'次回（話数を1つ、次回放送日を1週進める）'"
+                  button.small @click.stop='incrementEpisode(key)' v-if='editable' :disabled='isBusy(key)' v-tooltip.top="'次回（話数を1つ、次回放送日を1週進める）'"
                     i class='fa fa-plus'
                 td
                   code v-if='entry.annict_episode_id'
@@ -158,11 +158,14 @@ html lang='ja' data-theme='light'
                     | {{entry.start_time}}
                 td
                   template v-if='entry.next_on'
-                    small :class="{stale: isStaleNextOn(entry)}"
+                    small :class="{stale: isStaleNextOn(entry), invalid: isInvalidNextOn(entry)}"
                       | {{entry.next_on}}
                     span.tag.stale v-if='isStaleNextOn(entry)' v-tooltip.top="'次回放送日が過ぎています。通知は止まっています'"
                       i class='fa fa-circle-exclamation' aria-hidden='true'
                       span.sr-only 次回放送日が過去
+                    span.tag.invalid v-if='isInvalidNextOn(entry)' v-tooltip.top="'次回放送日が日付として読めません。通知は止まっています'"
+                      i class='fa fa-triangle-exclamation' aria-hidden='true'
+                      span.sr-only 次回放送日が不正
                   small.muted v-else='' 毎日
                 td
                   small v-if='entry.minutes'
@@ -176,7 +179,7 @@ html lang='ja' data-theme='light'
                     i class='fa fa-check' aria-hidden='true'
                     span.sr-only 実況対象
                 td
-                  button.small.enable-toggle :class="{off: !entry.enable}" @click.stop='toggleEnable(key, entry)' v-if='editable' :aria-pressed="entry.enable ? 'true' : 'false'" v-tooltip.top="entry.enable ? '無効にする' : '有効にする'"
+                  button.small.enable-toggle :class="{off: !entry.enable}" @click.stop='toggleEnable(key, entry)' v-if='editable' :disabled='isBusy(key)' :aria-pressed="entry.enable ? 'true' : 'false'" v-tooltip.top="entry.enable ? '無効にする' : '有効にする'"
                     i class='fa' :class="entry.enable ? 'fa-check' : 'fa-xmark'" aria-hidden='true'
                     span.sr-only
                       | {{entry.enable ? '有効' : '無効'}}
@@ -184,8 +187,9 @@ html lang='ja' data-theme='light'
                     i class='fa fa-check' aria-hidden='true'
                     span.sr-only 有効
                 td.actions
-                  button.small.danger @click.stop='deleteEntry(key)' v-if='editable' v-tooltip.top="'削除'"
-                    i class='fa fa-trash'
+                  button.small.danger @click.stop='deleteEntry(key)' v-if='editable' :disabled='isBusy(key)' v-tooltip.top="'削除'"
+                    i class='fa fa-trash' aria-hidden='true'
+                    span.sr-only 削除
     == slim.render 'fragment/footer'
     script type='module'
       |
@@ -200,6 +204,10 @@ html lang='ja' data-theme='light'
               account: {},
               editable: false,
               entries: {},
+              // 送信中のエントリ。番組表の更新は無ロックの read-modify-write なので、
+              // 「次回」の二度押しは話数 +2・次回放送日 +14 日になり、その週の
+              // 通知が丸ごと消える。往復が終わるまでボタンを止める (#4373)。
+              busy: {},
               annict: {keyword: null, works: [], episodes: []},
               form: {
                 open: false,
@@ -300,31 +308,53 @@ html lang='ja' data-theme='light'
                 .catch(e => Swal.fire({text: this.methods.createErrorMessage(e), icon: 'error'}))
             },
             deleteEntry (key) {
+              if (this.isBusy(key)) return
               Swal.fire({title: `エントリ '${key}' を削除しますか？`, icon: 'warning', showCancelButton: true, confirmButtonText: '削除', cancelButtonText: 'キャンセル'})
                 .then(result => {
                   if (!result.isConfirmed) return
+                  this.busy[key] = true
                   this.methods.deleteProgramEntry(key)
                     .then(_ => {
                       Swal.fire({title: '削除しました。', toast: true, position: 'top-end', icon: 'success', showConfirmButton: false, timer: 2000})
                       this.loadEntries()
                     })
                     .catch(e => Swal.fire({text: this.methods.createErrorMessage(e), icon: 'error'}))
+                    .finally(_ => {delete this.busy[key]})
                 })
+            },
+            // 日付として読めない next_on。サーバーは fail-closed で通知を出さない
+            // ので、一覧でも「過去日」ではなく「不正」として区別する。文字列比較
+            // だけだと 2026-02-31 を過去日、2026/08/08 を未来日と誤って読む。
+            isInvalidNextOn (entry) {
+              if (!entry.next_on) return false
+              const value = String(entry.next_on)
+              if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return true
+              const date = new Date(`${value}T00:00:00`)
+              if (Number.isNaN(date.getTime())) return true
+              // 2026-02-31 を繰り上げて解釈する実装向けの往復チェック。
+              return this.toDateKey(date) !== value
+            },
+            toDateKey (date) {
+              return [
+                date.getFullYear(),
+                String(date.getMonth() + 1).padStart(2, '0'),
+                String(date.getDate()).padStart(2, '0'),
+              ].join('-')
             },
             // next_on が過去日か。過ぎるとカレンダーに出なくなる (#4373) ので、
             // 一覧で気づけるようにする。日付だけで比較する（当日は過去扱いしない）。
             isStaleNextOn (entry) {
               if (!entry.next_on) return false
-              const today = new Date()
-              const todayKey = [
-                today.getFullYear(),
-                String(today.getMonth() + 1).padStart(2, '0'),
-                String(today.getDate()).padStart(2, '0'),
-              ].join('-')
-              return entry.next_on < todayKey
+              if (this.isInvalidNextOn(entry)) return false
+              return entry.next_on < this.toDateKey(new Date())
+            },
+            isBusy (key) {
+              return !!this.busy[key]
             },
             toggleEnable (key, entry) {
+              if (this.isBusy(key)) return
               const next = !entry.enable
+              this.busy[key] = true
               // 楽観更新。放送前後にまとめて切り替えるので、往復を待たずに
               // 行の見た目 (disabled クラス) が追従するほうが手数が減る (#4484)。
               // 失敗したら loadEntries() でサーバーの値へ巻き戻す。
@@ -338,14 +368,18 @@ html lang='ja' data-theme='light'
                   entry.enable = !next
                   Swal.fire({text: this.methods.createErrorMessage(e), icon: 'error'})
                 })
+                .finally(_ => {delete this.busy[key]})
             },
             incrementEpisode (key) {
+              if (this.isBusy(key)) return
+              this.busy[key] = true
               this.methods.incrementProgramEpisode(key)
                 .then(_ => {
                   Swal.fire({title: '話数を+1しました。', toast: true, position: 'top-end', icon: 'success', showConfirmButton: false, timer: 2000})
                   this.loadEntries()
                 })
                 .catch(e => Swal.fire({text: this.methods.createErrorMessage(e), icon: 'error'}))
+                .finally(_ => {delete this.busy[key]})
             },
             copyText (text, label) {
               navigator.clipboard.writeText(text)


### PR DESCRIPTION
5.31.0 のリリース前 5 観点レビュー（セキュリティ / API 契約 / 並行性・ライフサイクル / エラー処理・観測性 / スタイル・規約）で挙がった赤を是正する。

## 赤1: Misskey のアクセストークンが request ログに平文で残る（セキュリティ・観測性の 2 観点が独立に検出）

`i` は Misskey がボディで渡すトークン（`MisskeyController#token` のフォールバック）。`/logger/mask_query_params` は **URL のクエリにしか効かない**ため、ボディ側は素通しだった。#4511 で塞いだのはクエリ側だけで、トークンの主たる載り場所が残っていた。

dev27（ダイスキー）のログで `/api/notes/favorites/create` の行に生トークンが出ていることを確認済み。**これを止めないと、本番デプロイ後に予定している #4511 のログ再掃除は掃除した端から再汚染される。**

`SCRUBBED_LOG_PARAMS` に `i` / `access_token` を追加し、`config/application.yaml` のコメント（「Hash のキー `i` は巻き込まない」）に、ボディ側は誰が担当するのかを追記。再発防止テストを `test/unit/controller/log_scrub.rb` に追加した。

## 赤2〜4: #4480 / #4491 の仕様変更に `docs/api.md` が追随していない

| | 直した内容 |
|---|---|
| ゲートウェイエラー節 | **`error` の型が SNS 種別で変わる**（Misskey はオブジェクト、Mastodon は文字列）ことを明記。非 JSON・64KB 超・413・404 の例外もあわせて記載 |
| `favorites/create` | 冪等丸めが「400 のすべて」から `ALREADY_FAVORITED` 限定に変わった点を反映（`NO_SUCH_NOTE` は透過される） |
| `/status/tags` | docs は「上流のステータス」、実装は `e.status` ＝ **常に 502** だった。隣の `/scheduled_status/:id/tags` と同じく `source_status` を使う形へ実装を揃えた |

## 不正な `next_on` を fail-closed にする

`scheduled_date` が `Date::Error` を握って `nil` を返し、呼び出し側が**毎日扱い**へ倒れていた。曜日ルールを却下した理由（fail-open で古い話数のまま誤発火するのは鳴らないより悪い）が、そのまま不正値の経路に当たっていた。しかも週 1 回ではなく毎日鳴る。

値がある以上、解釈できなければイベントを出さない。番組表エディタも過去日とは別の**不正バッジ（橙）**で出す。従来の `isStaleNextOn` は素の文字列比較で、`2026-02-31` を「過去日（通知は止まっています）」と表示しながら実際は毎日発火し、`2026/08/08` は普通の未来日として警告なしだった。

## 番組表エディタの二度押し防止

番組表の更新は無ロックの read-modify-write（`increment_episode` は「読む → Annict を叩く → 書き戻す」）なので、「次回」の二度押しは話数 +2・`next_on` +14 日になり、**その週の VEVENT が丸ごと消える**。#4373 以前は「話数が 1 多い」で済んでいたものが通知の不発に昇格していた。

送信中は ＋ / 有効トグル / 削除を `disabled` にする。サーバー側のロックは差分が大きくステージング再検証の範囲も広がるため、別 Issue へ送る。

## 同梱した黄

- `handle_gateway_error` の silent 経路が Sentry だけでなく syslog も消していた（Misskey の 34 コードが一律無音）→ `silent ? error.log : error.alert`
- `find_token_by_digest` の `rescue next` が唯一のログ経路を消していた（DB プール枯渇時に全 webhook 404 が無音）→ 行 ID 付きで log
- `advance_next_on` の末尾 `return` 省略、`docs/CLAUDE.md` の表記規約 3 件（UI→WebUI / IP→IP アドレス / 設定ファイル・キーの表記）

## 検証

- `bundle exec rake lint` — rubocop / slim_lint / erb_lint / bundler-audit すべて緑
- `bundle exec rake test` — 873 tests, 0 failures, 0 errors（310 omissions は既知の #4503 分）

🤖 Generated with [Claude Code](https://claude.com/claude-code)