### PR TITLE
fix: Codex P2 3 件を是正する (#4373)

### DIFF
--- a/app/lib/mulukhiya/program.rb
+++ b/app/lib/mulukhiya/program.rb
@@ -164,14 +164,19 @@ module Mulukhiya
     # 翌日以降そのエントリが単発扱いになり、毎日出ていたイベントが消える。
     #
     # ズレたら日付を直接編集する。ここは既定値の前進であって規則ではない。
+    #
+    # ⚠ 書式は contract と同じ判定で見る。Date.strptime は `2026-08-08junk` を
+    # 通すので、素で渡すと壊れた値を黙って別の壊れた値へ書き換える
+    # (Codex P2 / PR #4529)。
     def advance_next_on(entry)
-      return unless entry['next_on'].is_a?(String) && entry['next_on'].present?
+      return entry['next_on'] unless entry['next_on'].is_a?(String) && entry['next_on'].present?
+      unless ProgramEntryContract.valid_date?(entry['next_on'])
+        # 不正値は触らずそのまま残す。話数の +1 まで巻き添えで落とさない。
+        logger.error(message: 'program next_on invalid', next_on: entry['next_on'])
+        return entry['next_on']
+      end
       entry['next_on'] = (Date.strptime(entry['next_on'], '%Y-%m-%d') + NEXT_ON_INTERVAL_DAYS)
         .strftime('%Y-%m-%d')
-      return entry['next_on']
-    rescue Date::Error
-      # 不正値は触らずそのまま残す。話数の +1 まで巻き添えで落とさない。
-      logger.error(message: 'program next_on invalid', next_on: entry['next_on'])
       return entry['next_on']
     end
 
@@ -185,8 +190,17 @@ module Mulukhiya
       coerced = entry.dup
       coerced['next_on'] = coerced['next_on'].strftime('%Y-%m-%d') if coerced['next_on'].is_a?(Date)
       coerced['start_time'] = format_sexagesimal(coerced['start_time']) if
-        coerced['start_time'].is_a?(Integer)
+        sexagesimal_time?(coerced['start_time'])
       return coerced
+    end
+
+    # ⚠ ただの整数 (`start_time: 20`) は 60 進数ではない。'00:00' へ寄せると
+    # 深夜 0 時のイベントとして出てしまうので、Integer のまま残して
+    # valid_start_time? に弾かせる (Codex P2 / PR #4529)。
+    def sexagesimal_time?(value)
+      return false unless value.is_a?(Integer)
+      return false unless (0...86_400).cover?(value)
+      return (value % 60).zero?
     end
 
     # YAML が 60 進数として読んだ 20:30 (= 73800) を 'HH:MM' へ戻す。

--- a/app/lib/mulukhiya/program_calendar.rb
+++ b/app/lib/mulukhiya/program_calendar.rb
@@ -110,17 +110,17 @@ module Mulukhiya
 
     # next_on を Date で返す。不正値は nil (呼び出し側がイベントごと落とす)。
     # 不正値で番組表全体を落とさない。
+    #
+    # ⚠ Date.strptime は寛容で `2026-08-08junk` や `2026-8-8` を通す。書式は
+    # contract と同じ判定で先に見る (Codex P2 / PR #4529)。
     def scheduled_date(entry)
       value = entry['next_on']
-      unless value.is_a?(String)
-        # YAML の手編集で `next_on: 20260808` と書くと Integer で入る。
+      # YAML の手編集で `next_on: 20260808` と書くと Integer で入る。
+      unless value.is_a?(String) && ProgramEntryContract.valid_date?(value)
         logger.error(message: 'program next_on invalid', next_on: value)
         return nil
       end
       return Date.strptime(value, '%Y-%m-%d')
-    rescue Date::Error
-      logger.error(message: 'program next_on invalid', next_on: value)
-      return nil
     end
 
     def summary(entry)

--- a/test/unit/lib/program_calendar.rb
+++ b/test/unit/lib/program_calendar.rb
@@ -192,6 +192,14 @@ module Mulukhiya
       assert_no_match(/program-weekly/, result)
     end
 
+    # ⚠ Date.strptime は寛容で末尾のゴミやゼロ埋め無しを通す。素で渡すと
+    # 「不正なのにイベントが出る」に戻る (Codex P2 / PR #4529)。
+    def test_lenient_next_on_emits_nothing
+      ['2026-08-08junk', '2026-8-8', ' 2026-08-08', '2026-08-08 '].each do |value|
+        assert_no_match(/program-weekly/, ics(weekly(value, start_time: '23:00')), "#{value} を通している")
+      end
+    end
+
     # 空文字は「未設定」と同じ。日付を消す操作を毎日扱いへ戻すため。
     def test_blank_next_on_falls_back_to_daily
       result = ics(weekly('', start_time: '23:00'))

--- a/test/unit/model/program.rb
+++ b/test/unit/model/program.rb
@@ -206,6 +206,18 @@ module Mulukhiya
       @program.save(original) if original
     end
 
+    # ⚠ ただの整数は 60 進数ではない。'00:00' へ寄せると深夜 0 時のイベントとして
+    # 出てしまうので、Integer のまま残して抽出条件で弾かせる (Codex P2 / PR #4529)。
+    def test_data_keeps_plain_integer_start_time
+      key = "test_plainint_#{Time.now.to_i}"
+      original = @program.data
+      @program.save(key => {'series' => 'A', 'start_time' => 20})
+
+      assert_equal(20, @program.data[key]['start_time'])
+    ensure
+      @program.save(original) if original
+    end
+
     # ⚠ 一覧の「有効」トグル (#4484) は enable だけを送る。false は blank_value?
     # ではないので、キーごと消えず false として残らなければならない。
     def test_update_entry_keeps_false_enable

--- a/views/program.slim
+++ b/views/program.slim
@@ -329,24 +329,26 @@ html lang='ja' data-theme='light'
               if (!entry.next_on) return false
               const value = String(entry.next_on)
               if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return true
-              const date = new Date(`${value}T00:00:00`)
-              if (Number.isNaN(date.getTime())) return true
-              // 2026-02-31 を繰り上げて解釈する実装向けの往復チェック。
-              return this.toDateKey(date) !== value
+              // 実在する日付か。2026-02-31 は Date が 3/3 へ繰り上げるので往復で見る。
+              // ⚠ ここは端末のタイムゾーンを混ぜてはいけないので UTC で組む。
+              const [year, month, day] = value.split('-').map(Number)
+              const date = new Date(Date.UTC(year, month - 1, day))
+              return date.getUTCFullYear() !== year ||
+                date.getUTCMonth() + 1 !== month ||
+                date.getUTCDate() !== day
             },
-            toDateKey (date) {
-              return [
-                date.getFullYear(),
-                String(date.getMonth() + 1).padStart(2, '0'),
-                String(date.getDate()).padStart(2, '0'),
-              ].join('-')
+            // 今日 (JST)。⚠ ブラウザのローカル日付では組まない。ProgramCalendar は
+            // next_on を +09:00 固定で解釈するので、国外の端末で日付境界をまたぐと
+            // 「カレンダーからは消えているのに警告が出ない」がありうる。
+            todayKeyJst () {
+              return new Date().toLocaleDateString('en-CA', {timeZone: 'Asia/Tokyo'})
             },
             // next_on が過去日か。過ぎるとカレンダーに出なくなる (#4373) ので、
             // 一覧で気づけるようにする。日付だけで比較する（当日は過去扱いしない）。
             isStaleNextOn (entry) {
               if (!entry.next_on) return false
               if (this.isInvalidNextOn(entry)) return false
-              return entry.next_on < this.toDateKey(new Date())
+              return entry.next_on < this.todayKeyJst()
             },
             isBusy (key) {
               return !!this.busy[key]


### PR DESCRIPTION
PR #4529 と #4533 に付いた Codex の P2 指摘 3 件（うち 1 件は重複）を是正する。3 件とも「番組表のデータが API を通らず入ってくる経路」（`var/program.yaml` の手編集・外部データソース）の話で、いずれも実在する入口。

## 1. `next_on` の書式検証が寛容（#4529 と #4533 で重複指摘）

`Date.strptime` は `2026-08-08junk` や `2026-8-8`、前後の空白を通す。#4533 で不正値を fail-closed にしたばかりだが、**「不正だと判定されない不正値」が残っていた**。番組表エディタ側は厳密な正規表現で「不正」バッジを出すため、また表示と挙動が食い違う。

`ProgramCalendar#scheduled_date` と `Program#advance_next_on` の両方で `ProgramEntryContract.valid_date?`（書式 + 実在日）を先に通すようにした。`advance_next_on` 側は、壊れた値を黙って別の壊れた値へ書き換えてしまう点も塞がる。

## 2. ただの整数の `start_time` を `00:00` に寄せていた

`start_time: 20` は 60 進数ではないのに `format_sexagesimal` が `'00:00'` へ変換し、`valid_start_time?` を通って**深夜 0 時のイベントとして出ていた**。#4373 で型による coerce を足す前は Integer のまま弾かれていたので、悪化させていたことになる。

60 進数として妥当な整数（0 以上 86400 未満・60 の倍数）だけを変換する。`20:30` → 73800、`9:05` → 32700 はいずれも 60 の倍数なので従来どおり通る。

## 3. stale 判定がブラウザのローカル日付だった

`ProgramCalendar` は `next_on` を `+09:00` 固定で解釈するのに、エディタは `new Date()` から端末ローカルの日付を組んでいた。国外の端末では日付境界付近で「カレンダーからは消えているのに警告が出ない」が起きる。`Asia/Tokyo` で今日を組むようにした。

あわせて、#4533 で入れた実在日チェックの往復を UTC で組み直している。`toDateKey` をそのまま JST 化すると、UTC+13 の端末で**正しい日付を不正と誤判定する**（ローカル解釈した深夜が JST では前日になるため）。

## 検証

- `bundle exec rake lint` — 全緑
- `bundle exec rake test` — 875 tests, 0 failures, 0 errors
- 追加テスト: 寛容な `next_on` 4 パターンが VEVENT を出さないこと、`start_time: 20` が Integer のまま残ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)