### PR TITLE
fix: 短縮 URL 展開の各ホップを SSRF allowlist に通す (#4535)

### DIFF
--- a/app/lib/mulukhiya/handler/shortened_url_handler.rb
+++ b/app/lib/mulukhiya/handler/shortened_url_handler.rb
@@ -23,17 +23,44 @@ module Mulukhiya
 
     private
 
+    # ⚠ 各ホップを必ず SSRF allowlist に通す (#4535)。
+    #
+    # ホップ追従は Ginseng::HTTP の host_validator に任せられない。あちらは
+    # 追従まで肩代わりして最終レスポンスだけ返すので、**最終 URL が取れず**
+    # 短縮 URL の展開そのものが成立しない。追うのがこちらである以上、検証も
+    # こちらの責務になる。
+    #
+    # 通さないと、rewritable? が無条件で許す t.co の短縮 URL 1 本で
+    # `http://169.254.169.254/...` 等へ GET を撃たせられる（本文は捨てるので
+    # ブラインドだが、内部エンドポイントへの到達は成立する）。#4410 / #4523 の
+    # 掃討の続き。
     def resolve_redirects(source)
+      return source unless permitted_host?(source)
       dest = source.clone
       redirects = 0
       while redirects < MAX_REDIRECTS
         next_uri, status = fetch_redirect(dest)
         break unless next_uri
         break unless (status / 100) == 3
+        # ⚠ GET を撃たないだけでは足りない。dest にしてしまうと、投稿本文が
+        # 内部 URL へ書き換わったまま連合に流れる。
+        break unless permitted_host?(next_uri)
         dest = next_uri
         redirects += 1
       end
       return dest
+    end
+
+    # 検証は「GET する直前の 1 回」で足りる。あるホップの next_uri は次の
+    # ホップの src なので、ここで通したものだけが fetch_redirect へ渡る。
+    def permitted_host?(uri)
+      return true if RemoteHost.validator.call(uri.host.to_s)
+      errors.push(
+        class: Ginseng::GatewayError.to_s,
+        message: "Rejected host '#{uri.host}'",
+        url: uri.to_s,
+      )
+      return false
     end
 
     def fetch_redirect(src)

--- a/app/lib/mulukhiya/program_fetcher.rb
+++ b/app/lib/mulukhiya/program_fetcher.rb
@@ -61,6 +61,9 @@ module Mulukhiya
       programs = {}
       success = 0
       uris.each do |v|
+        # allowlist 拒否は HEAD を撃つ前に確定させる。プリフライトの rescue へ
+        # 渡すと「判定不能」として GET へ倒れてしまう (#4535)。
+        RemoteHost.validate!(v)
         next unless valid_content_length?(v)
         response = @http.get(v, timeout: fetch_timeout, host_validator: RemoteHost.validator)
         next unless valid_response_size?(response, v)
@@ -99,6 +102,8 @@ module Mulukhiya
       # HEAD 非対応・一過性障害は判定不能。GET 側で再評価する。GAS など HEAD を
       # 受け付けないホストは 403/405 を返すが、これは想定内なので黙ってフォール
       # バックし、timeout・5xx 等の異常のみログする (#4397)。
+      # ⚠ allowlist 拒否はここへ来ない (呼び出し元の RemoteHost.validate! で
+      # 確定済み)。ここを通る = ホストは通ってよい、が保たれている (#4535)。
       status = e.respond_to?(:source_status) ? e.source_status : nil
       e.log(url: uri.to_s) unless [403, 405].include?(status)
       return true

--- a/app/lib/mulukhiya/pronunciation_dictionary.rb
+++ b/app/lib/mulukhiya/pronunciation_dictionary.rb
@@ -158,6 +158,9 @@ module Mulukhiya
     end
 
     def fetch_one(uri)
+      # allowlist 拒否は HEAD を撃つ前に確定させる。プリフライトの rescue へ
+      # 渡すと「判定不能」として GET へ倒れてしまう (#4535)。
+      RemoteHost.validate!(uri)
       return nil unless valid_content_length?(uri)
       response = @http.get(uri, timeout: fetch_timeout, host_validator: RemoteHost.validator)
       return nil unless valid_response_size?(response, uri)
@@ -204,6 +207,8 @@ module Mulukhiya
       # GAS など HEAD 非対応のホストは 403/405 を返す。これは想定内なので黙って GET へ
       # フォールバックし (GET 側 valid_response_size? が最終防衛線)、timeout・5xx 等の
       # 異常のみログする。GAS は Content-Length も返さず事前チェックは効かない (#4397)。
+      # ⚠ allowlist 拒否はここへ来ない (呼び出し元の RemoteHost.validate! で確定済み)。
+      # ここを通る = ホストは通ってよい、が保たれている (#4535)。
       status = e.respond_to?(:source_status) ? e.source_status : nil
       e.log(url: uri.to_s) unless [403, 405].include?(status)
       return true

--- a/app/lib/mulukhiya/remote_host.rb
+++ b/app/lib/mulukhiya/remote_host.rb
@@ -50,6 +50,19 @@ module Mulukhiya
       attr_writer :validator
     end
 
+    # allowlist を通らないホストで GatewayError を投げる (#4535)。
+    #
+    # HEAD プリフライトの rescue は「HEAD 非対応・一過性障害 = 判定不能」を
+    # GET へ倒すためのもの。allowlist 拒否まで同じ rescue が飲むと
+    # 「プリフライトが true = GET してよい」が成り立たなくなり、GET 側の
+    # host_validator が外れた瞬間に無検証へ戻る。拒否は HEAD を撃つ前に
+    # ここで確定させ、URL 単位の rescue へ渡す（拒否 1 件につきログも 1 本）。
+    def self.validate!(uri)
+      host = uri.respond_to?(:host) ? uri.host.to_s : uri.to_s
+      return true if validator.call(host)
+      raise Ginseng::GatewayError, "Rejected host '#{host}'"
+    end
+
     # Addrinfo.getaddrinfo は timeout を持てず、攻撃者が応答を引き延ばす権威
     # DNS を立てると Sinatra リクエストスレッド (Puma 5 本) を飽和させられる。
     # Resolv::DNS#timeouts= で 1 回あたりの解決待ちを上限化する。タイムアウト

--- a/test/unit/lib/remote_host.rb
+++ b/test/unit/lib/remote_host.rb
@@ -101,5 +101,26 @@ module Mulukhiya
       assert_equal(RemoteHost.dns_timeout, applied)
       assert_equal(['93.184.216.34', '2606:2800:220:1::1'], result)
     end
+
+    # validate! は allowlist 拒否を「判定不能」と区別するための入口 (#4535)。
+    # 拒否したときに **実際に例外になる**ことを正で押さえる。
+    def test_validate_raises_for_rejected_host
+      RemoteHost.validator = ->(_host) {false}
+
+      assert_raise(Ginseng::GatewayError) do
+        RemoteHost.validate!(Ginseng::URI.parse('http://169.254.169.254/latest/meta-data/'))
+      end
+    ensure
+      RemoteHost.validator = nil
+    end
+
+    def test_validate_passes_for_permitted_host
+      RemoteHost.validator = ->(host) {host == 'www.example.jp'}
+
+      assert_true(RemoteHost.validate!(Ginseng::URI.parse('https://www.example.jp/foo')))
+      assert_true(RemoteHost.validate!('www.example.jp'))
+    ensure
+      RemoteHost.validator = nil
+    end
   end
 end

--- a/test/unit/lib/shortened_url_ssrf.rb
+++ b/test/unit/lib/shortened_url_ssrf.rb
@@ -1,0 +1,71 @@
+require 'webmock/test_unit'
+
+module Mulukhiya
+  # 短縮 URL の展開が、リダイレクトの各ホップで SSRF allowlist を通ること (#4535)。
+  #
+  # ShortenedURLHandler は Location だけ見て自前でホップを追う (Ginseng::HTTP の
+  # host_validator に任せると最終 URL が取れない) ので、検証もハンドラ側の責務。
+  #
+  # ⚠ ファイル名を *_handler.rb にしない。TestCase.load が
+  # `Handler.create(name).disable?` を評価するため、ハンドラが無効な環境では
+  # ケースごと落ち、この回帰テストまで一緒に消える。
+  class ShortenedURLSsrfTest < TestCase
+    SHORTENED = 'https://t.co/deadbeef'.freeze
+    METADATA = 'http://169.254.169.254/latest/meta-data/'.freeze
+    PUBLIC_DEST = 'https://www.example.jp/article'.freeze
+
+    def setup
+      WebMock.disable_net_connect!
+      # sns を渡さないと Handler#initialize が実 SNS サービスを組み立て、
+      # Sequel (Postgres) 依存になる。展開処理は SNS を触らないのでダブルで足りる。
+      @handler = ShortenedURLHandler.new(sns: Object.new)
+      RemoteHost.validator = ->(host) {['t.co', 'www.example.jp'].include?(host)}
+    end
+
+    def teardown
+      super
+      # ⚠ 差し替えたままにすると以後のテストで SSRF ガードが効かなくなる。
+      # nil を入れると次の参照で既定 (RemoteHost.public?) が張り直される。
+      RemoteHost.validator = nil
+      WebMock.reset!
+      WebMock.allow_net_connect!
+    end
+
+    def resolve(url = SHORTENED)
+      return @handler.send(:resolve_redirects, Ginseng::URI.parse(url))
+    end
+
+    # 正のケース: 許可ホストへのリダイレクトはこれまでどおり展開される。
+    def test_follows_permitted_redirect
+      stub_request(:get, SHORTENED).to_return(status: 301, headers: {'Location' => PUBLIC_DEST})
+      stub_request(:get, PUBLIC_DEST).to_return(status: 200, body: 'ok')
+
+      assert_equal(PUBLIC_DEST, resolve.to_s)
+    end
+
+    # リンクローカル (メタデータサービス) へのリダイレクトは GET しない。
+    def test_blocks_redirect_to_link_local_metadata
+      stub_request(:get, SHORTENED).to_return(status: 302, headers: {'Location' => METADATA})
+
+      assert_equal(SHORTENED, resolve.to_s)
+      assert_not_requested(:get, METADATA)
+    end
+
+    # ⚠ GET しないだけでは足りない。弾いた URL を展開結果に採ると、投稿本文が
+    # 内部 URL へ書き換わったまま連合に流れる。
+    def test_does_not_rewrite_status_to_rejected_url
+      stub_request(:get, SHORTENED).to_return(status: 302, headers: {'Location' => METADATA})
+
+      assert_not_include(resolve.to_s, '169.254.169.254')
+      assert_true(@handler.errors.any? {|v| v[:message].to_s.include?('Rejected host')})
+    end
+
+    # 初段そのものが拒否ホストなら、1 回も GET しない。
+    def test_blocks_first_hop
+      stub_request(:get, METADATA).to_return(status: 200, body: 'ok')
+
+      assert_equal(METADATA, resolve(METADATA).to_s)
+      assert_not_requested(:get, METADATA)
+    end
+  end
+end


### PR DESCRIPTION
close #4535

## 変更

- `ShortenedURLHandler#resolve_redirects` の各ホップを `RemoteHost.validator` に通す。
  弾いた URL は **GET しない**だけでなく **展開結果にも採らない**（採ると投稿本文が
  内部 URL へ書き換わったまま連合に流れる）
- 番組表 (`ProgramFetcher`) / 読み辞書 (`PronunciationDictionary`) の HEAD プリフライトが
  allowlist 拒否の `GatewayError` まで「判定不能」として飲み `true`（＝ GET へ進め）に
  倒れていたのを是正。`RemoteHost.validate!` で HEAD を撃つ前に確定させ、URL 単位の
  rescue へ渡す（拒否 1 件につきログも 1 本になる）

## 設計メモ

`Ginseng::HTTP` の `host_validator` には寄せられない。あちらはホップ追従まで肩代わりして
**最終レスポンスだけ**返すので、短縮 URL の展開先 URL を取り出せず機能自体が壊れる。
追うのがハンドラ側である以上、検証もハンドラ側の責務。

## テスト

`test/unit/lib/shortened_url_ssrf.rb` を新設（4 件）。ファイル名を `*_handler.rb` に
しないのは、`TestCase.load` が `Handler.create(name).disable?` を評価するため、
ハンドラ無効な環境でこの回帰テストごと消えるのを避けるため。
ガードを外すと落ちることを確認済み（1 failures / 2 errors）。
`RemoteHost.validate!` の正・負も `test/unit/lib/remote_host.rb` に追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)