### PR TITLE
fix: warn のマスキング穴を塞ぎ、unresolved をレンダーごとに捨てる (#4560)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-core.git
-  revision: de82ea13eb9d174121bc550bc45cb67d902c0efc
+  revision: 47e97be7b962e823caa6cf89eec34608ec7e39e1
   branch: main
   specs:
-    ginseng-core (1.15.34)
+    ginseng-core (1.15.36)
       activesupport (>= 7.0.7.1)
       addressable (>= 2.9.0)
       cgi (>= 0.4.2)

--- a/app/lib/mulukhiya/renderer/rss20_feed_renderer.rb
+++ b/app/lib/mulukhiya/renderer/rss20_feed_renderer.rb
@@ -23,9 +23,7 @@ module Mulukhiya
           "CustomFeed command failed (exit #{command.status}): #{command.stderr}"
       end
       self.entries = parse_entries(command.stdout)
-      rendered = feed.to_s
-      log_unresolved_enclosures
-      render_storage[command] = rendered
+      render_storage[command] = render
     end
 
     alias save cache
@@ -50,14 +48,30 @@ module Mulukhiya
     end
 
     def to_s
-      return feed.to_s unless render_storage.key?(command)
+      return render(log: false) unless render_storage.key?(command)
       return render_storage[command]
     rescue => e
       e.log
-      return feed.to_s
+      return render(log: false)
     end
 
     private
+
+    # 1 レンダーぶんの描画 (#4560)。
+    #
+    # ⚠ **unresolved はレンダーごとに捨てる。**レンダラは CustomFeed#renderer が
+    # メモ化するので、貯めるとリクエストのたびに配列が伸び、後続の
+    # log_unresolved_enclosures が「そのレンダーぶん」でなく累積の count / sample を
+    # 報告する。
+    #
+    # ⚠ **リクエスト経路 (log: false) ではログを出さない。**5 分おきの更新側が
+    # 1 サイクル 1 行で出すので十分で、リクエストごとに出すと #4549 の再来になる。
+    def render(log: true)
+      unresolved_enclosures.clear
+      rendered = feed.to_s
+      log_unresolved_enclosures if log
+      return rendered
+    end
 
     def parse_entries(stdout)
       entries = JSON.parse(stdout)

--- a/test/unit/renderer/rss20_feed_renderer.rb
+++ b/test/unit/renderer/rss20_feed_renderer.rb
@@ -37,4 +37,56 @@ module Mulukhiya
       assert_empty(@renderer.entries)
     end
   end
+
+  # ⚠ **DBMS が無い環境でも走ること。**RSS20FeedRendererTest は
+  # `Environment.dbms_class&.config?` でケースごと omit されるので、そこに置くと
+  # この判定が一度も走らない（#4549 で absolute_uri をクラスメソッドにしたのと
+  # 同じ理由）。親の initialize は SNS(DB) と Redis を掴むので呼ばない。
+  class RSS20FeedRendererRenderTest < TestCase
+    class StubRenderer < RSS20FeedRenderer
+      attr_reader :logged
+
+      def initialize(values) # rubocop:disable Lint/MissingSuper
+        @values = values
+        @logged = []
+      end
+
+      private
+
+      # レンダー中に絶対化できない値を踏む、を模す。feed.to_s される側なので
+      # String を返しておけばよい。
+      def feed
+        @values.each {|value| unresolved_enclosure(value)}
+        return 'rendered'
+      end
+
+      def log_unresolved_enclosures
+        @logged.push(unresolved_enclosures.dup)
+      end
+    end
+
+    # レンダーごとに捨てること。捨てないとレンダラがメモ化される経路
+    # (CustomFeed#renderer) で伸び続け、count / sample が累積になる (#4560)。
+    def test_render_scopes_unresolved_to_one_render
+      renderer = StubRenderer.new(['/a.jpg', '/b.jpg'])
+      2.times {renderer.send(:render)}
+
+      assert_equal([['/a.jpg', '/b.jpg'], ['/a.jpg', '/b.jpg']], renderer.logged)
+      assert_equal(2, renderer.send(:unresolved_enclosures).size)
+    end
+
+    def test_render_returns_rendered_body
+      assert_equal('rendered', StubRenderer.new([]).send(:render))
+    end
+
+    # ⚠ リクエスト経路ではログを出さない。5 分おきの更新側が 1 サイクル 1 行で
+    # 出すので十分で、リクエストごとに出すと #4549 の再来になる。
+    def test_render_without_log_is_silent
+      renderer = StubRenderer.new(['/a.jpg'])
+      renderer.send(:render, log: false)
+
+      assert_empty(renderer.logged)
+      assert_equal(1, renderer.send(:unresolved_enclosures).size)
+    end
+  end
 end


### PR DESCRIPTION
Closes #4560

## 1. `logger.warn` がマスキング層を通らない

Codex は PR #4551 で「`Ginseng::Logger` に `warn` が無いので `NoMethodError` になる」と指摘したが、**その前提は誤り**（`Ginseng::Logger < Syslog::Logger`）。ただし掘ると別の実害があった。

`Ginseng::Logger` が上書きしているのは **`info` と `error` だけ**で、この 2 つだけが `create_message(message).to_json` を通る。`warn` / `debug` / `fatal` は素通りするので:

- 出力が JSON でなく **`Hash#to_s`** になり、他の行と書式が揃わない
- **#4511 / #4533 のマスキングが効かない**。モロヘイヤの `warn` 呼び出し 4 箇所のうち、`RSS20FeedRenderer#log_unresolved_enclosures` は**フィードの URL を載せる**

ginseng-core 側で塞いだ（pooza/ginseng-core#499 → PR #500 / #501、1.15.36）。⚠ **呼び出し側を `info` に書き換えて回るのは対症療法**で、severity は syslog の重要度として正当な使い分けなので Logger 側で直している。ブロック形式（`logger.warn {expensive}`）を殺さないこと・severity 無効時にブロックを評価しないことも #501 で担保した。本 PR は `Gemfile.lock` の追従のみ。

## 2. `unresolved_enclosures` がリクエスト経路で伸び続ける

Codex P2（PR #4550）。`@unresolved_enclosures` は push されるだけでクリアされず、`CustomFeed#renderer` がレンダラをメモ化するため、キャッシュミスの `to_s`（`feed.to_s` へフォールバック）を繰り返すと配列が伸びる。後続の `cache` が**そのレンダーぶんでなく累積**の `count` / `sample` を報告する。

`render(log: true)` を新設して 1 レンダーぶんにスコープした。⚠ **リクエスト経路では出さない**（5 分おきの更新側が 1 サイクル 1 行で出すので十分。リクエストごとに出すと #4549 の再来）。

### テストは DBMS 無しでも走る場所に置いた

⚠ `RSS20FeedRendererTest` は `Environment.dbms_class&.config?` でケースごと omit されるので、そこに足すと**この判定が一度も走らない**（#4549 で `absolute_uri` をクラスメソッドにしたのと同じ理由）。親の `initialize` を呼ばないスタブを使い、独立したテストクラスに置いた。

`unresolved_enclosures.clear` の 1 行だけを消すと `test_render_scopes_unresolved_to_one_render` が落ちることを確認済み。

## 検証

- `bundle exec rake lint` 全緑
- `bundle exec rake test` **932 tests / 1260 assertions / 0 failures / 0 errors / 313 omissions**

🤖 Generated with [Claude Code](https://claude.com/claude-code)