### PR TITLE
security: 検証で通した IP に接続して DNS リバインディングを塞ぐ (#4524)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-core.git
-  revision: a9fada1788a92cbaa99c19c0ed817607707fc5b8
+  revision: d026249c242894228aaa57fc1649f028c5bd03bb
   branch: main
   specs:
-    ginseng-core (1.15.37)
+    ginseng-core (1.16.0)
       activesupport (>= 7.0.7.1)
       addressable (>= 2.9.0)
       cgi (>= 0.4.2)

--- a/app/lib/mulukhiya/remote_host.rb
+++ b/app/lib/mulukhiya/remote_host.rb
@@ -16,33 +16,65 @@ module Mulukhiya
     ].freeze
 
     def self.public?(host, resolver: method(:resolve_addresses))
-      return false unless host.present?
-      return false unless host.include?('.')
-      return false if IPV4_LITERAL.match?(host)
-      return false if IPV6_BRACKET.match?(host)
+      return allowed_address(host, resolver:).present?
+    end
+
+    # 許可できるなら**接続に使う IP アドレス**を、拒否なら nil を返す (#4524)。
+    #
+    # ⚠ **真偽値ではなくアドレスを返すのが肝。**名前で検証して名前で接続すると、
+    # 権威 DNS を握った相手が検証時だけ公開 IP を返し、接続時に 127.0.0.1 を
+    # 返せる（DNS リバインディング / TOCTOU）。ここで通した IP をそのまま接続先へ
+    # 固定する（pinning は pooza/ginseng-core#503）。
+    #
+    # ⚠ **1 本に固定するので Net::HTTP の複数アドレスへのフォールバックは効かなく
+    # なる。**A レコードが複数あって先頭だけ落ちている相手は取得できない。
+    # allowlist の対象は管理者が設定した少数の URL なので、この不便より
+    # 「検証した先に繋ぐ」ほうを採る。
+    def self.allowed_address(host, resolver: method(:resolve_addresses))
+      return nil unless host.present?
+      return nil unless host.include?('.')
+      return nil if IPV4_LITERAL.match?(host)
+      return nil if IPV6_BRACKET.match?(host)
       addrs = resolver.call(host)
-      return false if addrs.empty?
-      addrs.none? do |ip|
-        addr = IPAddr.new(ip)
-        addr.private? || addr.loopback? || addr.link_local?
-      end
+      return nil if addrs.empty?
+      # ⚠ 1 本でも内部アドレスを含むなら拒否する。「公開 IP のほうを選べばよい」
+      # ではない。混ぜて返してくるのはリバインディングそのもの。
+      return nil if addrs.any? {|ip| internal_address?(ip)}
+      return preferred_address(addrs)
     rescue *RESOLUTION_ERRORS => e
       # DNS 障害・タイムアウト等の環境要因は SSRF allowlist の fail-closed
-      # 方針どおり false を返す。運用ミス（未到達ホスト等）と攻撃検知の
+      # 方針どおり nil（= 拒否）を返す。運用ミス（未到達ホスト等）と攻撃検知の
       # 切り分けのため warn ログを残す。IPAddr::Error 等のロジックバグは
       # ここで握らず呼び出し元へ伝播させ Sentry で可視化する。
       Logger.new.warn(remote_host: {host:, error: e.class.name, message: e.message})
-      return false
+      return nil
+    end
+
+    def self.internal_address?(ip)
+      addr = IPAddr.new(ip)
+      return addr.private? || addr.loopback? || addr.link_local?
+    end
+
+    # ⚠ IPv4 があれば IPv4 を採る。getaddresses は A と AAAA を混ぜて返すので、
+    # 素直に先頭を採ると IPv6 が来うる。モロヘイヤが動く本番 4 台は IPv4 を正と
+    # しており、IPv6 を掴むと到達しないか Happy Eyeballs のフォールバックぶんだけ
+    # 遅くなる（#4464 で踏んだ ::1 の 305ms と同じ形）。
+    def self.preferred_address(addrs)
+      return addrs.find {|ip| IPV4_LITERAL.match?(ip)} || addrs.first
     end
 
     # Ginseng::HTTP#get の host_validator へ渡す callable (#4410)。
     # リダイレクトの各ホップがこれを通る。
     #
+    # ⚠ **返すのは真偽値ではなく IP アドレス**（拒否なら nil）。ginseng-core は
+    # 文字列が返るとその IP へ接続を固定する (pooza/ginseng-core#503)。名前で
+    # 検証して名前で接続していると DNS リバインディングで抜けられる (#4524)。
+    #
     # ⚠ writer はテストの差し替え専用。実行時に緩めてはいけない。差し替えた
     # テストは teardown で必ず元へ戻すこと（残すと以後のテストで SSRF ガードが
     # 効かなくなり、守れているつもりの緑になる）。
     def self.validator
-      @validator ||= ->(host) {public?(host)}
+      @validator ||= ->(host) {allowed_address(host)}
       return @validator
     end
 

--- a/test/unit/lib/program_fetcher_ssrf.rb
+++ b/test/unit/lib/program_fetcher_ssrf.rb
@@ -48,10 +48,12 @@ module Mulukhiya
     end
 
     # RemoteHost.validator が実際に内部アドレスを弾く callable であること。
+    # ⚠ 拒否は false でなく **nil**（#4524 以降、許可時は接続先の IP を返す）。
+    # 呼び出し側はいずれも真偽で判定しているので、拒否は falsy であればよい。
     def test_remote_host_validator_rejects_private_address
-      assert_false(RemoteHost.validator.call('127.0.0.1'))
-      assert_false(RemoteHost.validator.call('localhost'))
-      assert_false(RemoteHost.validator.call(''))
+      assert_nil(RemoteHost.validator.call('127.0.0.1'))
+      assert_nil(RemoteHost.validator.call('localhost'))
+      assert_nil(RemoteHost.validator.call(''))
     end
 
     # Content-Length のプリフライト (HEAD) も同じ allowlist を通ること (#4523)。

--- a/test/unit/lib/remote_host.rb
+++ b/test/unit/lib/remote_host.rb
@@ -102,6 +102,67 @@ module Mulukhiya
       assert_equal(['93.184.216.34', '2606:2800:220:1::1'], result)
     end
 
+    # ⚠ **allowed_address が返すのは真偽値でなく接続先の IP** (#4524)。
+    # 名前で検証して名前で接続すると、権威 DNS を握った相手が検証時だけ公開 IP を
+    # 返し、接続時に 127.0.0.1 を返せる（DNS リバインディング）。
+    def test_allowed_address_returns_resolved_address
+      assert_equal(
+        '93.184.216.34',
+        RemoteHost.allowed_address('example.com', resolver: stub_resolver(['93.184.216.34'])),
+      )
+    end
+
+    def test_allowed_address_returns_nil_for_rejected_host
+      assert_nil(RemoteHost.allowed_address('attacker.example', resolver: stub_resolver(['127.0.0.1'])))
+      assert_nil(RemoteHost.allowed_address('nx.example', resolver: stub_resolver([])))
+      assert_nil(RemoteHost.allowed_address('localhost', resolver: stub_resolver(['8.8.8.8'])))
+    end
+
+    # ⚠ IPv4 があれば IPv4 を採る。getaddresses は A と AAAA を混ぜて返すので、
+    # 素直に先頭を採ると IPv6 を掴んで到達しない／遅くなる。
+    def test_allowed_address_prefers_ipv4
+      mixed = ['2606:2800:220:1::1', '93.184.216.34']
+
+      assert_equal(
+        '93.184.216.34',
+        RemoteHost.allowed_address('example.com', resolver: stub_resolver(mixed)),
+      )
+    end
+
+    def test_allowed_address_falls_back_to_ipv6_only
+      assert_equal(
+        '2606:2800:220:1::1',
+        RemoteHost.allowed_address('example.com', resolver: stub_resolver(['2606:2800:220:1::1'])),
+      )
+    end
+
+    # DNS 障害は fail-closed（nil = 拒否）。真偽値へ倒して true にしない。
+    def test_allowed_address_is_nil_on_dns_error
+      raising = ->(_host) {raise Resolv::ResolvError, 'timeout'}
+
+      assert_nil(RemoteHost.allowed_address('attacker.example', resolver: raising))
+    end
+
+    # validator は ginseng-core の host_validator へ渡る callable。**真偽値でなく
+    # IP を返す**とあちらが接続先を固定する (pooza/ginseng-core#503)。
+    # ⚠ 実 DNS を引かせないよう、解決前に弾かれる入力で確かめる。
+    def test_validator_rejects_without_resolving
+      assert_nil(RemoteHost.validator.call('127.0.0.1'))
+      assert_nil(RemoteHost.validator.call('localhost'))
+      assert_nil(RemoteHost.validator.call(''))
+    end
+
+    # 解決できた場合にアドレスが返ること（resolver を差し替えて確認する）。
+    def test_validator_returns_address_when_allowed
+      original = RemoteHost.method(:resolve_addresses)
+      RemoteHost.define_singleton_method(:resolve_addresses) {|_host| ['93.184.216.34']}
+      begin
+        assert_equal('93.184.216.34', RemoteHost.validator.call('example.com'))
+      ensure
+        RemoteHost.define_singleton_method(:resolve_addresses, original)
+      end
+    end
+
     # validate! は allowlist 拒否を「判定不能」と区別するための入口 (#4535)。
     # 拒否したときに **実際に例外になる**ことを正で押さえる。
     def test_validate_raises_for_rejected_host


### PR DESCRIPTION
Closes #4524

## 何が開いていたか

`RemoteHost.public?` は**ホスト名を解決して真偽値だけを返し**、その後 HTTParty / Net::HTTP が**同じ名前をもう一度解決して接続**していた。権威 DNS を握った相手が

1. 検証時の解決 → 公開 IP を返す（allowlist 通過）
2. 接続時の解決 → 127.0.0.1 / 169.254.169.254 を返す

と応答を振り分ければ allowlist を素通りできる（DNS リバインディング / TOCTOU）。TTL 0 なら OS・resolver のキャッシュもほぼ効かない。**#4410（ホップごとの検証）と #4523（HEAD プリフライトの検証）を足しても、「名前で検証して名前で接続する」構造が残っている限り塞がらない。**

## 直し方（Issue の案 A = pinning）

- `RemoteHost.allowed_address` を新設。許可なら**接続に使う IP**、拒否なら `nil` を返す
- `RemoteHost.validator` はこれを返すようになった。ginseng-core 1.16.0 が **文字列を受けると `Net::HTTP#ipaddr=` で接続先を固定する**（pooza/ginseng-core#503 / PR #504）
- `public?` は `allowed_address(...).present?` になっただけで、外から見た挙動は同じ（`sw_subscription_contract` 等の呼び出し元は無変更）

⚠ **`ipaddr=` は接続先だけを差し替える。**`Host:` ヘッダと TLS の SNI・証明書検証はホスト名のままなので HTTPS の検証は壊れない。

⚠ **1 本でも内部アドレスを含むなら拒否する**のは従来どおり。「公開 IP のほうを選べばよい」ではない（混ぜて返してくるのがリバインディングそのもの）。

⚠ **IPv4 があれば IPv4 を採る。**`getaddresses` は A と AAAA を混ぜて返すので素直に先頭を採ると IPv6 を掴む。本番 4 台は IPv4 を正としており、IPv6 だと到達しないか Happy Eyeballs のフォールバックぶん遅くなる（#4464 で踏んだ `::1` の 305ms と同型）。

## トレードオフ

**アドレスを 1 本に固定するので、Net::HTTP の複数アドレスへのフォールバックは効かなくなる。** A レコードが複数あって先頭だけ落ちている相手は取得できない。allowlist の対象は管理者が設定した少数の URL（番組表の GAS・読み辞書）なので、この不便より「検証した先に繋ぐ」ほうを採った。

## テスト

`RemoteHost` に 6 本追加（アドレスを返す / 拒否は nil / IPv4 優先 / IPv6 のみ / DNS 障害は fail-closed / validator の戻り）。ginseng-core 側にも 7 本（PR #504）。

⚠ 既存の `test_remote_host_validator_rejects_private_address` は **拒否が `false` から `nil` に変わった**ので追従させた（呼び出し元はいずれも真偽で判定しているため falsy であればよい）。

- `bundle exec rake lint` 全緑
- `bundle exec rake test` **952 tests / 1290 assertions / 0 failures / 0 errors / 313 omissions**

🤖 Generated with [Claude Code](https://claude.com/claude-code)