### PR TITLE
test/ci: タグ辞書キャッシュに署名と TTL を入れる (#4583)

### DIFF
--- a/app/lib/mulukhiya/tagging_dictionary.rb
+++ b/app/lib/mulukhiya/tagging_dictionary.rb
@@ -1,18 +1,33 @@
 module Mulukhiya
+  # 本文からハッシュタグを引くためのタグ辞書。リモート辞書 (GAS 等) を取り込んで
+  # Redis に丸ごとキャッシュし、DictionaryTagHandler / RemoteTagHandler が共有する。
+  #
+  # ⚠ **キャッシュは「どの dics 設定から作られたか」を署名として持つ (#4583)。**
+  # 以前は設定に依らない単一キーへ素の SET (TTL 無し) で書いていたため、
+  # 別の dics で温めたキャッシュを次のプロセスがそのまま読み、harness ゲートの
+  # 結果が「前に一度回したか」で変わっていた。署名と TTL で、キャッシュの中身を
+  # 「いまの設定から作られた、高々 ttl 秒前のもの」に閉じ込める。
   class TaggingDictionary < Hash
     include Package
     include SNSMethods
+
+    REDIS_KEY = 'tagging_dictionary'.freeze
+    # キャッシュ payload の形式。envelope を変えたら上げる。旧形式は「無い」ものと
+    # して捨てられ、次の refresh で作り直される。
+    CACHE_PAYLOAD_VERSION = 1
+    DEFAULT_CACHE_TTL = 3600
 
     def initialize
       super
       @handler = Handler.create(:dictionary_tag)
       @http = HTTP.new
       refresh unless cache.is_a?(Hash)
-      update(cache)
+      update(cache.to_h)
     end
 
     def clear
       @cache = nil
+      @generated_at = nil
       super
     end
 
@@ -42,20 +57,44 @@ module Mulukhiya
       update(sort_by {|k, _| k.length}.to_h)
     end
 
+    # キャッシュされている辞書エントリ。未充填 (初回・TTL 切れ・UNLINK 直後)、
+    # 旧形式、別の dics 設定由来なら nil。
     def cache
-      @cache ||= Marshal.load(redis['tagging_dictionary']) # rubocop:disable Security/MarshalLoad
+      @cache ||= load_cache
       return @cache
-    rescue => e
-      e.alert
-      return nil
+    end
+
+    # キャッシュを作った時刻。「いまどの取得回の辞書を使っているか」をログ・テスト
+    # から見るための世代表示 (#4583)。未充填なら nil。
+    def generated_at
+      cache
+      return @generated_at
+    end
+
+    # いまの dics 設定の指紋。これが変われば以前のキャッシュは別物として捨てる。
+    def signature
+      @signature ||= Digest::SHA256.hexdigest(sources.to_json)
+      return @signature
     end
 
     def refresh
+      entries = merge(fetch)
       clear
-      redis['tagging_dictionary'] = Marshal.dump(merge(fetch))
-      update(cache)
+      if discardable?(entries)
+        # ソースはあるのに 1 件も取れなかった回。直近の good を残したまま戻る。
+        # ⚠ fail-open 自体は残す (GAS の一過性障害で辞書が消し飛ぶのを防ぐ意図は
+        # 正しい)。TTL があるので古い内容が無期限に居座ることはない (#4583)。
+        alert_empty_result
+        update(cache.to_h)
+        return self
+      end
+      redis.setex(REDIS_KEY, cache_ttl, Marshal.dump(build_payload(entries)))
+      update(cache.to_h)
+      log_generation
+      return self
     rescue => e
       e.alert
+      return self
     end
 
     def short?(word)
@@ -70,11 +109,108 @@ module Mulukhiya
       return !self[key][:words]&.include?(key)
     end
 
+    def cache_ttl
+      return config['/handler/dictionary_tag/cache/ttl'] || DEFAULT_CACHE_TTL
+    rescue Ginseng::ConfigError
+      # 既定値は config/application.yaml にあるので通常ここへは来ない。設定ファイル
+      # が古い環境でも TTL 無しの素の SET へ退行させないための定数フォールバック。
+      return DEFAULT_CACHE_TTL
+    end
+
+    # キャッシュを捨てる。テスト・運用で「既知の状態から始める」ための入口。
+    def self.invalidate_cache
+      return Redis.new.unlink(REDIS_KEY)
+    end
+
     private
 
     def redis
       @redis ||= Redis.new
       return @redis
+    end
+
+    # いまの設定で構成されている辞書ソース。署名と「ソースが 0 本か」の判定に使う。
+    def sources
+      @sources ||= @handler.all.to_a
+      return @sources
+    end
+
+    def load_cache
+      raw = redis[REDIS_KEY]
+      # 未充填は異常ではない。alert しない (TTL を入れた以上、失効は日常的に起きる)。
+      return nil unless raw
+      payload = Marshal.load(raw) # rubocop:disable Security/MarshalLoad
+      return nil unless valid_payload?(payload)
+      @generated_at = payload[:generated_at]
+      return payload[:entries]
+    rescue => e
+      # 壊れたキャッシュ。次の refresh で作り直せるので握るが、黙って空にはしない。
+      e.log(redis_key: REDIS_KEY)
+      return nil
+    end
+
+    # 読み込んだ payload がいまの設定のものか。読み辞書側の
+    # PronunciationDictionary#valid_schema? と同じで、外れたら型・理由を残す。
+    def valid_payload?(payload)
+      unless payload.is_a?(Hash) && payload[:entries].is_a?(Hash)
+        logger.error(
+          message: 'tagging dictionary cache malformed',
+          redis_key: REDIS_KEY,
+          type: payload.class.name,
+        )
+        return false
+      end
+      return true if payload[:version] == CACHE_PAYLOAD_VERSION && payload[:signature] == signature
+      # 設定が変わった・古い形式だった、という正常な失効。error にはしない。
+      logger.info(
+        message: 'tagging dictionary cache discarded',
+        redis_key: REDIS_KEY,
+        cached_version: payload[:version],
+        cached_signature: payload[:signature],
+        signature:,
+      )
+      return false
+    end
+
+    # 「ソースは設定されているのに 1 件も取れず、しかも生きたキャッシュがある」回か。
+    # ⚠ **サブクラスの parse は失敗を握って {} を返す**ので、例外の数では検出できない。
+    # 結果が空かどうかで判定する (#4573 と同型の「黙って空になる」への歯止め)。
+    def discardable?(entries)
+      return false if entries.present?
+      return false if sources.none?
+      return cache.present?
+    end
+
+    # どの取得回の辞書を使っているかをログに残す。実走のたびに世代が出るので、
+    # 「前の実行が温めたキャッシュを読んでいる」状態を後から突き合わせられる。
+    def log_generation
+      logger.info(
+        message: 'tagging dictionary refreshed',
+        redis_key: REDIS_KEY,
+        signature:,
+        generated_at: generated_at&.iso8601,
+        sources: sources.size,
+        entries: size,
+        ttl: cache_ttl,
+      )
+    end
+
+    def alert_empty_result
+      Ginseng::GatewayError.new('tagging dictionary fetch returned nothing').alert(
+        redis_key: REDIS_KEY,
+        sources: sources.count,
+        cached_entries: cache.to_h.size,
+        generated_at: generated_at&.iso8601,
+      )
+    end
+
+    def build_payload(entries)
+      return {
+        version: CACHE_PAYLOAD_VERSION,
+        signature:,
+        generated_at: Time.now,
+        entries:,
+      }
     end
 
     def fetch

--- a/app/lib/mulukhiya/test_case.rb
+++ b/app/lib/mulukhiya/test_case.rb
@@ -46,6 +46,7 @@ module Mulukhiya
     def self.load(cases = nil)
       ENV['TEST'] = Package.full_name
       TestHarness.apply!
+      invalidate_shared_caches
       Sidekiq::Testing.fake!
       file_map(cases).each do |name, path|
         raise 'disabled' if name.end_with?('_handler') && Handler.create(name).disable?
@@ -55,6 +56,19 @@ module Mulukhiya
       rescue => e
         puts "- case: #{name} (#{e.message})" if Environment.test?
       end
+    end
+
+    # プロセスをまたいで居座る共有キャッシュを、スイート開始時に既知の状態へ戻す。
+    #
+    # ⚠ **「実走の前に手で UNLINK する」を手順書に書くだけでは弱い (#4583)。**
+    # タグ辞書は Redis に残り、テストの結果が「前に一度回したか」で変わっていた。
+    # 人間が手順を踏み忘れても効くよう、スイートのロードに織り込む。
+    def self.invalidate_shared_caches
+      TaggingDictionary.invalidate_cache
+    rescue => e
+      # Redis 未起動などで落ちても、ここでスイート全体を止めない。実際に辞書を
+      # 触るテストがその場で落ちる。
+      e.log
     end
 
     def self.names(cases = nil)

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -90,6 +90,8 @@ handler:
       - https://pf.korako.me/plugins/community-hashtag-map.json
     cache_ttl: 3600
   dictionary_tag:
+    cache:
+      ttl: 3600
     dics: []
     word:
       min: 2

--- a/config/schema/handler/dictionary_tag.yaml
+++ b/config/schema/handler/dictionary_tag.yaml
@@ -1,6 +1,12 @@
 label: 辞書タグ
 description: 本文中のキーワードに基づいてハッシュタグを自動付与します
 properties:
+  cache:
+    properties:
+      ttl:
+        minimum: 1
+        type: integer
+    type: object
   dics:
     items:
       properties:

--- a/test/unit/lib/tagging_dictionary_cache.rb
+++ b/test/unit/lib/tagging_dictionary_cache.rb
@@ -1,0 +1,151 @@
+module Mulukhiya
+  # タグ辞書キャッシュの健全性 (#4583) の回帰テスト。
+  #
+  # ⚠ **TaggingDictionaryTest と分けてあるのは、あちらが DB 前提だから。**
+  # `Handler.create(:dictionary_tag)` は Sequel のモデルを触るので、DB の無い環境
+  # では TaggingDictionary をそのまま new できず、クラスごと omission になる。
+  # キャッシュの世代・署名・TTL は辞書ソースの設定だけで決まり、ハンドラの実体を
+  # 必要としないので、辞書ソースを返すだけのダブルを差し込んで常に実走させる。
+  # #4503 の教訓どおり、ゲートを守るテストが環境次第で omission になるのは避ける。
+  class TaggingDictionaryCacheTest < TestCase
+    DICS = [
+      {'url' => 'https://example.jp/api/dic/v1/a.json', 'type' => 'related'},
+      {'url' => 'https://example.jp/api/dic/v1/b.json'},
+    ].freeze
+
+    ENTRY_KEYS = ['キュアスタ'].freeze
+
+    def setup
+      @dic = create_dictionary(DICS)
+    end
+
+    def teardown
+      super
+      # 実設定と署名が合わないので本番経路からは読まれないが、後続のテストに
+      # 余計なキーを残さない。
+      TaggingDictionary.invalidate_cache
+    rescue => e
+      e.log
+    end
+
+    def test_cache_ttl
+      assert_kind_of(Integer, @dic.cache_ttl)
+      assert_predicate(@dic.cache_ttl, :positive?)
+    end
+
+    # 素の SET (TTL 無し) へ退行していないことを、実際の Redis の TTL で確かめる。
+    # これが -1 だと「前に一度回したか」でゲートの結果が変わる (#4583)。
+    def test_refresh_sets_ttl
+      @dic.refresh
+      ttl = redis.redis.call('TTL', TaggingDictionary::REDIS_KEY)
+
+      assert_predicate(ttl, :positive?, "tagging_dictionary の TTL が #{ttl}")
+      assert_operator(ttl, :<=, @dic.cache_ttl)
+    end
+
+    def test_refresh_stamps_generation
+      @dic.refresh
+
+      assert_not_nil(@dic.generated_at)
+      assert_equal(ENTRY_KEYS, @dic.keys)
+
+      payload = load_payload
+
+      assert_equal(TaggingDictionary::CACHE_PAYLOAD_VERSION, payload[:version])
+      assert_equal(@dic.signature, payload[:signature])
+      assert_equal(ENTRY_KEYS, payload[:entries].keys)
+      assert_kind_of(Time, payload[:generated_at])
+    end
+
+    def test_signature_follows_dics
+      assert_equal(Digest::SHA256.hexdigest(DICS.to_json), @dic.signature)
+      assert_not_equal(@dic.signature, create_dictionary(DICS.take(1)).signature)
+    end
+
+    # 別の dics 設定で温めたキャッシュを読まない。これが #4583 の芯で、
+    # 「前に誰が回したか」で辞書の中身が変わるのを断つ。
+    def test_cache_ignores_foreign_signature
+      @dic.refresh
+
+      assert_equal(ENTRY_KEYS, @dic.cache.to_h.keys)
+
+      other = create_dictionary(DICS.take(1))
+
+      assert_nil(other.cache)
+      assert_nil(other.generated_at)
+    end
+
+    def test_cache_ignores_legacy_payload
+      # 旧形式 = エントリの生ハッシュを直に Marshal したもの
+      redis[TaggingDictionary::REDIS_KEY] = Marshal.dump(build_entries)
+
+      assert_nil(create_dictionary(DICS).cache)
+    end
+
+    def test_cache_ignores_broken_payload
+      redis[TaggingDictionary::REDIS_KEY] = 'not a marshal dump'
+
+      assert_nil(create_dictionary(DICS).cache)
+    end
+
+    def test_cache_absent_is_not_an_error
+      TaggingDictionary.invalidate_cache
+
+      assert_nil(@dic.cache)
+      assert_nil(@dic.generated_at)
+    end
+
+    # 全ソースが空を返した回で、生きているキャッシュを空へ潰さない (#4583)。
+    # ⚠ RemoteDictionary のサブクラスは失敗を握って {} を返すので、例外の有無では
+    # 検出できない。結果が空かどうかで判定していることを押さえる。
+    def test_refresh_keeps_last_known_good
+      @dic.refresh
+      generated_at = @dic.generated_at
+
+      empty = create_dictionary(DICS, wordsets: [])
+      empty.refresh
+
+      assert_equal(ENTRY_KEYS, empty.cache.to_h.keys)
+      assert_equal(ENTRY_KEYS, empty.keys)
+      assert_equal(generated_at, empty.generated_at)
+    end
+
+    # ソースが 1 本も無いなら空が正しい結果。歯止めを効かせない。
+    def test_refresh_persists_empty_without_sources
+      @dic.refresh
+
+      none = create_dictionary([], wordsets: [])
+      none.refresh
+
+      assert_equal({}, none.cache.to_h)
+      assert_empty(none)
+    end
+
+    private
+
+    def redis
+      @redis ||= Redis.new
+      return @redis
+    end
+
+    def load_payload
+      return Marshal.load(redis[TaggingDictionary::REDIS_KEY]) # rubocop:disable Security/MarshalLoad
+    end
+
+    # merge は wordset の中身 (words 配列) を破壊的に触るので、呼ばれるたびに
+    # 作り直したものを渡す。
+    def build_entries
+      return ENTRY_KEYS.to_h do |key|
+        [key, {pattern: Regexp.new(key), regexp: key, words: [key]}]
+      end
+    end
+
+    def create_dictionary(dics, wordsets: nil)
+      dic = TaggingDictionary.allocate
+      dic.instance_variable_set(:@handler, Struct.new(:all).new(dics))
+      builder = -> {wordsets || [build_entries]}
+      dic.define_singleton_method(:fetch) {builder.call}
+      return dic
+    end
+  end
+end


### PR DESCRIPTION
## 何を直したか

harness ゲートの結果が「前に一度回したか」で変わっていた（#4583）。芯は 2 つ。

1. `tagging_dictionary` が **TTL 無しの素の SET** で、実行と実行のあいだで消えない
2. キャッシュが **「どの `dics` 設定から作られたか」を持たない**ので、別の設定で温めた
   キャッシュを次のプロセスがそのまま読む

2 のほうが実害が大きい。`DictionaryTagHandlerTest#setup` は `dics` を 5 件（うち 1 件は
`strict: true`）へ差し替えて `refresh` するので、その回のキャッシュが
`RemoteTagHandler#search_remote_tags` の `reject` 3 条件（`short?` / `local_tags.member?` /
`strict_key?`）に効く。3 条件とも同じ辞書を読んでいる。

## 変更点

- キャッシュ本体を `version` / `signature` / `generated_at` / `entries` の envelope に包む。
  署名は `dics` 設定の指紋。署名違い・バージョン違い・旧形式は「無いもの」として作り直す
- `setex` で TTL を付ける（既定 3600 秒。`/handler/dictionary_tag/cache/ttl`）
- **全ソースが空を返した回は、生きているキャッシュを空へ潰さない。**
  ⚠ `RemoteDictionary` のサブクラスは失敗を握って `{}` を返すので、例外の有無では検出できない。
  結果が空かどうかで判定している。fail-open 自体は残す（GAS の一過性障害で辞書が消し飛ぶのを
  防ぐ意図は正しい）。TTL があるので古い内容が無期限に居座ることもない
- キャッシュ未充填で `alert` しない。TTL を入れた以上、失効は日常的に起きる
- `refresh` のたびに世代（`signature` / `generated_at` / `entries` / `ttl`）をログへ出す
- **スイートのロード時にキャッシュを捨てる。**⚠ 「実走の前に手で `UNLINK` する」を手順書に
  書くだけでは弱い（#4503 の教訓）。人間が踏み忘れても効く形にした

## テストの置き場所

回帰テストは `TaggingDictionaryCacheTest` として**別クラス**に置いた。
`Handler.create(:dictionary_tag)` が Sequel のモデルを触るため、既存の
`TaggingDictionaryTest` は **DB の無い環境でクラスごと omission** になり、ゲートを守れない。
キャッシュの世代・署名・TTL は辞書ソースの設定だけで決まるので、辞書ソースを返すだけの
ダブルを差し込んで常に実走させている。

## 検証

- `bundle exec rake test`: 978 → **988 tests / 0 failures / 0 errors / 313 omissions**
  （omissions は前後で不変。新規 10 件はすべて実走）
- `bundle exec rake lint`: 通過（rubocop 467 files + erb-lint + slim-lint 58 YAML + bundler-audit）

## 積み残し

`RemoteTagHandlerTest` の `キュアスタ!` が **3 つある reject 条件のどれで落ちているか**は
未特定のまま。これは #4584 の担当で、本 PR の着地後に A/B の再現性が担保できてから着手する。

Closes #4583

🤖 Generated with [Claude Code](https://claude.com/claude-code)