### PR TITLE
fix: 本日マージ 2 件への Codex P2 を消化する (#4534 / #4567)

### DIFF
--- a/app/lib/mulukhiya/program.rb
+++ b/app/lib/mulukhiya/program.rb
@@ -27,10 +27,12 @@ module Mulukhiya
     # 番組表全体の差し替え。auto_update の pull（ProgramUpdateWorker）と rake から
     # 呼ばれる。エディタ経由の書き込みと同じロックで直列化する (#4534)。
     #
-    # ⚠ 編集 4 メソッドはロックを取ったうえで persist を呼ぶ。ここを経由させると
-    # 自分自身のロックと衝突して ConflictError になる。
+    # ⚠ 編集 4 メソッドは lock.synchronize の内側で fetcher.save を直接呼ぶ。
+    # ここを経由させると自分自身のロックと衝突して ConflictError になる。
+    # 逆に、ロックの外から fetcher.save を呼ぶと #4534 で塞いだ lost update が
+    # そのまま復活する。
     def save(programs)
-      return lock.synchronize {persist(programs)}
+      return lock.synchronize {fetcher.save(programs)}
     end
 
     def data
@@ -84,7 +86,7 @@ module Mulukhiya
         raise Ginseng::ConflictError, "キー '#{key}' は既に存在します。" if programs.key?(key)
         attrs = attributes.transform_keys(&:to_s).reject {|_, v| blank_value?(v)}
         programs[key] = attrs.to_h {|k, v| [k, normalize_value(k, v)]}
-        persist(programs)
+        fetcher.save(programs)
         next programs[key]
       end
     end
@@ -117,7 +119,7 @@ module Mulukhiya
             programs[key][k.to_s] = normalize_value(k.to_s, v)
           end
         end
-        persist(programs)
+        fetcher.save(programs)
         next programs[key]
       end
     end
@@ -129,24 +131,27 @@ module Mulukhiya
         programs = data
         next nil unless programs.key?(key)
         entry = programs.delete(key)
-        persist(programs)
+        fetcher.save(programs)
         next entry
       end
     end
 
-    # ⚠ Annict の GraphQL 呼び出し（/service/annict/timeout: 5 秒 × 最大 3 回）を
-    # **ロックの内側に置いている**のは意図的 (#4534)。話数の +1 と、その話数に
-    # 対応するサブタイトル・annict_episode_id の解決は 1 つの不可分な更新で、
-    # 分けると「解決している間に別の +1 が入り、古い話数のサブタイトルを
-    # 上書きする」という別の lost update を作る。
+    # ⚠ Annict の GraphQL 呼び出しは**ロックの外**で先に済ませる (#4534)。
     #
-    # 代わりに、Annict が詰まっている間は他の編集が最大十数秒 409 を受ける。
-    # ⚠ これは黙って巻き戻るより良い、という判断であって無害ではない。エディタは
-    # 409 をトーストで見せて再試行させる。TTL(30 秒) は Annict の最悪値に
-    # 余裕を足した値なので、ここを縮めるなら TTL も見直すこと。
+    # 当初はロックの内側に置いていたが、それだと **TTL を超えうる**（open と read で
+    # 各 5 秒 × 最大 3 回 + リトライ待ち ≧ 30 秒）。ロックが先に失効すると別の編集が
+    # 獲得でき、そこへ元のリクエストが書き戻して**塞いだはずの lost update が
+    # そのまま戻る**（PR #4569 の Codex P2）。TTL を伸ばす手もあるが、プロセスが
+    # 死んだときに編集が止まる時間もそのまま伸びるので採らない。
+    #
+    # ⚠ 代わりに「引いた時点の話数」を持ち回り、**ロックの中で話数が一致したときだけ
+    # 載せる**。一致しない = 待っている間に別の +1 が入った、ということなので、
+    # 古い話数のサブタイトルで上書きしてはいけない。載せなかった場合は
+    # annict_episode_id が nil のまま（Annict が引けなかったときと同じ状態）になる。
     def increment_episode(key, annict: nil)
       raise auto_update_conflict if auto_update?
       key = key.to_s
+      next_episode, next_ep = prepare_annict_increment(key, annict)
       return lock.synchronize do
         programs = data
         raise Ginseng::NotFoundError, "キー '#{key}' が見つかりません。" unless programs.key?(key)
@@ -154,14 +159,11 @@ module Mulukhiya
         entry['episode'] = (entry['episode'] || 0).to_i + 1
         entry['annict_episode_id'] = nil
         advance_next_on(entry)
-        if annict && entry['annict_work_id']
-          next_ep = next_annict_episode(annict, entry['annict_work_id'], entry['episode'])
-          if next_ep
-            entry['annict_episode_id'] = next_ep['annictId']
-            entry['subtitle'] = next_ep['title'] if next_ep['title']
-          end
+        if annict_applicable?(next_ep, next_episode, entry['episode'])
+          entry['annict_episode_id'] = next_ep['annictId']
+          entry['subtitle'] = next_ep['title'] if next_ep['title']
         end
-        persist(programs)
+        fetcher.save(programs)
         next entry
       end
     end
@@ -199,13 +201,6 @@ module Mulukhiya
     # プロセスをまたいでも効く。
     def lock
       @lock ||= ProgramLockStorage.new
-    end
-
-    # ロックを取らずに書き戻す。⚠ 直接呼ばないこと。呼び出し元はいずれも
-    # lock.synchronize の内側にいる前提で、外から呼ぶと #4534 で塞いだ
-    # lost update がそのまま復活する。
-    def persist(programs)
-      return fetcher.save(programs)
     end
 
     # nil または空白のみの文字列は「未設定」として扱い、保存対象から除く。
@@ -299,6 +294,30 @@ module Mulukhiya
     # 拒否し「auto_update を切ってから編集する」運用に倒す (#4272)。
     def auto_update_conflict
       return Ginseng::ConflictError.new('自動更新が有効のため、編集できません。')
+    end
+
+    # ロックを取る前に Annict を引く。annict が無い / 作品 ID が紐づいていない
+    # エントリではネットワークへ出ない。
+    #
+    # ⚠ ここでの読みは Annict を先に引くためだけのもの。**存在チェックの正本は
+    # ロックの中**（外で raise すると、ロック競合より先に 404 を返してしまう）。
+    def prepare_annict_increment(key, annict)
+      current = data[key] || {}
+      episode = (current['episode'] || 0).to_i + 1
+      return [episode, nil] unless annict && current['annict_work_id']
+      return [episode, next_annict_episode(annict, current['annict_work_id'], episode)]
+    end
+
+    # ロックの外で引いた Annict の結果を、ロックの中で確定した話数に載せてよいか。
+    #
+    # ⚠ 待っている間に別の +1 が入っていたら**載せない**。載せると古い話数の
+    # サブタイトル・annict_episode_id で新しい話数を上書きしてしまう（#4534 で
+    # 塞いだ lost update と同じ壊れ方を、別経路で作ることになる）。
+    # 載せなかった場合は annict_episode_id が nil のまま = Annict を引けなかった
+    # ときと同じ状態になる。
+    def annict_applicable?(next_ep, expected_episode, actual_episode)
+      return false unless next_ep
+      return expected_episode == actual_episode
     end
 
     def next_annict_episode(annict, work_id, episode_number)

--- a/app/lib/mulukhiya/storage/program_lock_storage.rb
+++ b/app/lib/mulukhiya/storage/program_lock_storage.rb
@@ -33,10 +33,12 @@ module Mulukhiya
     # してもロックを失わない余裕」で決める。RMW の途中に TTL が切れると、
     # ロック無しで書き込む別リクエストが現れて lost update が黙って復活する。
     #
-    # increment_episode は Annict の GraphQL を挟むが、その呼び出しは
-    # ロックの外へ出してある（Program#increment_episode 参照）ので、ロックを
-    # 持っている区間は Redis と YAML の書き込みだけ。他のロック（既定 30 秒）と
-    # 水準を揃える。
+    # ⚠ **ロックを持っている区間にネットワーク I/O を入れないこと。**
+    # increment_episode の Annict 呼び出し（open / read で各 5 秒 × 最大 3 回 +
+    # リトライ待ち）は素でこの TTL を超えうる。超えると別の編集がロックを獲得でき、
+    # そこへ元のリクエストが書き戻して lost update が復活する（PR #4569 の Codex P2）。
+    # 現状 Annict はロックの外で先に解決してあるので、区間は Redis と YAML の
+    # 書き込みだけ。他のロック（既定 30 秒）と水準を揃える。
     #
     # 定数にして config ルックアップを持たない（存在しないパスは ConfigError を
     # raise し、acquire の rescue に飲まれてロックが黙って無効化される footgun を

--- a/test/unit/lib/program_annict_staleness.rb
+++ b/test/unit/lib/program_annict_staleness.rb
@@ -1,0 +1,38 @@
+module Mulukhiya
+  # ロックの外で引いた Annict の結果を、ロックの中の話数に載せてよいかの判定
+  # （#4534 / PR #4569 の Codex P2）。
+  #
+  # ⚠ ProgramTest へは足さない。あちらは livecure? が false の環境で丸ごと omit
+  # されるため、番組表を持たないサーバーでは一度も検査されない
+  # （[ProgramScalarCoercionTest](program_scalar_coercion.rb) と同じ理由）。
+  # ここは I/O を持たない純関数だけを見るので、どの環境でも必ず走る。
+  class ProgramAnnictStalenessTest < TestCase
+    NEXT_EP = {'annictId' => 123, 'title' => 'サブタイトル'}.freeze
+
+    def applicable?(next_ep, expected, actual)
+      return Program.instance.send(:annict_applicable?, next_ep, expected, actual)
+    end
+
+    # 素直な系列: 引いた話数と、ロックの中で確定した話数が一致する。
+    def test_applies_when_episode_matches
+      assert(applicable?(NEXT_EP, 5, 5))
+    end
+
+    # ⚠ 本丸。Annict を待っている間に別の +1 が入ると、ロックの中の話数が先へ
+    # 進む。ここで載せてしまうと**古い話数のサブタイトルで新しい話数を上書き**
+    # する（#4534 で塞いだのと同じ壊れ方）。
+    def test_rejects_when_another_increment_slipped_in
+      assert_false(applicable?(NEXT_EP, 5, 6))
+    end
+
+    # 巻き戻った場合も同様に載せない（手編集で話数を戻した等）。
+    def test_rejects_when_episode_went_backwards
+      assert_false(applicable?(NEXT_EP, 5, 4))
+    end
+
+    # Annict を引けなかった / 対象作品が紐づいていない。
+    def test_rejects_without_episode
+      assert_false(applicable?(nil, 5, 5))
+    end
+  end
+end

--- a/test/unit/model/webhook.rb
+++ b/test/unit/model/webhook.rb
@@ -112,7 +112,12 @@ module Mulukhiya
     #
     # ⚠ `statusCode == 404` だけでは足りない (PR #4557 の Codex P2)。ルートには届いた
     # うえで参照先が無い 404 も同じ形を取りうるので、**ルートが無いこと**まで確かめる。
-    # `error` の文字列と、message が叩いた path そのものを名指していることを見る。
+    #
+    # ⚠ path を含むかどうかでも足りない (PR #4568 の Codex P2)。ハンドラが同じ包絡で
+    # `Webhook /mulukhiya/webhook/<digest> not found` を返せば部分一致してしまい、
+    # **ルートは在るのに omit する**。Fastify の route-miss の文面ごと突き合わせる。
+    # Webhook#command は必ず POST なのでメソッド名も固定でよい。
+    #
     # ここが将来 Fastify の文言変更で外れた場合は omit されず assert で赤くなる
     # （実退行を飲むより、検証条件のズレに気づけるほうを採る）。
     def endpoint_missing?(body, path)
@@ -121,7 +126,7 @@ module Mulukhiya
       return false unless parsed.is_a?(Hash)
       return false unless parsed['statusCode'] == 404
       return false unless parsed['error'] == 'Not Found'
-      return parsed['message'].to_s.include?(path)
+      return parsed['message'].to_s == "Route POST:#{path} not found"
     end
   end
 end


### PR DESCRIPTION
本日マージした PR #4569 / #4568 に、マージ直後 Codex から P2 が 1 件ずつ届いた。どちらも**塞いだつもりで開いていた**型なので同セッション中に消化する。

## 1. Annict の呼び出しがロックの TTL を超えうる（#4534 / PR #4569 の P2）

PR #4569 では「話数の +1 とサブタイトルの解決は不可分」という理由で Annict の GraphQL を**ロックの内側**に置いた。これが誤り。

- Annict は open と read で各 5 秒 × 最大 3 回 + リトライ待ち。**素で 30 秒の TTL を超えうる**
- 超えるとロックが先に失効し、別の編集が獲得できる。そこへ元のリクエストが書き戻して、**#4534 で塞いだはずの lost update がそのまま戻る**
- TTL を伸ばす手もあるが、**プロセスが死んだときに編集が止まる時間もそのまま伸びる**ので採らない

Annict をロックの外で先に引き、**「引いた時点の話数」を持ち回ってロックの中で一致を確かめる**形にした。一致しない = 待っている間に別の +1 が入った、ということなので古い話数のサブタイトルを載せない（載せなければ `annict_episode_id` は nil のまま = Annict を引けなかったときと同じ状態）。

⚠ **存在チェックの正本はロックの中に残した。**外で `NotFoundError` を上げると、**ロック競合より先に 404 を返す**ようになり `ProgramWriteLockTest` が実際に落ちた。ロックの外の読みは Annict を引くためだけのものと位置づけている。

判定は純関数 `annict_applicable?` に出し、`ProgramAnnictStalenessTest` で検証する。⚠ **`ProgramTest` には置かない**（livecure? が false の環境で丸ごと omit される。`ProgramScalarCoercionTest` と同じ理由）。

## 2. message の部分一致では route-not-found を特定できない（#4567 / PR #4568 の P2）

ハンドラが同じ Fastify 包絡で `Webhook /mulukhiya/webhook/<digest> not found` を返すと path を含むので一致してしまい、**ルートは在るのに omit する**。#4567 で塞ごうとした穴が別の形で残っていた。route-miss の文面ごと（`Route POST:<path> not found`）突き合わせる。`Webhook#command` は必ず POST なのでメソッド名も固定でよい。

## 付随

`persist` を潰して `fetcher.save` の直接呼び出しにした。⚠ **これは `Metrics/ClassLength` の上限 200 行に合わせるための削りであって設計判断ではない。**`Program` は現在 200/200 ちょうどで、次に数行足すと機械的に赤くなる。編集系の分離を #4570 として起票した。

## テスト

`rake test`: **968 tests / 1324 assertions / 0 failures / 0 errors / 313 omissions**。omission は据え置き（新規 4 件も実際に走っている）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)