### PR TITLE
並行性: 読み経路のキャッシュ温めを NX にし、書き込みの巻き戻しを塞ぐ (#4575)

### DIFF
--- a/app/lib/mulukhiya/program_fetcher.rb
+++ b/app/lib/mulukhiya/program_fetcher.rb
@@ -152,8 +152,28 @@ module Mulukhiya
     def load_from_yaml
       return {} unless yaml_exist?
       programs = YAML.safe_load_file(YAML_PATH, permitted_classes: PERMITTED_YAML_CLASSES) || {}
-      update_cache(programs)
+      warm_cache(programs)
       return programs
+    end
+
+    # 読み経路のキャッシュ温め (#4575)。
+    #
+    # ⚠ **書き経路の update_cache と違い NX。**load はロックを取らないので、
+    # ここを無条件 SET にすると「YAML を読んでから SET するまで」の間に完走した
+    # 書き込みを、読み手が古い内容で上書きできる。program キャッシュには TTL が
+    # 無く load はキャッシュを優先するため、以後すべての面が旧データを返し続け、
+    # 次の編集がそれを read-modify-write して YAML まで巻き戻る（#4534 が塞いだ
+    # 症状が、書き手同士でなく「書き手 × 読み手」で復活する）。
+    #
+    # ⚠ **読み経路をロックに載せる方向は採らない。**読みは書きより桁違いに多く
+    # （ProgramUpdateWorker が毎分・API・iCalendar）、409 が跳ね上がる。
+    #
+    # 温めの失敗は無害（次の read が YAML へ倒れるだけ）なので alert しない。
+    def warm_cache(programs)
+      return redis.setnx(REDIS_KEY, programs.to_json)
+    rescue => e
+      e.log(program: {event: 'warm_cache_failed'})
+      return false
     end
 
     def update_cache(programs)

--- a/app/lib/mulukhiya/redis.rb
+++ b/app/lib/mulukhiya/redis.rb
@@ -21,6 +21,20 @@ module Mulukhiya
       logger.info({storage: underscore}.merge(message))
     end
 
+    # 既に値があれば書き換えない SET (#4575)。獲得できたとき true。
+    #
+    # ⚠ **キャッシュを「温める」読み経路はこちらを使うこと。**素の SET だと、
+    # 古い内容を読んだ読み手が、その後に完走した書き手の新しい値を上書きできる。
+    # 番組表のように読みがロックの外にある構造では、それが恒久的なロールバックに
+    # なる（読みはキャッシュを優先するので、以後ずっと旧データが返る）。
+    # ⚠ Naming/PredicateMethod を inline disable する。真偽値を返すが、これは
+    # 述語ではなく「獲得できたか」を返す副作用付きコマンド。`setnx?` にすると
+    # 副作用の無い問い合わせに見えるので、Redis のコマンド名のまま残す。
+    def setnx(key, value) # rubocop:disable Naming/PredicateMethod
+      value = '' if value.nil?
+      return redis.call('SET', create_key(key), value, 'NX') == 'OK'
+    end
+
     def clear
       bar = ProgressBar.create(total: all_keys.count)
       all_keys.each do |key|

--- a/test/unit/lib/program_warm_cache.rb
+++ b/test/unit/lib/program_warm_cache.rb
@@ -1,0 +1,86 @@
+module Mulukhiya
+  # 読み経路のキャッシュ温めが既存の値を上書きしないこと (#4575)。
+  #
+  # ⚠ 本物の `program` キーは触らない。ProgramFetcher::REDIS_KEY を書くと、
+  # 番組表を持つ環境で実データのキャッシュを壊す（ProgramWriteLockTest が
+  # var/program.yaml も Redis も触らない方針にしているのと同じ理由）。
+  class ProgramWarmCacheTest < TestCase
+    KEY = 'test:program_warm_cache'.freeze
+
+    def disable?
+      return true unless Redis.health[:status] == 'OK'
+      return super
+    end
+
+    def setup
+      return if disable?
+      @redis = Redis.new
+      @redis.unlink(KEY)
+    end
+
+    def teardown
+      return if disable?
+      @redis&.unlink(KEY)
+      super
+    end
+
+    def test_setnx_sets_when_absent
+      return if disable?
+
+      assert_true(@redis.setnx(KEY, 'v1'))
+      assert_equal('v1', @redis[KEY])
+    end
+
+    # ここが本題。無条件 SET だと、古い内容を読んだ読み手が、その後に完走した
+    # 書き手の新しい値を上書きできる。
+    def test_setnx_does_not_overwrite
+      return if disable?
+      @redis.setnx(KEY, 'v1')
+
+      assert_false(@redis.setnx(KEY, 'v2'))
+      assert_equal('v1', @redis[KEY])
+    end
+
+    # 書き経路（update_cache）は無条件 SET のままであること。読みだけ NX に
+    # したつもりが両方 NX になると、編集がキャッシュへ反映されなくなる。
+    def test_plain_set_still_overwrites
+      return if disable?
+      @redis.setnx(KEY, 'v1')
+      @redis[KEY] = 'v2'
+
+      assert_equal('v2', @redis[KEY])
+    end
+
+    # ProgramFetcher の読み経路が setnx を通ること。⚠ ここが []= に戻ると
+    # 「書き手 × 読み手」の lost update が黙って復活する。
+    def test_warm_cache_uses_setnx
+      return if disable?
+      called = []
+      fetcher = ProgramFetcher.new
+      double = Object.new
+      double.define_singleton_method(:setnx) do |key, value|
+        called.push([:setnx, key, value])
+        next true
+      end
+      double.define_singleton_method(:[]=) {|key, value| called.push([:set, key, value])}
+      fetcher.define_singleton_method(:redis) {double}
+
+      fetcher.send(:warm_cache, {'x' => {'series' => 'y'}})
+
+      assert_equal(1, called.count)
+      assert_equal(:setnx, called.first.first)
+      assert_equal(ProgramFetcher::REDIS_KEY, called.first[1])
+    end
+
+    # 温めの失敗は無害（次の read が YAML へ倒れる）なので、例外を上げず false。
+    def test_warm_cache_swallows_error
+      return if disable?
+      fetcher = ProgramFetcher.new
+      double = Object.new
+      double.define_singleton_method(:setnx) {|_key, _value| raise Ginseng::Redis::Error, 'boom'}
+      fetcher.define_singleton_method(:redis) {double}
+
+      assert_false(fetcher.send(:warm_cache, {}))
+    end
+  end
+end


### PR DESCRIPTION
Fixes #4575

5.33.0 リリース前 5 観点レビューで、**並行性観点（赤）と観測性観点（黄）が独立に検出**したもの。**#4534 は書き手同士を直列化したが、書き手 × 読み手が残っていた。**

## 何が起きていたか

`ProgramFetcher#load` は `cached_data || load_from_yaml` で、キャッシュミス時に `load_from_yaml` が**読み経路のまま無条件 SET** を撃っていた。この書き込みは `ProgramLockStorage` を通らない。

| 時刻 | B（読み） | A（書き） | Redis | YAML |
|---|---|---|---|---|
| t=0.00 | `load` → cache nil | | 無し | v1 |
| t=0.01 | YAML v1 を読む（**まだ SET していない**） | | 無し | v1 |
| t=0.05 | | ロック獲得 → 温め SET(v1) | v1 | v1 |
| t=0.10 | | episode +1 → `save(v2)` → release → **200** | v2 | v2 |
| t=1.20 | `update_cache(v1)` = **SET(v1)** | | **v1** | v2 |

`program` キャッシュに **TTL が無く**、`load` はキャッシュを優先するので、以降すべての面が旧データを返し続ける。次の編集はその旧データを RMW するので **YAML まで巻き戻る**。`ProgramLockStorage` のクラス doc が「単発の lost update が恒久的なロールバックになる」と書いている、まさにその壊れ方。

⚠ **窓はミリ秒ではない。**`update_cache` は失敗時 1 秒 sleep × 3 回リトライし、`redis-client` の既定は `reconnect_attempts: false`。**Redis 再起動直後は死んだソケットを掴んだ最初の 1 コマンドが必ず例外になり、リトライで 1 秒以上眠る。**「Redis を再起動した」という単一イベントが、①キャッシュを空にし ②読み手の SET を遅らせる、を同時に起こす。デプロイ直後の編集がいちばん危ない。

`auto_update: true` のサーバーは 1 分後の pull で自己修復するが、**エディタ運用（`auto_update: false`）では次の編集まで残る**。

## 実装

`Mulukhiya::Redis#setnx` を足し、読み経路だけ `warm_cache`（NX）に分ける。書き経路の `update_cache` は無条件 SET のまま。

⚠ **読み経路をロックに載せる方向は採らない。**読みは書きより桁違いに多く（`ProgramUpdateWorker` が毎分・API・iCalendar）、409 が跳ね上がる。

⚠ `Naming/PredicateMethod` は inline disable。真偽値を返すが述語ではなく「獲得できたか」を返す副作用付きコマンドで、`setnx?` にすると副作用の無い問い合わせに見える。

## テスト

`ProgramWarmCacheTest` を新設。⚠ **本物の `program` キーは触らない**（番組表を持つ環境で実データのキャッシュを壊すため。`ProgramWriteLockTest` と同じ方針）。

- NX が既存の値を上書きしないこと（**本題**）
- **書き経路は無条件 SET のままであること**（読みだけ NX にしたつもりが両方 NX になると、編集がキャッシュへ反映されなくなる）
- `warm_cache` が `setnx` を通ること（`[]=` に戻ると lost update が黙って復活する）
- 温めの失敗が例外を上げないこと

`rake test`: **975 tests / 1335 assertions / 0 failures / 0 errors / 313 omissions**（omission 据え置き＝5 本とも実際に走っている）。
`rubocop`: 466 files / no offenses。

🤖 Generated with [Claude Code](https://claude.com/claude-code)