### PR TITLE
security: 内部アドレス判定に予約レンジを足し、ゼロアドレスを塞ぐ (#4574)

### DIFF
--- a/app/lib/mulukhiya/remote_host.rb
+++ b/app/lib/mulukhiya/remote_host.rb
@@ -32,7 +32,8 @@ module Mulukhiya
       '224.0.0.0/4',        # multicast
       '240.0.0.0/4',        # reserved (255.255.255.255 を含む)
       '::/128',             # unspecified
-      '64:ff9b::/96',       # NAT64 (RFC 6146)
+      '64:ff9b::/96',       # NAT64 well-known prefix (RFC 6146)
+      '64:ff9b:1::/48',     # NAT64 local-use prefix (RFC 8215)
       'ff00::/8',           # IPv6 multicast
     ].map {|v| IPAddr.new(v)}.freeze
 

--- a/app/lib/mulukhiya/remote_host.rb
+++ b/app/lib/mulukhiya/remote_host.rb
@@ -15,6 +15,27 @@ module Mulukhiya
       Errno::ETIMEDOUT,
     ].freeze
 
+    # IPAddr の private? / loopback? / link_local? が拾わない予約・特殊用途レンジ (#4574)。
+    #
+    # ⚠ **`0.0.0.0` は 3 述語のいずれも false を返す**のに、Linux / BSD の connect(2) は
+    # ローカルホスト宛として扱う。pinning は検証したアドレスへ接続を固定するので、
+    # ここを開けたままだと「公開ホスト名なのに localhost へ繋ぐ」経路が決定的に通る。
+    # `::`（IPv6 未指定アドレス）も同じ。
+    #
+    # ⚠ **CGNAT / NAT64 は本番 4 台では実害に届かない**が、Linode の一部リージョンや
+    # 将来の CT 群では内部へ届きうるので同じ表で塞いでおく。
+    RESERVED_RANGES = [
+      '0.0.0.0/8',          # this-network (0.0.0.0 を含む)
+      '100.64.0.0/10',      # CGNAT (RFC 6598)
+      '192.0.0.0/24',       # IETF protocol assignments
+      '198.18.0.0/15',      # benchmarking (RFC 2544)
+      '224.0.0.0/4',        # multicast
+      '240.0.0.0/4',        # reserved (255.255.255.255 を含む)
+      '::/128',             # unspecified
+      '64:ff9b::/96',       # NAT64 (RFC 6146)
+      'ff00::/8',           # IPv6 multicast
+    ].map {|v| IPAddr.new(v)}.freeze
+
     def self.public?(host, resolver: method(:resolve_addresses))
       return allowed_address(host, resolver:).present?
     end
@@ -52,7 +73,12 @@ module Mulukhiya
 
     def self.internal_address?(ip)
       addr = IPAddr.new(ip)
-      return addr.private? || addr.loopback? || addr.link_local?
+      # ⚠ IPv4-mapped / IPv4-compatible は IPv6 として扱われるので、先に素の IPv4 へ
+      # 畳んでからレンジと突き合わせる。畳まないと ::ffff:0.0.0.0 が
+      # RESERVED_RANGES の 0.0.0.0/8 と family 違いで一致しない (#4574)。
+      addr = addr.native if addr.ipv4_mapped? || addr.ipv4_compat?
+      return true if addr.private? || addr.loopback? || addr.link_local?
+      return RESERVED_RANGES.any? {|range| range.include?(addr)}
     end
 
     # ⚠ IPv4 があれば IPv4 を採る。getaddresses は A と AAAA を混ぜて返すので、

--- a/test/unit/lib/remote_host.rb
+++ b/test/unit/lib/remote_host.rb
@@ -42,6 +42,36 @@ module Mulukhiya
       assert_false(RemoteHost.public?('attacker.example', resolver: stub_resolver(mixed)))
     end
 
+    # ⚠ ゼロアドレスは private? / loopback? / link_local? のいずれも false を返すのに、
+    # connect(2) はローカルホスト宛として扱う。pinning が効いているぶん確実に届く (#4574)。
+    def test_returns_false_when_resolver_returns_zero_address
+      ['0.0.0.0', '::', '::ffff:0.0.0.0', '0.1.2.3'].each do |address|
+        assert_false(
+          RemoteHost.public?('attacker.example', resolver: stub_resolver([address])),
+          "#{address} を許可してはいけない",
+        )
+      end
+    end
+
+    def test_returns_false_when_resolver_returns_reserved_range
+      ['100.64.0.1', '192.0.0.1', '198.18.0.1', '224.0.0.1', '255.255.255.255', '64:ff9b::7f00:1'].each do |address|
+        assert_false(
+          RemoteHost.public?('attacker.example', resolver: stub_resolver([address])),
+          "#{address} を許可してはいけない",
+        )
+      end
+    end
+
+    # 予約レンジを足したせいで正当な公開アドレスまで落ちていないこと。
+    def test_returns_true_for_public_addresses_outside_reserved_ranges
+      ['8.8.8.8', '93.184.216.34', '2606:2800:220:1:248:1893:25c8:1946'].each do |address|
+        assert_true(
+          RemoteHost.public?('example.com', resolver: stub_resolver([address])),
+          "#{address} は許可されるべき",
+        )
+      end
+    end
+
     def test_returns_false_when_resolver_returns_empty
       assert_false(RemoteHost.public?('nx.example', resolver: stub_resolver([])))
     end

--- a/test/unit/lib/remote_host.rb
+++ b/test/unit/lib/remote_host.rb
@@ -54,7 +54,14 @@ module Mulukhiya
     end
 
     def test_returns_false_when_resolver_returns_reserved_range
-      ['100.64.0.1', '192.0.0.1', '198.18.0.1', '224.0.0.1', '255.255.255.255', '64:ff9b::7f00:1'].each do |address|
+      # ⚠ NAT64 は well-known (RFC 6146) と local-use (RFC 8215) で別レンジ。
+      # 前者だけ塞ぐと、local-use を使う環境で内部 IPv4 へ変換されて抜ける。
+      addresses = [
+        '100.64.0.1', '192.0.0.1', '198.18.0.1', '224.0.0.1', '255.255.255.255',
+        '64:ff9b::7f00:1', '64:ff9b:1::7f00:1'
+      ]
+
+      addresses.each do |address|
         assert_false(
           RemoteHost.public?('attacker.example', resolver: stub_resolver([address])),
           "#{address} を許可してはいけない",


### PR DESCRIPTION
Fixes #4574

5.33.0 リリース前 5 観点レビューで、**セキュリティ観点と観測性観点が独立に検出**した赤。

## 何を直したか

`RemoteHost.internal_address?` は `private? || loopback? || link_local?` の 3 述語しか見ておらず、**`0.0.0.0` と `::` はいずれも false** を返していた。Linux / BSD の `connect(2)` はこれらをローカルホスト宛として扱うので、権威 DNS を握った相手が `A 0.0.0.0` を返すだけで内部へ届く。

**実測で到達を確認済み:**

```
pin=0.0.0.0    => 200 "INTERNAL-DATA"     # 127.0.0.1 の待受に到達
pin=127.0.0.1  => 200 "INTERNAL-DATA"
```

⚠ ブラインドではない。各ホップの失敗は `errors` に積まれ `Handler#reportable?` が errors 有りで必ず true を返すため、`Connection refused` と `Bad response NNN` の差が**投稿者へ戻る**。

## 実装

`RESERVED_RANGES` に予約・特殊用途レンジを明示列挙して拒否する。

- `0.0.0.0/8`（this-network）・`::/128`（unspecified）— **本命**
- `100.64.0.0/10`（CGNAT）・`64:ff9b::/96`（NAT64）— 本番 4 台では実害に届かないが Linode の一部リージョンや将来の CT 群で顕在化しうる
- `192.0.0.0/24`・`198.18.0.0/15`・`224.0.0.0/4`・`240.0.0.0/4`・`ff00::/8`

⚠ **IPv4-mapped は `native` へ畳んでから突き合わせる。**畳まないと `::ffff:0.0.0.0` が `0.0.0.0/8` と family 違いで一致しない（`IPAddr#include?` は family が違うと false を返す）。

## ⚠ #4524 が作った穴ではない

v5.32.1 の `public?` も同じ 3 述語だったので、ゼロアドレスは元から素通りしていた。#4524 が変えたのは「検証したアドレスへ接続を固定する」点で、OS のリゾルバ挙動に依存しない決定的な経路になった。**この述語を書き直したのが 5.33.0 なので、塞ぐならこのリリース。**

## テスト

負テスト 2 本（ゼロアドレス 4 種・予約レンジ 6 種）と、**予約レンジを足したせいで正当な公開アドレスまで落ちていないことの正テスト** 1 本を追加。

`rake test`: **973 tests / 1339 assertions / 0 failures / 0 errors / 313 omissions**（omission は基準値どおり据え置き）。
`rubocop`: no offenses。

🤖 Generated with [Claude Code](https://claude.com/claude-code)