### PR TITLE
security: 短縮 URL 展開の各ホップも検証した IP へ固定する (#4524 の Codex P1)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-core.git
-  revision: d026249c242894228aaa57fc1649f028c5bd03bb
+  revision: f03563fcb96d046bdb942e5799007827fb382d4d
   branch: main
   specs:
-    ginseng-core (1.16.0)
+    ginseng-core (1.16.1)
       activesupport (>= 7.0.7.1)
       addressable (>= 2.9.0)
       cgi (>= 0.4.2)

--- a/app/lib/mulukhiya/handler/shortened_url_handler.rb
+++ b/app/lib/mulukhiya/handler/shortened_url_handler.rb
@@ -35,17 +35,18 @@ module Mulukhiya
     # ブラインドだが、内部エンドポイントへの到達は成立する）。#4410 / #4523 の
     # 掃討の続き。
     def resolve_redirects(source)
-      return source unless permitted_host?(source)
+      return source unless address = permitted_address(source)
       dest = source.clone
       redirects = 0
       while redirects < MAX_REDIRECTS
-        next_uri, status = fetch_redirect(dest)
+        next_uri, status = fetch_redirect(dest, address)
         break unless next_uri
         break unless (status / 100) == 3
         # ⚠ GET を撃たないだけでは足りない。dest にしてしまうと、投稿本文が
         # 内部 URL へ書き換わったまま連合に流れる。
-        break unless permitted_host?(next_uri)
+        break unless next_address = permitted_address(next_uri)
         dest = next_uri
+        address = next_address
         redirects += 1
       end
       return dest
@@ -53,18 +54,24 @@ module Mulukhiya
 
     # 検証は「GET する直前の 1 回」で足りる。あるホップの next_uri は次の
     # ホップの src なので、ここで通したものだけが fetch_redirect へ渡る。
-    def permitted_host?(uri)
-      return true if RemoteHost.validator.call(uri.host.to_s)
+    #
+    # ⚠ **戻り値のアドレスを捨てない** (#4524)。名前で検証して名前で接続すると、
+    # 権威 DNS を握った相手が検証時だけ公開 IP を返し、GET のときに 127.0.0.1 を
+    # 返せる。ここは自前でホップを追う経路なので、pinning も自前で渡す必要がある。
+    def permitted_address(uri)
+      address = RemoteHost.validator.call(uri.host.to_s)
+      return address if address
       errors.push(
         class: Ginseng::GatewayError.to_s,
         message: "Rejected host '#{uri.host}'",
         url: uri.to_s,
       )
-      return false
+      return nil
     end
 
-    def fetch_redirect(src)
-      response = http.get(src, {follow_redirects: false})
+    def fetch_redirect(src, address)
+      options = Ginseng::PinnedAddressAdapter.pin({follow_redirects: false}, address)
+      response = http.get(src, options)
       return [nil, nil] unless location = response.headers['location']
       dest = normalize_location(src, location)
       return [nil, nil] unless dest&.host

--- a/test/unit/lib/shortened_url_ssrf.rb
+++ b/test/unit/lib/shortened_url_ssrf.rb
@@ -67,5 +67,44 @@ module Mulukhiya
       assert_equal(METADATA, resolve(METADATA).to_s)
       assert_not_requested(:get, METADATA)
     end
+
+    # ⚠ **検証で通したアドレスを捨てない** (#4524)。ここは自前でホップを追う経路
+    # なので、Ginseng::HTTP の host_validator は使えず pinning も自前で渡す。
+    # 捨てると GET のたびに名前を引き直し、権威 DNS を握った相手に
+    # 「検証は公開 IP・接続は 127.0.0.1」を返される（DNS リバインディング）。
+    def test_pins_validated_address_on_every_hop
+      addresses = {'t.co' => '203.0.113.1', 'www.example.jp' => '198.51.100.2'}
+      RemoteHost.validator = ->(host) {addresses[host]}
+      stub_request(:get, SHORTENED).to_return(status: 301, headers: {'Location' => PUBLIC_DEST})
+      stub_request(:get, PUBLIC_DEST).to_return(status: 200, body: 'ok')
+
+      assert_equal(['203.0.113.1', '198.51.100.2'], recorded_pins {resolve})
+    end
+
+    # 真偽値を返す validator でも壊れないこと（pinning しないだけ）。
+    def test_boolean_validator_still_resolves
+      stub_request(:get, SHORTENED).to_return(status: 301, headers: {'Location' => PUBLIC_DEST})
+      stub_request(:get, PUBLIC_DEST).to_return(status: 200, body: 'ok')
+
+      assert_equal(PUBLIC_DEST, resolve.to_s)
+    end
+
+    private
+
+    # PinnedAddressAdapter.pin に渡ったアドレスを順に記録する。
+    def recorded_pins
+      recorded = []
+      original = Ginseng::PinnedAddressAdapter.method(:pin)
+      Ginseng::PinnedAddressAdapter.define_singleton_method(:pin) do |options, address|
+        recorded.push(address)
+        original.call(options, address)
+      end
+      begin
+        yield
+      ensure
+        Ginseng::PinnedAddressAdapter.define_singleton_method(:pin, original)
+      end
+      return recorded
+    end
   end
 end


### PR DESCRIPTION
PR #4564 にマージ後届いた Codex の P1 が妥当だったので直す。あわせて ginseng-core 側の P1（pooza/ginseng-core#505）にも追随する。

## 1. 短縮 URL の展開が pinning を素通りしていた（mulukhiya 側 P1）

`ShortenedURLHandler#permitted_host?` は `RemoteHost.validator` を呼びながら**戻り値のアドレスを捨てて**おり、`fetch_redirect` の `http.get(src, follow_redirects: false)` は `host_validator` も渡していなかった。結果、**このハンドラだけ「名前で検証して名前で接続する」ままで、#4564 が塞いだはずのリバインディングがそのまま通る**。

⚠ ここは `Ginseng::HTTP` の `host_validator` に任せられない（あちらは追従まで肩代わりして最終レスポンスだけ返すので、短縮 URL の展開先が取れない）。**追うのがこちらである以上、pinning もこちらの責務**になる。

`permitted_host?` → `permitted_address` に変え、通したアドレスを `fetch_redirect` へ渡して `Ginseng::PinnedAddressAdapter.pin` で固定する。**ホップごとに付け替える**。

## 2. ginseng-core 1.16.1 への追随

- **プロキシ経由の pinning を fail-closed に**（pooza/ginseng-core#505）。`Net::HTTP#connect` は `proxy?` のとき `@ipaddr` を見ずプロキシへ繋ぎ、平文なら絶対 URI・HTTPS なら CONNECT でホスト名を渡すので、**名前を解決するのはプロキシ**になる。pinning が黙って無効化されるくらいなら落とす。⚠ `Net::HTTP.new` の proxy 引数は既定が `:ENV` なので、`http_proxy` を置いた環境では明示していなくても該当する
- **`pin` は String のときだけ効かせる。**真偽値を返す従来の validator の戻りを渡されても `ipaddr = true` を差さない

## テスト

- `test_pins_validated_address_on_every_hop` — 各ホップで **`203.0.113.1` → `198.51.100.2`** の順に pin が渡ること
- `test_boolean_validator_still_resolves` — 真偽値を返す validator でも展開が壊れないこと
- `bundle exec rake lint` 全緑 / `bundle exec rake test` **954 tests / 0 failures / 0 errors / 313 omissions**

🤖 Generated with [Claude Code](https://claude.com/claude-code)