### PR TITLE
fix: 番組表エディタの JST 日付キーを明示的に組む (#4373)

### DIFF
--- a/views/program.slim
+++ b/views/program.slim
@@ -337,11 +337,24 @@ html lang='ja' data-theme='light'
                 date.getUTCMonth() + 1 !== month ||
                 date.getUTCDate() !== day
             },
-            // 今日 (JST)。⚠ ブラウザのローカル日付では組まない。ProgramCalendar は
-            // next_on を +09:00 固定で解釈するので、国外の端末で日付境界をまたぐと
-            // 「カレンダーからは消えているのに警告が出ない」がありうる。
+            // 今日 (JST) を YYYY-MM-DD で。⚠ ブラウザのローカル日付では組まない。
+            // ProgramCalendar は next_on を +09:00 固定で解釈するので、国外の端末で
+            // 日付境界をまたぐと「カレンダーからは消えているのに警告が出ない」が
+            // ありうる。⚠ toLocaleDateString('en-CA') は ISO 形式を保証しない。
+            // Intl データ次第で M/D/YYYY へ落ちると、下の字句比較が未来日を過去日と
+            // 誤読する（2027-01-01 < 8/6/2026）ので、年月日を取り出して自分で組む。
             todayKeyJst () {
-              return new Date().toLocaleDateString('en-CA', {timeZone: 'Asia/Tokyo'})
+              const parts = new Intl.DateTimeFormat('en-US', {
+                timeZone: 'Asia/Tokyo',
+                year: 'numeric',
+                month: '2-digit',
+                day: '2-digit'
+              }).formatToParts(new Date())
+              const value = (type, digits) => {
+                const part = parts.find(entry => entry.type === type)
+                return String(Number(part && part.value)).padStart(digits, '0')
+              }
+              return `${value('year', 4)}-${value('month', 2)}-${value('day', 2)}`
             },
             // next_on が過去日か。過ぎるとカレンダーに出なくなる (#4373) ので、
             // 一覧で気づけるようにする。日付だけで比較する（当日は過去扱いしない）。


### PR DESCRIPTION
## 概要

#4538 に付いた Codex P2 の是正。

`todayKeyJst()` が `toLocaleDateString('en-CA')` に ISO `YYYY-MM-DD` を期待していたが、この形式は仕様上保証されない。Intl データ次第で `M/D/YYYY` へ落ちると、`isStaleNextOn()` の字句比較が逆転し、**未来日を「過去日（通知は止まっています）」と誤表示する**（`2027-01-01` < `8/6/2026`）。

`Intl.DateTimeFormat#formatToParts` から年月日を取り出して明示的に組み直す。

## 検証

- `rake lint` 通過（rubocop 455 files no offenses / erb-lint / slim-lint / bundler-audit）
- `rake test` 875 tests, 0 failures, 0 errors（311 omissions は #4503 の既知分）
- 組み直したキーが `en-CA` 経路と一致することを確認（`2026-08-07`）

## 備考

5.31.0 のステージング再検証前に載せる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)