### PR TITLE
並行性: 番組表の書き込みを Redis ロックで直列化する (#4534)

### DIFF
--- a/app/lib/mulukhiya/controller/api_controller.rb
+++ b/app/lib/mulukhiya/controller/api_controller.rb
@@ -935,7 +935,8 @@ module Mulukhiya
       return @renderer.to_s
     rescue => e
       if e.is_a?(Ginseng::ConflictError)
-        # 409 (auto_update? 有効時 or 重複キー) は期待動作のため Sentry alert 不要
+        # 409 (auto_update? 有効時 / 重複キー / 書き込みロック競合 #4534) は
+        # 期待動作のため Sentry alert 不要
         Logger.new.info(program_entry: {event: 'conflict', key: params[:key], message: e.message})
       else
         e.alert
@@ -962,7 +963,8 @@ module Mulukhiya
       return @renderer.to_s
     rescue => e
       if e.is_a?(Ginseng::ConflictError)
-        # 409 (auto_update? 有効時) は期待動作のため Sentry alert 不要
+        # 409 (auto_update? 有効時 / 書き込みロック競合 #4534) は期待動作のため
+        # Sentry alert 不要
         Logger.new.info(program_entry: {event: 'conflict', key: params[:key], message: e.message})
       else
         e.alert
@@ -981,7 +983,8 @@ module Mulukhiya
       return @renderer.to_s
     rescue => e
       if e.is_a?(Ginseng::ConflictError)
-        # 409 (auto_update? 有効時) は期待動作のため Sentry alert 不要
+        # 409 (auto_update? 有効時 / 書き込みロック競合 #4534) は期待動作のため
+        # Sentry alert 不要
         Logger.new.info(program_entry: {event: 'conflict', key: params[:key], message: e.message})
       else
         e.alert
@@ -1000,7 +1003,8 @@ module Mulukhiya
       return @renderer.to_s
     rescue => e
       if e.is_a?(Ginseng::ConflictError)
-        # 409 (auto_update? 有効時) は期待動作のため Sentry alert 不要
+        # 409 (auto_update? 有効時 / 書き込みロック競合 #4534) は期待動作のため
+        # Sentry alert 不要
         Logger.new.info(program_entry: {event: 'conflict', key: params[:key], message: e.message})
       else
         e.alert

--- a/app/lib/mulukhiya/program.rb
+++ b/app/lib/mulukhiya/program.rb
@@ -24,8 +24,13 @@ module Mulukhiya
       return config['/program/auto_update'] != false
     end
 
+    # 番組表全体の差し替え。auto_update の pull（ProgramUpdateWorker）と rake から
+    # 呼ばれる。エディタ経由の書き込みと同じロックで直列化する (#4534)。
+    #
+    # ⚠ 編集 4 メソッドはロックを取ったうえで persist を呼ぶ。ここを経由させると
+    # 自分自身のロックと衝突して ConflictError になる。
     def save(programs)
-      return fetcher.save(programs)
+      return lock.synchronize {persist(programs)}
     end
 
     def data
@@ -74,12 +79,14 @@ module Mulukhiya
       raise auto_update_conflict if auto_update?
       key = key.to_s
       raise Ginseng::ValidateError, 'キーが空です。' if key.empty?
-      programs = data
-      raise Ginseng::ConflictError, "キー '#{key}' は既に存在します。" if programs.key?(key)
-      attrs = attributes.transform_keys(&:to_s).reject {|_, v| blank_value?(v)}
-      programs[key] = attrs.to_h {|k, v| [k, normalize_value(k, v)]}
-      save(programs)
-      return programs[key]
+      return lock.synchronize do
+        programs = data
+        raise Ginseng::ConflictError, "キー '#{key}' は既に存在します。" if programs.key?(key)
+        attrs = attributes.transform_keys(&:to_s).reject {|_, v| blank_value?(v)}
+        programs[key] = attrs.to_h {|k, v| [k, normalize_value(k, v)]}
+        persist(programs)
+        next programs[key]
+      end
     end
 
     def generate_key(attributes = {})
@@ -100,47 +107,63 @@ module Mulukhiya
     def update_entry(key, attributes)
       raise auto_update_conflict if auto_update?
       key = key.to_s
-      programs = data
-      raise Ginseng::NotFoundError, "キー '#{key}' が見つかりません。" unless programs.key?(key)
-      attributes.each do |k, v|
-        if blank_value?(v)
-          programs[key].delete(k.to_s)
-        else
-          programs[key][k.to_s] = normalize_value(k.to_s, v)
+      return lock.synchronize do
+        programs = data
+        raise Ginseng::NotFoundError, "キー '#{key}' が見つかりません。" unless programs.key?(key)
+        attributes.each do |k, v|
+          if blank_value?(v)
+            programs[key].delete(k.to_s)
+          else
+            programs[key][k.to_s] = normalize_value(k.to_s, v)
+          end
         end
+        persist(programs)
+        next programs[key]
       end
-      save(programs)
-      return programs[key]
     end
 
     def delete_entry(key)
       raise auto_update_conflict if auto_update?
       key = key.to_s
-      programs = data
-      return nil unless programs.key?(key)
-      entry = programs.delete(key)
-      save(programs)
-      return entry
+      return lock.synchronize do
+        programs = data
+        next nil unless programs.key?(key)
+        entry = programs.delete(key)
+        persist(programs)
+        next entry
+      end
     end
 
+    # ⚠ Annict の GraphQL 呼び出し（/service/annict/timeout: 5 秒 × 最大 3 回）を
+    # **ロックの内側に置いている**のは意図的 (#4534)。話数の +1 と、その話数に
+    # 対応するサブタイトル・annict_episode_id の解決は 1 つの不可分な更新で、
+    # 分けると「解決している間に別の +1 が入り、古い話数のサブタイトルを
+    # 上書きする」という別の lost update を作る。
+    #
+    # 代わりに、Annict が詰まっている間は他の編集が最大十数秒 409 を受ける。
+    # ⚠ これは黙って巻き戻るより良い、という判断であって無害ではない。エディタは
+    # 409 をトーストで見せて再試行させる。TTL(30 秒) は Annict の最悪値に
+    # 余裕を足した値なので、ここを縮めるなら TTL も見直すこと。
     def increment_episode(key, annict: nil)
       raise auto_update_conflict if auto_update?
       key = key.to_s
-      programs = data
-      raise Ginseng::NotFoundError, "キー '#{key}' が見つかりません。" unless programs.key?(key)
-      entry = programs[key]
-      entry['episode'] = (entry['episode'] || 0).to_i + 1
-      entry['annict_episode_id'] = nil
-      advance_next_on(entry)
-      if annict && entry['annict_work_id']
-        next_ep = next_annict_episode(annict, entry['annict_work_id'], entry['episode'])
-        if next_ep
-          entry['annict_episode_id'] = next_ep['annictId']
-          entry['subtitle'] = next_ep['title'] if next_ep['title']
+      return lock.synchronize do
+        programs = data
+        raise Ginseng::NotFoundError, "キー '#{key}' が見つかりません。" unless programs.key?(key)
+        entry = programs[key]
+        entry['episode'] = (entry['episode'] || 0).to_i + 1
+        entry['annict_episode_id'] = nil
+        advance_next_on(entry)
+        if annict && entry['annict_work_id']
+          next_ep = next_annict_episode(annict, entry['annict_work_id'], entry['episode'])
+          if next_ep
+            entry['annict_episode_id'] = next_ep['annictId']
+            entry['subtitle'] = next_ep['title'] if next_ep['title']
+          end
         end
+        persist(programs)
+        next entry
       end
-      save(programs)
-      return entry
     end
 
     def count
@@ -169,6 +192,20 @@ module Mulukhiya
 
     def fetcher
       @fetcher ||= ProgramFetcher.new
+    end
+
+    # 書き込みの直列化ロック (#4534)。⚠ Program は Singleton なので、この
+    # インスタンスはプロセス内で共有される。ロックの実体は Redis 側なので
+    # プロセスをまたいでも効く。
+    def lock
+      @lock ||= ProgramLockStorage.new
+    end
+
+    # ロックを取らずに書き戻す。⚠ 直接呼ばないこと。呼び出し元はいずれも
+    # lock.synchronize の内側にいる前提で、外から呼ぶと #4534 で塞いだ
+    # lost update がそのまま復活する。
+    def persist(programs)
+      return fetcher.save(programs)
     end
 
     # nil または空白のみの文字列は「未設定」として扱い、保存対象から除く。

--- a/app/lib/mulukhiya/storage/program_lock_storage.rb
+++ b/app/lib/mulukhiya/storage/program_lock_storage.rb
@@ -1,0 +1,87 @@
+require 'securerandom'
+
+module Mulukhiya
+  # 番組表の書き込み直列化ロック (#4534)。
+  #
+  # `Program` の編集 4 メソッド（add_entry / update_entry / delete_entry /
+  # increment_episode）はいずれも「Redis から全体を読む → 破壊的に変更する →
+  # 全体を書き戻す」形で、排他が無いと lost update が起こる。特に痛いのは
+  # 「増分と別編集の交差」で、片方の save が削除したエントリを復活させ、
+  # トグルを巻き戻す。両方の HTTP は 200 を返すので気づけない。
+  #
+  # ⚠ さらに交差すると YAML と Redis キャッシュの内容がズレ、以降の read は
+  # Redis の旧スナップショットを返し続けるため、単発の lost update が
+  # **恒久的なロールバック**になる。
+  #
+  # ComposeTemplateLockStorage (#4457 / #4460) と同型だが、番組表は
+  # per-account でなくインスタンスに 1 つなので key も 1 つ。保持中の競合は
+  # 409 (ConflictError) で即返し、クライアントに再取得 → 再試行させる
+  # （番組表の編集は低頻度なのでキューイングしない）。Redis 障害時はロックを
+  # 諦めて実行を阻害しない (fail-open)。
+  class ProgramLockStorage < Redis
+    # TTL 切れで自然解放後に別リクエストが同一 key を acquire したケースで、遅延
+    # release が他者の新ロックを消さないよう compare-and-delete する。
+    RELEASE_SCRIPT = <<~LUA.freeze
+      if redis.call('GET', KEYS[1]) == ARGV[1] then
+        return redis.call('DEL', KEYS[1])
+      else
+        return 0
+      end
+    LUA
+
+    # ロック保持の TTL 秒。⚠ 「処理時間の見積り」ではなく「Ruby 側がストール
+    # してもロックを失わない余裕」で決める。RMW の途中に TTL が切れると、
+    # ロック無しで書き込む別リクエストが現れて lost update が黙って復活する。
+    #
+    # increment_episode は Annict の GraphQL を挟むが、その呼び出しは
+    # ロックの外へ出してある（Program#increment_episode 参照）ので、ロックを
+    # 持っている区間は Redis と YAML の書き込みだけ。他のロック（既定 30 秒）と
+    # 水準を揃える。
+    #
+    # 定数にして config ルックアップを持たない（存在しないパスは ConfigError を
+    # raise し、acquire の rescue に飲まれてロックが黙って無効化される footgun を
+    # 避けるため。rescue は Redis 障害のみを対象に保つ）。
+    LOCK_TTL_SECONDS = 30
+
+    # 番組表の書き込みを直列化して block を実行する。保持中は ConflictError(409)。
+    def synchronize
+      token = acquire
+      begin
+        return yield
+      ensure
+        release(token) if token
+      end
+    end
+
+    def ttl
+      return LOCK_TTL_SECONDS
+    end
+
+    private
+
+    # SET key value NX EX ttl で原子的に獲得。獲得できれば token を返す。
+    # 他者保有中は ConflictError。Redis 障害時は fail-open で nil を返す
+    # （nil の間はロック無しで実行され、release も走らない）。
+    def acquire
+      key = create_key(lock_key)
+      token = SecureRandom.uuid
+      return token if redis.call('SET', key, token, 'NX', 'EX', ttl) == 'OK'
+      raise Ginseng::ConflictError, '別の更新が進行中です。少し待って再試行してください。'
+    rescue Ginseng::ConflictError
+      raise
+    rescue => e
+      e.log
+      return nil
+    end
+
+    def release(token)
+      redis.call('EVAL', RELEASE_SCRIPT, 1, create_key(lock_key), token)
+    rescue => e
+      e.log
+    end
+
+    def lock_key
+      return 'program_lock'
+    end
+  end
+end

--- a/app/lib/mulukhiya/worker/program_update_worker.rb
+++ b/app/lib/mulukhiya/worker/program_update_worker.rb
@@ -13,6 +13,12 @@ module Mulukhiya
       return if disable?
       Program.instance.update
       log(programs: Program.instance.count)
+    rescue Ginseng::ConflictError => e
+      # 書き込みロック (#4534) の競合。every 1m なので取りこぼしても次の周回で
+      # 追いつく。⚠ alert には上げない。設定・運用の誤りではなく、直列化が
+      # 意図どおり働いた結果なので、上げると毎分の Sentry ノイズになる
+      # （#4542 と同型の「クライアント起因なのに alert」）。
+      log(skipped: 'locked', message: e.message)
     end
   end
 end

--- a/test/unit/lib/program_lock_storage.rb
+++ b/test/unit/lib/program_lock_storage.rb
@@ -1,0 +1,71 @@
+module Mulukhiya
+  class ProgramLockStorageTest < TestCase
+    def disable?
+      return true unless Redis.health[:status] == 'OK'
+      return super
+    end
+
+    def setup
+      return if disable?
+      @storage = ProgramLockStorage.new
+      @token = nil
+    end
+
+    def teardown
+      return if disable?
+      @storage.send(:release, @token) if @token
+    end
+
+    def test_ttl
+      return if disable?
+
+      assert_kind_of(Integer, @storage.ttl)
+      assert_operator(@storage.ttl, :>, 0)
+    end
+
+    # ⚠ 「実際にブロックする」正テスト。fail-open の rescue が効きすぎて（config
+    # ルックアップの ConfigError 等を飲んで）ロックが黙って無効化されるのは、
+    # 書けてしまう側からは気づけない。ここが唯一の検出点になる。
+    def test_acquire_blocks_duplicate
+      return if disable?
+
+      @token = @storage.send(:acquire)
+
+      assert(@token)
+      assert_raise(Ginseng::ConflictError) {@storage.send(:acquire)}
+    end
+
+    def test_release_allows_reacquire
+      return if disable?
+
+      @token = @storage.send(:acquire)
+      @storage.send(:release, @token)
+      @token = @storage.send(:acquire)
+
+      assert(@token)
+    end
+
+    # 例外で抜けてもロックを持ち逃げしない（持ち逃げすると TTL の 30 秒間、
+    # 番組表の編集が全部 409 になる）。
+    def test_synchronize_releases_on_error
+      return if disable?
+
+      assert_raise(RuntimeError) {@storage.synchronize {raise 'boom'}}
+      @token = @storage.send(:acquire)
+
+      assert(@token)
+    end
+
+    # 遅れて届いた release が、TTL 切れ後に他者が取り直したロックを消さないこと
+    # （compare-and-delete）。
+    def test_release_does_not_delete_others_lock
+      return if disable?
+      stale = @storage.send(:acquire)
+      @storage.send(:release, stale)
+      @token = @storage.send(:acquire)
+      @storage.send(:release, stale)
+
+      assert_raise(Ginseng::ConflictError) {@storage.send(:acquire)}
+    end
+  end
+end

--- a/test/unit/lib/program_write_lock.rb
+++ b/test/unit/lib/program_write_lock.rb
@@ -1,0 +1,82 @@
+module Mulukhiya
+  # 番組表の書き込み経路が ProgramLockStorage を**通っている**ことの検証 (#4534)。
+  #
+  # ⚠ ProgramTest には置かない。あちらの disable? は livecure?（= var/program.yaml
+  # が在るか /program/urls が設定されているか）で丸ごと倒れるので、番組表を持たない
+  # 環境ではケースごと omit され一度も走らない。ロックが黙って無効化される事故を
+  # 検出するためのテストが、その環境で走らないのでは意味がない
+  # （#4549 で absolute_uri をクラスメソッドへ出したのと同じ理由）。
+  #
+  # ⚠ ここでは書き込みを 1 つも成功させない。全ケースがロック獲得の時点で
+  # ConflictError になるため、var/program.yaml も Redis のキャッシュも触らずに済む。
+  # 書き込みが通ってしまう＝ロックが素通りしている、なのでその時点で赤になる。
+  class ProgramWriteLockTest < TestCase
+    LOCKED_MESSAGE = '別の更新が進行中です。少し待って再試行してください。'.freeze
+
+    def disable?
+      return true unless Redis.health[:status] == 'OK'
+      return super
+    end
+
+    def setup
+      return if disable?
+      @program = Program.instance
+      # auto_update が有効だと編集 4 メソッドはロックに到達する前に 409 を返す。
+      # ⚠ 同じ ConflictError なので、倒しておかないと**ロックが無くても緑になる**。
+      @original_auto_update = config['/program/auto_update']
+      config['/program/auto_update'] = false
+      @storage = ProgramLockStorage.new
+      @token = @storage.send(:acquire)
+    end
+
+    def teardown
+      return if disable?
+      @storage.send(:release, @token) if @token
+      config['/program/auto_update'] = @original_auto_update
+    end
+
+    def test_add_entry_blocked
+      return if disable?
+
+      assert_locked {@program.add_entry('test_lock_add', 'series' => 'A')}
+    end
+
+    def test_update_entry_blocked
+      return if disable?
+
+      assert_locked {@program.update_entry('test_lock_update', 'episode' => 9)}
+    end
+
+    def test_delete_entry_blocked
+      return if disable?
+
+      assert_locked {@program.delete_entry('test_lock_delete')}
+    end
+
+    def test_increment_episode_blocked
+      return if disable?
+
+      assert_locked {@program.increment_episode('test_lock_increment')}
+    end
+
+    # auto_update の pull（ProgramUpdateWorker）とエディタの編集は同じ YAML /
+    # Redis を触るので、save も同じロックで直列化する。別々にすると交差する。
+    def test_save_blocked
+      return if disable?
+
+      assert_locked {@program.save({})}
+    end
+
+    private
+
+    # ⚠ 例外クラスだけでなくメッセージまで見る。auto_update の 409 も
+    # ConflictError なので、クラスだけだと**別の理由で緑になった**のを見逃す。
+    def assert_locked(&)
+      assert(@token, 'ロックを獲得できていない（Redis 不通か fail-open）')
+      error = assert_raise(Ginseng::ConflictError, &)
+
+      assert_equal(LOCKED_MESSAGE, error.message)
+      assert_equal(409, error.status)
+    end
+  end
+end


### PR DESCRIPTION
Closes #4534

5.33.0 に残っていた最後の実装項目。5.32.0 では意図的に見送っていた（実況が使う書き込み経路そのものに手を入れる変更のため）。

## 何が壊れていたか

`Program` の書き込みは 4 メソッドとも「Redis から全体を読む → 破壊的に変更する → 全体を書き戻す」形で排他が無い。特に `increment_episode` は読みと書きの間に Annict の GraphQL（timeout 5 秒 × 最大 3 回）を挟むので窓が数秒〜十数秒あり、puma は 5 スレッド。

- 増分と別編集が交差すると、`save` が**削除したエントリを復活させ、有効トグルを巻き戻す**。両方の HTTP が 200 を返しトーストも出るので気づけない
- ⚠ 交差すると YAML と Redis キャッシュの内容がズレる。以降の read は Redis の旧スナップショットを返し続けるため、**単発の lost update が恒久的なロールバックになる**

## 変更

- `ProgramLockStorage` を新設。`ComposeTemplateLockStorage`（#4457 / #4460）と同型で、`SET NX EX` + compare-and-delete + fail-open、TTL は定数 30 秒。番組表はインスタンスに 1 つなので key も 1 つ
- 編集 4 メソッド（`add_entry` / `update_entry` / `delete_entry` / `increment_episode`）を `lock.synchronize` で囲み、内側では非ロックの private `persist` を呼ぶ（`save` 経由にすると自分のロックと衝突する）
- **`save` もロックに載せた。** auto_update の pull（`ProgramUpdateWorker`）とエディタの編集は同じ YAML / Redis を触るので、別ロックにすると交差する
- `ProgramUpdateWorker` は競合を **alert に上げず**次の周回へ送る（every 1m で追いつく。直列化が意図どおり働いた結果を毎分 Sentry に流すのは #4542 と同型）

## 判断したトレードオフ

⚠ **Annict の呼び出しはロックの内側に残した。** Issue には「RMW の外へ出して窓を 1ms 未満にする」案を書いていたが、話数の +1 と、その話数に対応するサブタイトル・`annict_episode_id` の解決は 1 つの不可分な更新で、分けると「解決している間に別の +1 が入り、**古い話数のサブタイトルで上書きする**」という別の lost update を作る。

代わりに、Annict が詰まっている間は他の編集が最大十数秒 409 を受ける。黙って巻き戻るより良い、という判断であって無害ではない。TTL(30 秒) は Annict の最悪値に余裕を足した値なので、ここを縮めるなら TTL も見直すこと。

なお二度押しは #4533 でクライアント側が塞いである。ここで塞がるのは並行リクエストと複数タブ・複数端末。

## テスト

⚠ **ロックの正テストを `ProgramTest` に置かなかった。** あちらの `disable?` は `livecure?`（`var/program.yaml` が在るか `/program/urls` が設定されているか）で丸ごと倒れるので、番組表を持たない環境ではケースごと omit され**一度も走らない**。ロックが黙って無効化される事故の検出点が、その環境で走らないのでは意味がない（#4549 で `absolute_uri` をクラスメソッドへ出したのと同じ理由）。

- `ProgramLockStorageTest` — ロック機構そのもの（獲得の排他・解放後の再獲得・例外時の解放・遅延 release が他者のロックを消さないこと）
- `ProgramWriteLockTest` — **書き込み 5 経路がロックを通っていること**。⚠ `auto_update` を false に倒したうえで、例外クラスだけでなくメッセージまで見る。auto_update の 409 も `ConflictError` なので、クラスだけだと**ロックが無くても緑になる**
  - ⚠ ここでは書き込みを 1 つも成功させない。全ケースがロック獲得の時点で倒れるので `var/program.yaml` も Redis も触らない

`rake test`: **964 tests / 1320 assertions / 0 failures / 0 errors / 313 omissions**。omission は据え置き（新規 10 件はすべて実際に走っている）ので CI の `omission_baseline` は変更不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)