### PR TITLE
5.32.1（ホットフィックス）

### DIFF
--- a/app/lib/mulukhiya/renderer/rss20_feed_renderer.rb
+++ b/app/lib/mulukhiya/renderer/rss20_feed_renderer.rb
@@ -23,10 +23,27 @@ module Mulukhiya
           "CustomFeed command failed (exit #{command.status}): #{command.stderr}"
       end
       self.entries = parse_entries(command.stdout)
-      render_storage[command] = feed.to_s
+      rendered = feed.to_s
+      log_unresolved_enclosures
+      render_storage[command] = rendered
     end
 
     alias save cache
+
+    # 相対 URL を base で絶対化する (#4549)。絶対化できなければ nil。
+    #
+    # ⚠ インスタンスメソッドにしない。インスタンスは SNS (DB) と Redis を掴むので、
+    # DB の無い環境ではテストがケースごと omit され、**この判定が一度も走らない**。
+    def self.absolute_uri(value, base)
+      return nil if value.blank?
+      uri = Ginseng::URI.parse(value.to_s)
+      return uri.to_s if uri.absolute?
+      return nil if base.blank?
+      return ::URI.join(base.to_s, value.to_s).to_s
+    rescue
+      # 相対解決に失敗する値 (制御文字入り等) は enclosure ごと落とす。
+      return nil
+    end
 
     def clear
       render_storage.unlink(command)
@@ -51,13 +68,50 @@ module Mulukhiya
       return []
     end
 
+    # ⚠ 相対 URL はここで絶対化する (#4549)。
+    #
+    # 基底クラスは `@http.base_uri = channel[:link]` を置いて Ginseng::HTTP#create_uri に
+    # 解決させていたが、こちらは fetch_image を上書きして MediaMetadataStorage
+    # (base_uri を持たない別の HTTP) へ委譲したので、その解決だけが落ちていた。
+    # サイト相対の画像 URL を返すフィード (dqdai-anime) は **サムネイルが全滅**したうえ、
+    # 5 分おきに `base_uri undefined` をエントリ数ぶん吐き続けていた (日 2 万行)。
     def fetch_image(uri)
-      return nil unless uri
+      return nil unless uri = absolute_uri(uri)
       metadata_storage.push(uri) unless metadata_storage.key?(uri)
       return metadata_storage[uri]
     rescue => e
-      e.log
+      e.log(uri: uri.to_s)
       return nil
+    end
+
+    # channel の link を基準に絶対 URL へ寄せる。絶対化できない値は nil を返して
+    # enclosure ごと落とす (壊れた URL を enclosure に載せない)。
+    def absolute_uri(value)
+      return nil if value.blank?
+      return self.class.absolute_uri(value, @http.base_uri) || unresolved_enclosure(value)
+    end
+
+    # 絶対化できなかった値を覚えておく。⚠ **ここで 1 件ずつログを出さない。**
+    # エントリごとに出すと 5 分おきにエントリ数ぶん積み上がる (#4549 の再来)。
+    # まとめて 1 行にするのは log_unresolved_enclosures の仕事。
+    def unresolved_enclosure(value)
+      unresolved_enclosures.push(value.to_s)
+      return nil
+    end
+
+    def unresolved_enclosures
+      @unresolved_enclosures ||= []
+      return @unresolved_enclosures
+    end
+
+    def log_unresolved_enclosures
+      return if unresolved_enclosures.empty?
+      logger.warn(
+        message: 'feed enclosure url unresolved',
+        link: channel[:link].to_s,
+        count: unresolved_enclosures.size,
+        sample: unresolved_enclosures.first,
+      )
     end
   end
 end

--- a/app/lib/mulukhiya/storage/media_metadata_storage.rb
+++ b/app/lib/mulukhiya/storage/media_metadata_storage.rb
@@ -26,7 +26,14 @@ module Mulukhiya
       values = MediaFile.new(path).file.values.merge(url: uri.to_s)
       set(uri, values)
       log(url: uri.to_s)
-    rescue Ginseng::GatewayError => e
+    # ⚠ ネガティブキャッシュを GatewayError だけに絞らない (#4549)。
+    #
+    # 呼び出し元（フィード生成）は 5 分おきに全エントリを舐め直すので、ここで
+    # 空を置かない失敗は **毎サイクル同じ URL を叩き直し、同じログを出し続ける**。
+    # 実際 URL が絶対化できない RuntimeError がこの rescue を通らず、
+    # 1 サイクル 79 行 = 日 2 万行のログになっていた。
+    # 一過性の障害も ttl のあいだ諦めることになるが、それは GatewayError で既にそう。
+    rescue => e
       e.log(url: uri.to_s)
       set(uri, {})
     end

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -465,7 +465,7 @@ package:
     - tkoishi@b-shock.co.jp
   license: MIT
   url: https://github.com/pooza/mulukhiya-toot-proxy
-  version: 5.32.0
+  version: 5.32.1
 parser:
   note:
     fields:

--- a/test/unit/renderer/feed_enclosure_uri.rb
+++ b/test/unit/renderer/feed_enclosure_uri.rb
@@ -1,0 +1,57 @@
+module Mulukhiya
+  # カスタムフィードの enclosure URL を channel の link で絶対化すること (#4549)。
+  #
+  # ⚠ RSS20FeedRendererTest 本体は DBMS 未設定の環境でケースごと omit される。
+  # そこへ足すと「DB の無い手元では一度も走らない」ので、インスタンスを作らずに
+  # 済むクラスメソッドとして切り出し、こちらで常に検査する。
+  class FeedEnclosureURITest < TestCase
+    BASE = 'https://dq-dai.com/news/'.freeze
+
+    def resolve(value, base = BASE)
+      return RSS20FeedRenderer.absolute_uri(value, base)
+    end
+
+    # ⚠ ここが本体。サイト相対の画像 URL を返すフィード (dqdai-anime) は、
+    # これが無いと **サムネイルが全滅**したうえ 5 分おきに例外を吐き続ける。
+    def test_resolves_site_relative_path
+      assert_equal(
+        'https://dq-dai.com/dai/img/news/thumb.webp',
+        resolve('/dai/img/news/thumb.webp'),
+      )
+    end
+
+    def test_resolves_document_relative_path
+      assert_equal('https://dq-dai.com/news/thumb.webp', resolve('thumb.webp'))
+    end
+
+    # 絶対 URL は素通し（既存フィードの挙動を変えない）。
+    def test_keeps_absolute_url
+      url = 'https://www.dqdai-official.com/wp-content/uploads/2026/07/01-1-500x335.jpg'
+
+      assert_equal(url, resolve(url))
+    end
+
+    def test_returns_nil_for_blank
+      assert_nil(resolve(nil))
+      assert_nil(resolve(''))
+      assert_nil(resolve('   '))
+    end
+
+    # 基準が無ければ絶対化できない。**enclosure ごと落とす**のが正しい
+    # （相対のまま載せると購読側が解決できない URL を掴む）。
+    def test_returns_nil_without_base
+      assert_nil(resolve('/dai/img/news/thumb.webp', nil))
+      assert_nil(resolve('/dai/img/news/thumb.webp', ''))
+    end
+
+    # 基準が無くても絶対 URL は通る。
+    def test_keeps_absolute_url_without_base
+      assert_equal('https://example.jp/a.png', resolve('https://example.jp/a.png', nil))
+    end
+
+    # 解決に失敗する値で例外を投げない（フィード全体を落とさない）。
+    def test_returns_nil_for_broken_value
+      assert_nil(resolve("http://\n/broken"))
+    end
+  end
+end


### PR DESCRIPTION
## 概要

ホットフィックス。カスタムフィードの相対 enclosure URL が解決されず、サムネイルが欠落したまま
syslog に日 2 万行のエラーを積んでいた件（#4549）を修正する。

⚠ **適用先はデルムリン丼（zugoga）のみ**（ユーザー判断）。実害が出ているのがこのサーバーだけのため。
shallu / gomander / sweep は 5.32.0 のままで、5.33.0 で揃える。

## 変更内容

### バグ修正

- **#4549 カスタムフィードの相対 enclosure URL が解決されない** — `fetch_image` を
  `MediaMetadataStorage` へ委譲した際に、基底クラスが `@http.base_uri` で行っていた相対 URL の
  解決が落ちていた。`dqdai-anime`（80 エントリ）は `<enclosure>` が 1 件しか出ておらず、
  `FeedUpdateWorker` が 5 分おきに `base_uri undefined` を 79 行吐いていた

あわせて、絶対化できなかった値のログを 1 サイクル 1 行にまとめ、`MediaMetadataStorage` の
ネガティブキャッシュを `GatewayError` 限定から広げた（恒久的な失敗を毎サイクル叩き直さない）。

## アップグレード手順

[更新手順](https://github.com/pooza/mulukhiya-toot-proxy/wiki/%E6%9B%B4%E6%96%B0%E6%89%8B%E9%A0%86)を参照してください。
4.x系からのアップグレードは[4.x → 5.0 アップグレードガイド](https://github.com/pooza/mulukhiya-toot-proxy/wiki/4.x-%E2%86%92-5.0-%E3%82%A2%E3%83%83%E3%83%97%E3%82%B0%E3%83%AC%E3%83%BC%E3%83%89%E3%82%AC%E3%82%A4%E3%83%89)も参照してください。

**必要 Ruby: 4.0.6**（`.ruby-version`）。5.32.0 から据え置きです。

Gemfile に差分はないため `bundle install` は不要です。起動スクリプトの変更もありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)