### PR TITLE
fix: Annict の照合に作品 ID を加える (#4534 / PR #4571 の Codex P2)

### DIFF
--- a/app/lib/mulukhiya/program.rb
+++ b/app/lib/mulukhiya/program.rb
@@ -1,7 +1,12 @@
 module Mulukhiya
   # 番組表データの参照・編集 (ドメインロジック) を担う。HTTP 取得・YAML/Redis
   # 永続化といった I/O は ProgramFetcher へ委譲する (#4347)。
-  class Program
+  #
+  # ⚠ ClassLength の上限（200 行）を 1 行超えている。**参照系と編集系という 2 つの
+  # 関心を抱えているのが本体**で、編集系を別クラスへ出すのが正しい直し方なので
+  # #4570 として起票してある。⚠ **無関係なメソッドを詰めて行数を捻出しない**
+  # （#4534 で persist を潰したのがそれで、設計判断ではなく上限合わせだった）。
+  class Program # rubocop:disable Metrics/ClassLength
     include Singleton
     include Package
 
@@ -144,14 +149,14 @@ module Mulukhiya
     # そのまま戻る**（PR #4569 の Codex P2）。TTL を伸ばす手もあるが、プロセスが
     # 死んだときに編集が止まる時間もそのまま伸びるので採らない。
     #
-    # ⚠ 代わりに「引いた時点の話数」を持ち回り、**ロックの中で話数が一致したときだけ
-    # 載せる**。一致しない = 待っている間に別の +1 が入った、ということなので、
-    # 古い話数のサブタイトルで上書きしてはいけない。載せなかった場合は
-    # annict_episode_id が nil のまま（Annict が引けなかったときと同じ状態）になる。
+    # ⚠ 代わりに「引いた時点の話数と作品 ID」を持ち回り、**ロックの中で両方とも
+    # 一致したときだけ載せる**。一致しない = 待っている間に別の +1 が入ったか作品を
+    # 差し替えられた、ということなので、古い内容で上書きしてはいけない。載せなかった
+    # 場合は annict_episode_id が nil のまま（Annict が引けなかったときと同じ状態）。
     def increment_episode(key, annict: nil)
       raise auto_update_conflict if auto_update?
       key = key.to_s
-      next_episode, next_ep = prepare_annict_increment(key, annict)
+      prepared = prepare_annict_increment(key, annict)
       return lock.synchronize do
         programs = data
         raise Ginseng::NotFoundError, "キー '#{key}' が見つかりません。" unless programs.key?(key)
@@ -159,9 +164,9 @@ module Mulukhiya
         entry['episode'] = (entry['episode'] || 0).to_i + 1
         entry['annict_episode_id'] = nil
         advance_next_on(entry)
-        if annict_applicable?(next_ep, next_episode, entry['episode'])
-          entry['annict_episode_id'] = next_ep['annictId']
-          entry['subtitle'] = next_ep['title'] if next_ep['title']
+        if annict_applicable?(prepared, entry)
+          entry['annict_episode_id'] = prepared[:episode_data]['annictId']
+          entry['subtitle'] = prepared[:episode_data]['title'] if prepared[:episode_data]['title']
         end
         fetcher.save(programs)
         next entry
@@ -304,8 +309,9 @@ module Mulukhiya
     def prepare_annict_increment(key, annict)
       current = data[key] || {}
       episode = (current['episode'] || 0).to_i + 1
-      return [episode, nil] unless annict && current['annict_work_id']
-      return [episode, next_annict_episode(annict, current['annict_work_id'], episode)]
+      work_id = current['annict_work_id']
+      return {episode:, work_id:} unless annict && work_id
+      return {episode:, work_id:, episode_data: next_annict_episode(annict, work_id, episode)}
     end
 
     # ロックの外で引いた Annict の結果を、ロックの中で確定した話数に載せてよいか。
@@ -313,11 +319,17 @@ module Mulukhiya
     # ⚠ 待っている間に別の +1 が入っていたら**載せない**。載せると古い話数の
     # サブタイトル・annict_episode_id で新しい話数を上書きしてしまう（#4534 で
     # 塞いだ lost update と同じ壊れ方を、別経路で作ることになる）。
+    #
+    # ⚠ **話数だけでなく作品 ID も見る** (PR #4571 の Codex P2)。
+    # ProgramEntryUpdateContract は annict_work_id の変更を許しているので、
+    # 待っている間に作品を差し替えられると「話数は同じだが別作品」になる。
+    # そこへ旧作品のサブタイトルを載せてはいけない。
+    #
     # 載せなかった場合は annict_episode_id が nil のまま = Annict を引けなかった
     # ときと同じ状態になる。
-    def annict_applicable?(next_ep, expected_episode, actual_episode)
-      return false unless next_ep
-      return expected_episode == actual_episode
+    def annict_applicable?(prepared, entry)
+      return false unless prepared[:episode_data]
+      return prepared.values_at(:episode, :work_id) == entry.values_at('episode', 'annict_work_id')
     end
 
     def next_annict_episode(annict, work_id, episode_number)

--- a/test/unit/lib/program_annict_staleness.rb
+++ b/test/unit/lib/program_annict_staleness.rb
@@ -1,38 +1,60 @@
 module Mulukhiya
-  # ロックの外で引いた Annict の結果を、ロックの中の話数に載せてよいかの判定
-  # （#4534 / PR #4569 の Codex P2）。
+  # ロックの外で引いた Annict の結果を、ロックの中のエントリに載せてよいかの判定
+  # （#4534 / PR #4569・#4571 の Codex P2）。
   #
   # ⚠ ProgramTest へは足さない。あちらは livecure? が false の環境で丸ごと omit
   # されるため、番組表を持たないサーバーでは一度も検査されない
   # （[ProgramScalarCoercionTest](program_scalar_coercion.rb) と同じ理由）。
   # ここは I/O を持たない純関数だけを見るので、どの環境でも必ず走る。
   class ProgramAnnictStalenessTest < TestCase
-    NEXT_EP = {'annictId' => 123, 'title' => 'サブタイトル'}.freeze
+    EPISODE_DATA = {'annictId' => 123, 'title' => 'サブタイトル'}.freeze
 
-    def applicable?(next_ep, expected, actual)
-      return Program.instance.send(:annict_applicable?, next_ep, expected, actual)
+    # ロックを取る前に引いた内容（話数・作品 ID・Annict の応答）。
+    def prepared(episode: 5, work_id: 42, episode_data: EPISODE_DATA)
+      return {episode:, work_id:, episode_data:}
     end
 
-    # 素直な系列: 引いた話数と、ロックの中で確定した話数が一致する。
-    def test_applies_when_episode_matches
-      assert(applicable?(NEXT_EP, 5, 5))
+    # ロックの中で確定したエントリ。
+    def entry(episode: 5, work_id: 42)
+      return {'episode' => episode, 'annict_work_id' => work_id}
     end
 
-    # ⚠ 本丸。Annict を待っている間に別の +1 が入ると、ロックの中の話数が先へ
-    # 進む。ここで載せてしまうと**古い話数のサブタイトルで新しい話数を上書き**
-    # する（#4534 で塞いだのと同じ壊れ方）。
+    def applicable?(prepared, entry)
+      return Program.instance.send(:annict_applicable?, prepared, entry)
+    end
+
+    # 素直な系列: 引いた時点と、ロックの中で確定した内容が一致する。
+    def test_applies_when_episode_and_work_match
+      assert(applicable?(prepared, entry))
+    end
+
+    # ⚠ 本丸その 1。Annict を待っている間に別の +1 が入ると、ロックの中の話数が
+    # 先へ進む。ここで載せると**古い話数のサブタイトルで新しい話数を上書き**する
+    # （#4534 で塞いだのと同じ壊れ方）。
     def test_rejects_when_another_increment_slipped_in
-      assert_false(applicable?(NEXT_EP, 5, 6))
+      assert_false(applicable?(prepared, entry(episode: 6)))
     end
 
     # 巻き戻った場合も同様に載せない（手編集で話数を戻した等）。
     def test_rejects_when_episode_went_backwards
-      assert_false(applicable?(NEXT_EP, 5, 4))
+      assert_false(applicable?(prepared, entry(episode: 4)))
+    end
+
+    # ⚠ 本丸その 2。ProgramEntryUpdateContract は annict_work_id の変更を許して
+    # いるので、待っている間に作品を差し替えられると**話数は同じだが別作品**に
+    # なる。そこへ旧作品のサブタイトルを載せてはいけない (PR #4571 の Codex P2)。
+    def test_rejects_when_work_id_was_swapped
+      assert_false(applicable?(prepared, entry(work_id: 43)))
+    end
+
+    # 作品 ID を外された場合も同様。
+    def test_rejects_when_work_id_was_cleared
+      assert_false(applicable?(prepared, entry(work_id: nil)))
     end
 
     # Annict を引けなかった / 対象作品が紐づいていない。
-    def test_rejects_without_episode
-      assert_false(applicable?(nil, 5, 5))
+    def test_rejects_without_episode_data
+      assert_false(applicable?(prepared(episode_data: nil), entry))
     end
   end
 end


### PR DESCRIPTION
PR #4571 のマージ直後に届いた Codex P2。**3 連続で「塞いだつもりで開いていた」**が出た系列の 3 本目。

## 穴

PR #4571 で Annict の呼び出しをロックの外へ出し、「引いた時点の話数」がロックの中で一致したときだけ載せる形にした。しかし**作品 ID を見ていなかった**。

`ProgramEntryUpdateContract` は `annict_work_id` の変更を許しているので、ロックの外で Annict を引いている数秒の間に別タブで作品を差し替えられると、**話数は同じまま**なので照合を通り、**旧作品の `annict_episode_id` とサブタイトルが新しい作品に載る**。

## 対処

引いた時点の**話数と作品 ID の両方**を持ち回り、ロックの中で両方一致したときだけ載せる。

```ruby
def annict_applicable?(prepared, entry)
  return false unless prepared[:episode_data]
  return prepared.values_at(:episode, :work_id) == entry.values_at('episode', 'annict_work_id')
end
```

`ProgramAnnictStalenessTest` に「作品が差し替わった」「作品 ID を外された」の 2 ケースを追加（純関数なので livecure? に依存せずどこでも走る）。

## ClassLength について

`Program` が 201/200 になった。⚠ **無関係なメソッドを詰めて行数を捻出するのは #4534 で一度やって「設計判断ではなく上限合わせ」だと分かった**ので、今回は繰り返さず inline disable で明示する。正しい直し方（参照系と編集系の分離）は #4570。

## テスト

`rake test`: **970 tests / 1326 assertions / 0 failures / 0 errors / 313 omissions**。omission は据え置き。

🤖 Generated with [Claude Code](https://claude.com/claude-code)