### PR TITLE
test/ci: リリースゲートの穴 2 件を塞ぐ (#4559)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,7 @@ jobs:
         run: |
           bundle exec rake lint
       - name: Run test (${{ matrix.controller }})
+        id: test
         run: |
           set -o pipefail
           bundle exec rake test 2>&1 | tee test-result.log
@@ -57,10 +58,22 @@ jobs:
         if: always()
         env:
           BASELINE: ${{ matrix.omission_baseline }}
+          TEST_OUTCOME: ${{ steps.test.outcome }}
         run: |
+          # 集計できないときは fail closed (#4559)。test-unit がサマリの書式を
+          # 変えただけでラチェットが黙って無効化されると、#4503 で塞いだ
+          # 「守れているつもりの緑」がそのまま戻る。
+          # ⚠ テスト自体が落ちている run では既にジョブが赤なので追撃しない。
+          abort_unless_test_failed () {
+            if [ "$TEST_OUTCOME" != "success" ]; then
+              echo "::warning::$1（テストが失敗しているため、ここでは落とさない）"
+              exit 0
+            fi
+            echo "::error::$1"
+            exit 1
+          }
           if [ ! -f test-result.log ]; then
-            echo "::warning::テストが実行されなかったため omission を集計できません"
-            exit 0
+            abort_unless_test_failed "テスト結果のログが無いため omission を集計できません"
           fi
           summary="$(grep -E '^[0-9]+ tests, ' test-result.log | tail -1 || true)"
           omissions="$(printf '%s' "$summary" | sed -nE 's/.*, ([0-9]+) omissions.*/\1/p')"
@@ -78,8 +91,7 @@ jobs:
             echo "0 failures / 0 errors を確認すること（手順は docs/test-harness.md、経緯は #4503）。"
           } >> "$GITHUB_STEP_SUMMARY"
           if [ -z "$omissions" ]; then
-            echo "::warning::omission 件数を集計できませんでした"
-            exit 0
+            abort_unless_test_failed "omission 件数を集計できませんでした (集計行: ${summary:-なし})"
           fi
           if [ "$omissions" -gt "$BASELINE" ]; then
             echo "::error::omission が ${omissions} 件で上限 ${BASELINE} を超えました。実行されていないテストが増えています (#4503)"

--- a/app/lib/mulukhiya/test_harness.rb
+++ b/app/lib/mulukhiya/test_harness.rb
@@ -9,6 +9,11 @@ module Mulukhiya
 
     PREFIXES = {'mastodon' => 'MASTODON', 'misskey' => 'MISSKEY'}.freeze
 
+    class << self
+      # announce の一度きり判定。run をまたがないのでテストから戻せる。
+      attr_accessor :announced
+    end
+
     def self.apply!
       return new.apply!
     end
@@ -39,6 +44,7 @@ module Mulukhiya
       # mulukhiya は Mastodon の DB を直読みするため DSN があれば postgres.dsn も配線。
       values['postgres'] = {'dsn' => conn[:db_dsn]} if conn[:db_dsn]
       merge_local(values)
+      announce(type, conn)
       # DB 接続はブート時 (apply! より前、mulukhiya.rb の dbms_class&.connect) に
       # 確立される。Postgres は Singleton のため connect では既存インスタンスが返るだけで
       # 後から差した DSN を反映しない。reconnect で singleton を張り直し注入 DSN を使わせる。
@@ -64,6 +70,22 @@ module Mulukhiya
           db_dsn: env["#{prefix}_DB_DSN"].presence
         }
       end
+    end
+
+    # どのコントローラで走っているかを run の頭で stderr に出す (#4559)。返り値は
+    # 出力した文字列（テストから検証するため）。
+    #
+    # ⚠ **両系の .env.test を同じシェルで source すると、1 つ目の <PREFIX>_* が
+    # 残る。**接続情報が 2 つ揃うと target_controller は config['/controller']
+    # (既定 mastodon) を採るので、Misskey のつもりで Mastodon を 2 回走らせたまま
+    # 「両系緑」とゲートを通せてしまう。この行と source した .env.test を
+    # 突き合わせれば取り違えに気づける。
+    def announce(type, conn)
+      message = "TestHarness: controller=#{type} url=#{conn[:url]}"
+      return message if self.class.announced
+      warn message
+      self.class.announced = true
+      return message
     end
 
     private

--- a/docs/test-harness.md
+++ b/docs/test-harness.md
@@ -82,6 +82,9 @@ Misskey ハーネス（`fedi-test-harness/misskey`）でも同様。コントロ
 `config/local.yaml` を編集しなくても自動で Misskey が選択される。Mastodon と Misskey の
 両方を同時に source した場合は `config['/controller']` の値が優先される。
 
+⚠ **これはリリースゲートの取り違えの原因になる。**後述「リリースゲートとしての実走」の
+「系ごとにシェルを分ける」を必ず読むこと（#4559）。
+
 ```sh
 cd ~/repos/chubo2/fedi-test-harness/misskey && ./scripts/setup.sh
 cd ~/repos/mulukhiya-toot-proxy
@@ -95,9 +98,27 @@ bundle exec rake test
 CI には実インスタンスが無く、アカウント依存のテスト 300 件超が omission のまま
 `100% passed` と出るため、**CI の緑はこのゲートの代わりにならない**（#4503）。
 
+### ⚠ 系ごとにシェルを分ける（同じシェルで両系を source しない）
+
+`source .env.test` した変数は**シェルに残る**。Mastodon → Misskey の順に同じシェルで
+source すると `MASTODON_*` と `MISSKEY_*` が両方揃い、コントローラ選択は
+`config['/controller']`（既定 `mastodon`）に倒れる。つまり **Misskey のつもりで
+Mastodon をもう一度走らせたまま「両系緑」とゲートを通せてしまう**（#4559）。
+
+- 系ごとに**別のシェル**（別タブ・`bash -c` の中・`env -i`）で回す
+- 実走の頭で `TestHarness` が **選択したコントローラを stderr に出す**ので、source した
+  `.env.test` と一致しているかを毎回見る:
+
+  ```text
+  TestHarness: controller=misskey url=http://localhost:3001
+  ```
+
+- 結果を記録するときは、この行もセットで残す（後から取り違えを検証できる）
+
 判定基準:
 
 - **Mastodon 系・Misskey 系の両方で `0 failures / 0 errors`。**片系だけでは不可
+- **実走ごとの `TestHarness: controller=...` が、狙った系と一致している**
 - 両系とも `develop` の同一 HEAD で走らせる
 - omission は許容する（harness が構造的に提供しない範囲 = デーモン層・webhook・streaming・
   nodeinfo・seed 等を `harness?` で omit しているため）。ただし**件数が前回から大きく増えて

--- a/test/unit/lib/test_harness.rb
+++ b/test/unit/lib/test_harness.rb
@@ -1,3 +1,4 @@
+require 'stringio'
 require 'tmpdir'
 
 module Mulukhiya
@@ -13,11 +14,15 @@ module Mulukhiya
       ENV_KEYS.each {|key| ENV.delete(key)}
       # apply! は raw['local'] を恒久変更するため、退避して後続テストへの漏れを防ぐ。
       @saved_local = config.raw['local']&.dup
+      # announce は一度きりなので、済み扱いにしてテスト出力を汚さない。
+      @saved_announced = TestHarness.announced
+      TestHarness.announced = true
     end
 
     def teardown
       @saved.each {|key, value| value.nil? ? ENV.delete(key) : ENV[key] = value}
       config.raw['local'] = @saved_local
+      TestHarness.announced = @saved_announced
       super
     end
 
@@ -94,6 +99,54 @@ module Mulukhiya
       assert_equal('misskey_token', conn[:token])
       assert_equal('misskey', config['/controller'])
       assert_equal('http://localhost:3001', config['/misskey/url'])
+    end
+
+    # ⚠ 両系の .env.test を同じシェルで source した状態。接続情報が 2 つ揃うと
+    # config['/controller'] が勝つので、Misskey のつもりで Mastodon を走らせられる
+    # (#4559)。この挙動自体は仕様なので、取り違えは announce で気づく。
+    def test_apply_prefers_configured_controller_when_both_available
+      config['/controller'] = 'mastodon'
+      ENV['MASTODON_URL'] = 'http://localhost:3000'
+      ENV['MASTODON_ACCESS_TOKEN'] = 'mastodon_token'
+      ENV['MISSKEY_URL'] = 'http://localhost:3001'
+      ENV['MISSKEY_ACCESS_TOKEN'] = 'misskey_token'
+      conn = TestHarness.apply!
+
+      assert_equal('mastodon_token', conn[:token])
+      assert_equal('mastodon', config['/controller'])
+    end
+
+    def test_apply_announces_selected_controller
+      TestHarness.announced = nil
+      config['/controller'] = 'mastodon'
+      ENV['MISSKEY_URL'] = 'http://localhost:3001'
+      ENV['MISSKEY_ACCESS_TOKEN'] = 'misskey_token'
+      stderr = StringIO.new
+      saved = $stderr
+      begin
+        $stderr = stderr
+        TestHarness.apply!
+      ensure
+        $stderr = saved
+      end
+
+      assert_match(/controller=misskey/, stderr.string)
+      assert_match(%r{url=http://localhost:3001}, stderr.string)
+    end
+
+    def test_announce_is_emitted_once
+      TestHarness.announced = nil
+      conn = {url: 'http://localhost:3000'}
+      stderr = StringIO.new
+      saved = $stderr
+      begin
+        $stderr = stderr
+        2.times {TestHarness.new.announce('mastodon', conn)}
+      ensure
+        $stderr = saved
+      end
+
+      assert_equal(1, stderr.string.lines.size)
     end
 
     def test_apply_is_noop_without_connection_info


### PR DESCRIPTION
Closes #4559

## 1. 実走したコントローラを自己申告させる

`source .env.test` した変数はシェルに残るので、Mastodon → Misskey の順に同じシェルで source すると接続情報が 2 つ揃い、`TestHarness#target_controller` は `config['/controller']`（既定 `mastodon`）を採る。つまり **Misskey のつもりで Mastodon をもう一度走らせたまま「両系緑」とゲートを通せていた**。

- `TestHarness#announce` を追加し、run の頭で `TestHarness: controller=misskey url=http://localhost:3001` を stderr に出す（一度きり）
- [docs/test-harness.md](docs/test-harness.md) のゲート節に「系ごとにシェルを分ける」を追加し、判定基準に**この行が狙った系と一致していること**を足した
- 選択ルール自体は仕様なので変えていない。**取り違えに気づける手段を足す**方向で直している

テストは 3 本追加:

- `test_apply_prefers_configured_controller_when_both_available` — 両系揃ったときに config が勝つ（＝踏める）ことを固定
- `test_apply_announces_selected_controller` — `$stderr` を差し替えて出力を検証
- `test_announce_is_emitted_once` — 2 回呼んでも 1 行

## 2. omission 集計を fail closed に

test-unit がサマリの書式を変えた（あるいは装飾が入った）だけで、集計をパースできず **warning のまま success** になり、#4503 で入れたラチェットが黙って無効化される。集計不能を error にした。

⚠ **テスト自体が落ちている run では追撃しない**（前段のステップが既にジョブを赤くしている）。`steps.test.outcome` で切り分けている。

## 検証

- `bundle exec rake lint` 全緑
- `bundle exec rake test` **932 tests / 1260 assertions / 0 failures / 0 errors / 313 omissions**（omission 件数は CI の mastodon baseline と一致）

## 経緯

PR #4555 に付いた Codex の指摘 2 件（マージ後に届いていて未処理だった）。2026-08-10 の同期で triage した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)