### PR TITLE
obs: ALT 編集 PUT の 404 を Sentry alert から外す (#4542)

### DIFF
--- a/app/lib/mulukhiya/controller/mastodon_controller.rb
+++ b/app/lib/mulukhiya/controller/mastodon_controller.rb
@@ -2,6 +2,18 @@ module Mulukhiya
   class MastodonController < Controller
     include ControllerMethods
 
+    # ALT 編集 (PUT /api/:version/statuses/:id) で Sentry alert を抑止する
+    # 上流ステータス (#4542)。
+    #
+    # 404 は「編集対象が存在しない・削除済み・リモートの投稿」で出る
+    # **クライアントエラー**。capsicum の操作次第で常時発生しうるので、
+    # alert に乗せるとノイズが積み上がるだけで運用判断に使えない。
+    #
+    # ⚠ 抑止するのは Sentry だけで syslog には残る (controller.rb の
+    # handle_gateway_error)。「上流が /source を廃止して全滅」のような事故は
+    # 頻度・偏りで追える。
+    STATUS_UPDATE_SILENT_STATUSES = [401, 404].freeze
+
     post '/api/:version/statuses' do
       verify_token_integrity!
       tags = TootParser.new(params[:status]).tags
@@ -70,7 +82,7 @@ module Mulukhiya
       @renderer.status = 422
       return @renderer.to_s
     rescue Ginseng::GatewayError => e
-      handle_gateway_error(e)
+      handle_gateway_error(e, silent_statuses: STATUS_UPDATE_SILENT_STATUSES)
       return @renderer.to_s
     end
 

--- a/test/unit/controller/gateway_error_transparency.rb
+++ b/test/unit/controller/gateway_error_transparency.rb
@@ -91,6 +91,36 @@ module Mulukhiya
       )
     end
 
+    # ALT 編集 (PUT /api/:version/statuses/:id) の 404 はクライアント起因なので
+    # alert しない (#4542)。抑止側は「実際に抑止していること」を正で押さえる。
+    def test_alert_is_suppressed_for_status_update_not_found
+      error = build_error(404, {error: 'Record not found'}.to_json)
+
+      assert_false(
+        alerted?(error) do
+          @controller.handle_gateway_error(
+            error,
+            silent_statuses: MastodonController::STATUS_UPDATE_SILENT_STATUSES,
+          )
+        end,
+      )
+    end
+
+    # ⚠ 黙らせるのは 401 / 404 だけ。上流の 5xx まで抑止すると、
+    # 「/source が廃止されて ALT 編集が全滅」を Sentry で拾えなくなる。
+    def test_alert_fires_for_status_update_server_error
+      error = build_error(500, {error: 'Internal Server Error'}.to_json)
+
+      assert_true(
+        alerted?(error) do
+          @controller.handle_gateway_error(
+            error,
+            silent_statuses: MastodonController::STATUS_UPDATE_SILENT_STATUSES,
+          )
+        end,
+      )
+    end
+
     def test_user_fault_codes_covers_known_misskey_codes
       ['TOO_MANY_DRAFTS', 'ALREADY_FAVORITED', 'NO_SUCH_NOTE', 'MAX_FILE_SIZE_EXCEEDED'].each do |code|
         assert_includes(MisskeyController::USER_FAULT_CODES, code)


### PR DESCRIPTION
close #4542

## 変更

`put '/api/:version/statuses/:id'`（ALT 編集）の rescue を
`handle_gateway_error(e, silent_statuses: STATUS_UPDATE_SILENT_STATUSES)` にした。
定数は `MastodonController` に `[401, 404].freeze` で置いてある。

404 は「編集対象が存在しない・削除済み・リモートの投稿」で出るクライアントエラーで、
capsicum の操作次第で常時発生しうる。⚠ 抑止するのは Sentry だけで **syslog には残る**
ので、「上流が `/source` を廃止して全滅」のような事故は頻度・偏りで追える。

## 他エンドポイントの棚卸し（Issue の宿題）

Sentry の unresolved を全件見て `mastodon_controller` の 404 を追った結果:

| Short ID | route | count | last seen | 判断 |
| --- | --- | --- | --- | --- |
| 2D / 2E | ALT 編集 PUT | 4 / 1 | 2026-08-07 | **今回抑止** |
| 29 | `POST .../favourite` | 1 | 2026-06-27 | 据え置き（6 週で 1 件） |
| B | `POST /api/:version/statuses`（投稿本体） | 5 | 2026-06-11 | **抑止しない**。投稿が 404 で落ちるのは alert すべき異常 |

reblog / bookmark の 404 は 1 件も無い。fav は同型（削除済み投稿への fav）だが実績が
6 週で 1 件しかなく、いま黙らせても得るものが無いので据え置き。増えたら同じ定数へ寄せる。

## テスト

`test/unit/controller/gateway_error_transparency.rb` に 2 件追加。
404 が **実際に抑止されること**（正）と、500 は **抑止されないこと**（黙らせすぎない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)