### PR TITLE
fix: ALT 編集が投稿の添付・CW・閲覧注意を壊さないようにする (#4589)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,10 +42,10 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-fediverse.git
-  revision: 442c49d486cbf87ea89848f0abd6ccde21edca44
+  revision: dae831dbce6871c1465851dc3c6df925dda99da3
   branch: main
   specs:
-    ginseng-fediverse (1.8.26)
+    ginseng-fediverse (1.8.27)
 
 GIT
   remote: https://github.com/pooza/ginseng-piefed.git

--- a/app/lib/mulukhiya/controller/mastodon_controller.rb
+++ b/app/lib/mulukhiya/controller/mastodon_controller.rb
@@ -14,6 +14,11 @@ module Mulukhiya
     # 頻度・偏りで追える。
     STATUS_UPDATE_SILENT_STATUSES = [401, 404].freeze
 
+    # PUT /api/:version/statuses/:id が受け付ける X-Mulukhiya-Purpose。
+    # nil / '' は nginx を経由しない直接アクセス（#4474 の map が外部からの
+    # Purpose 無し PUT を 405 で弾くため、実質モロヘイヤ自身の転送のみ）。
+    STATUS_UPDATE_PURPOSES = [nil, '', 'media_update', 'tag'].freeze
+
     post '/api/:version/statuses' do
       verify_token_integrity!
       tags = TootParser.new(params[:status]).tags
@@ -63,16 +68,12 @@ module Mulukhiya
     put '/api/:version/statuses/:id' do
       verify_token_integrity!
       purpose = request.env['HTTP_X_MULUKHIYA_PURPOSE']
-      case purpose
-      when nil, '', 'media_update'
-        source = sns.fetch_status_source(params[:id], {headers: @headers})
-        body = {status: source['text'], media_attributes: params[:media_attributes]}.compact
-      when 'tag'
-        body = {status: params[:status], media_attributes: params[:media_attributes]}.compact
-      else
-        raise Ginseng::ValidateError, "unknown purpose: #{purpose}"
+      raise Ginseng::ValidateError, "unknown purpose: #{purpose}" unless STATUS_UPDATE_PURPOSES.member?(purpose)
+      raise Ginseng::ValidateError, 'media_attributes is required' if params[:media_attributes].blank?
+      body = case purpose
+      when 'tag' then {status: params[:status], media_attributes: params[:media_attributes]}.compact
+      else create_media_update_body(params)
       end
-      raise Ginseng::ValidateError, 'media_attributes is required' if body.empty?
       reporter.response = sns.update_status(params[:id], body, {headers: @headers})
       @renderer.message = reporter.response.parsed_response
       @renderer.status = reporter.response.code
@@ -128,6 +129,39 @@ module Mulukhiya
     get '/api/v1/mulukhiya/diag' do
       @renderer.message = token_echo_response
       return @renderer.to_s
+    end
+
+    # ALT 編集 (#4589) で SNS へ送る body。
+    #
+    # ⚠ **現状維持したい値も明示的に送り直すこと。** Mastodon の
+    # `UpdateStatusService` は「送らなかったパラメータ」を現状維持ではなく
+    # **「空で更新」**として扱う。コントローラの `update_options` がハッシュ
+    # リテラルなので、値が nil でも `options.key?` は常に true になるため。
+    #
+    # 落とすと ALT が反映されないどころか投稿が壊れる:
+    #
+    # - `media_ids` … `validate_media!` が `[]` を返し `media_attributes` の
+    #   ループが対象を見つけられず **ALT が適用されない**うえ、
+    #   `ordered_media_attachment_ids = []` で **投稿から添付が全部外れる**
+    # - `spoiler_text` … **CW が消える**（`/source` が返しているのに未使用だった）
+    # - `sensitive` … **閲覧注意フラグが外れる**
+    #
+    # `/source` は本文と CW しか返さないので、添付の順序と閲覧注意は
+    # `fetch_status` から取る（リクエストが 1 本増える）。
+    #
+    # ⚠ `poll` も同じ構造（空なら `previous_poll.destroy`）だが、Mastodon は
+    # 添付とアンケートを同時に持てないため ALT 編集では到達しない。`tag` purpose
+    # を実装するときは別途注意すること。
+    def create_media_update_body(params)
+      source = sns.fetch_status_source(params[:id], {headers: @headers})
+      status = sns.fetch_status(params[:id], {headers: @headers})
+      return {
+        status: source['text'],
+        spoiler_text: source['spoiler_text'].to_s,
+        sensitive: status['sensitive'] ? true : false,
+        media_ids: Array(status['media_attachments']).map {|v| v['id']},
+        media_attributes: params[:media_attributes],
+      }
     end
 
     def token

--- a/app/lib/mulukhiya/controller/mastodon_controller.rb
+++ b/app/lib/mulukhiya/controller/mastodon_controller.rb
@@ -68,13 +68,12 @@ module Mulukhiya
     put '/api/:version/statuses/:id' do
       verify_token_integrity!
       purpose = request.env['HTTP_X_MULUKHIYA_PURPOSE']
-      raise Ginseng::ValidateError, "unknown purpose: #{purpose}" unless STATUS_UPDATE_PURPOSES.member?(purpose)
-      raise Ginseng::ValidateError, 'media_attributes is required' if params[:media_attributes].blank?
-      body = case purpose
-      when 'tag' then {status: params[:status], media_attributes: params[:media_attributes]}.compact
-      else create_media_update_body(params)
-      end
-      reporter.response = sns.update_status(params[:id], body, {headers: @headers})
+      validate_status_update!(purpose, params)
+      reporter.response = sns.update_status(
+        params[:id],
+        create_status_update_body(purpose, params),
+        {headers: @headers},
+      )
       @renderer.message = reporter.response.parsed_response
       @renderer.status = reporter.response.code
       return @renderer.to_s
@@ -129,6 +128,19 @@ module Mulukhiya
     get '/api/v1/mulukhiya/diag' do
       @renderer.message = token_echo_response
       return @renderer.to_s
+    end
+
+    def validate_status_update!(purpose, params)
+      unless STATUS_UPDATE_PURPOSES.member?(purpose)
+        raise Ginseng::ValidateError, "unknown purpose: #{purpose}"
+      end
+      attributes = params[:media_attributes]
+      raise Ginseng::ValidateError, 'media_attributes is required' if attributes.blank?
+    end
+
+    def create_status_update_body(purpose, params)
+      return create_media_update_body(params) unless purpose == 'tag'
+      return {status: params[:status], media_attributes: params[:media_attributes]}.compact
     end
 
     # ALT 編集 (#4589) で SNS へ送る body。

--- a/app/lib/mulukhiya/controller/mastodon_controller.rb
+++ b/app/lib/mulukhiya/controller/mastodon_controller.rb
@@ -130,11 +130,24 @@ module Mulukhiya
       return @renderer.to_s
     end
 
+    # purpose ごとに必須パラメータが違う。
+    #
+    # ⚠ **`tag` に `media_attributes` を要求しない。** こちらはタグを付け替えた
+    # 本文を送り直す経路で、**添付を持たない投稿にも来る**。一律に要求すると
+    # 本文だけのタグ書き換えが 422 になる（PR #4590 の Codex P2）。
+    #
+    # 逆に ALT 編集側（nil / '' / `media_update`）では必須。欠けると
+    # `flatten_media_attributes` が nil を each して落ちるうえ、そもそも
+    # 「何も変えない PUT」にしかならない。
     def validate_status_update!(purpose, params)
       unless STATUS_UPDATE_PURPOSES.member?(purpose)
         raise Ginseng::ValidateError, "unknown purpose: #{purpose}"
       end
       attributes = params[:media_attributes]
+      if purpose == 'tag'
+        return if params[:status].present? || attributes.present?
+        raise Ginseng::ValidateError, 'status or media_attributes is required'
+      end
       raise Ginseng::ValidateError, 'media_attributes is required' if attributes.blank?
     end
 

--- a/test/unit/controller/alt_edit_body.rb
+++ b/test/unit/controller/alt_edit_body.rb
@@ -64,13 +64,13 @@ module Mulukhiya
         },
       )
 
-      assert_equal(%w[111 222 333], body[:media_ids])
+      assert_equal(['111', '222', '333'], body[:media_ids])
     end
 
     def test_media_ids_are_empty_without_attachments
       body = build_body(status: {'sensitive' => false})
 
-      assert_equal([], body[:media_ids])
+      assert_empty(body[:media_ids])
     end
 
     # CW を消さないために必須。`/source` が返しているのに使っていなかった。
@@ -90,16 +90,16 @@ module Mulukhiya
     end
 
     def test_sensitive_is_restored
-      assert_equal(true, build_body(status: {'sensitive' => true, 'media_attachments' => []})[:sensitive])
-      assert_equal(false, build_body(status: {'sensitive' => false, 'media_attachments' => []})[:sensitive])
+      assert(build_body(status: {'sensitive' => true, 'media_attachments' => []})[:sensitive])
+      refute(build_body(status: {'sensitive' => false, 'media_attachments' => []})[:sensitive])
     end
 
     # ⚠ false と nil を同一視しない。`.compact` で落とすと閲覧注意が意図せず動く。
     def test_sensitive_is_false_not_nil_when_absent
       body = build_body(status: {'media_attachments' => []})
 
-      assert_equal(false, body[:sensitive])
-      assert(body.key?(:sensitive))
+      # ⚠ refute だけだと nil でも通ってしまうので、型で false を名指しする。
+      assert_equal(FalseClass, body[:sensitive].class)
     end
   end
 end

--- a/test/unit/controller/alt_edit_body.rb
+++ b/test/unit/controller/alt_edit_body.rb
@@ -99,7 +99,7 @@ module Mulukhiya
       body = build_body(status: {'media_attachments' => []})
 
       # ⚠ refute だけだと nil でも通ってしまうので、型で false を名指しする。
-      assert_equal(FalseClass, body[:sensitive].class)
+      assert_instance_of(FalseClass, body[:sensitive])
     end
   end
 end

--- a/test/unit/controller/alt_edit_body.rb
+++ b/test/unit/controller/alt_edit_body.rb
@@ -1,0 +1,105 @@
+module Mulukhiya
+  # ALT 編集 (`PUT /api/:version/statuses/:id`) が SNS へ送る body (#4589)。
+  #
+  # ⚠ **眼目は「現状維持したい値も送り直す」こと。** Mastodon の
+  # `UpdateStatusService` は「送らなかったパラメータ」を現状維持ではなく
+  # **「空で更新」**として扱う（`options.key?` で分岐し、コントローラの
+  # `update_options` がハッシュリテラルなのでキーは常に存在する）。
+  #
+  # そのため、ここで欠けると ALT が反映されないどころか投稿が壊れる:
+  #
+  # - `media_ids` … ALT が適用されないうえ **投稿から添付が全部外れる**
+  # - `spoiler_text` … **CW が消える**
+  # - `sensitive` … **閲覧注意フラグが外れる**
+  class AltEditBodyTest < TestCase
+    # `fetch_status_source` / `fetch_status` だけ返す SNS のダブル。
+    class SnsDouble
+      def initialize(source, status)
+        @source = source
+        @status = status
+      end
+
+      def fetch_status_source(_id, _params = {})
+        return @source
+      end
+
+      def fetch_status(_id, _params = {})
+        return @status
+      end
+    end
+
+    def build_body(source: nil, status: nil, params: nil)
+      controller = MastodonController.new!
+      controller.instance_variable_set(:@headers, {})
+      controller.instance_variable_set(:@sns, SnsDouble.new(
+        source || {'text' => '本文', 'spoiler_text' => ''},
+        status || {'sensitive' => false, 'media_attachments' => [{'id' => '111'}]},
+      ))
+      return controller.create_media_update_body(
+        params || {id: '1', media_attributes: [{id: '111', description: 'ゴメちゃん'}]},
+      )
+    end
+
+    def test_media_attributes_are_passed_through
+      body = build_body
+
+      assert_equal([{id: '111', description: 'ゴメちゃん'}], body[:media_attributes])
+    end
+
+    # 本文は `/source` の生テキストから戻す。status entity の `content` は HTML
+    # なので、そちらを使うと投稿本文が HTML へ置き換わる。
+    def test_status_comes_from_source_text
+      body = build_body(source: {'text' => 'もとの本文', 'spoiler_text' => ''})
+
+      assert_equal('もとの本文', body[:status])
+    end
+
+    # 添付が外れないために必須。**順序も保つ**（ordered_media_attachment_ids に
+    # そのまま入るので、入れ替えると投稿内の並びが変わる）。
+    def test_media_ids_are_restored_in_order
+      body = build_body(
+        status: {
+          'sensitive' => false,
+          'media_attachments' => [{'id' => '111'}, {'id' => '222'}, {'id' => '333'}],
+        },
+      )
+
+      assert_equal(%w[111 222 333], body[:media_ids])
+    end
+
+    def test_media_ids_are_empty_without_attachments
+      body = build_body(status: {'sensitive' => false})
+
+      assert_equal([], body[:media_ids])
+    end
+
+    # CW を消さないために必須。`/source` が返しているのに使っていなかった。
+    def test_spoiler_text_is_restored
+      body = build_body(source: {'text' => '本文', 'spoiler_text' => 'ネタバレ'})
+
+      assert_equal('ネタバレ', body[:spoiler_text])
+    end
+
+    # ⚠ CW 無しは nil ではなく空文字で送る。nil だと `.compact` 等で落ちうるし、
+    # 落ちれば Mastodon 側で「空で更新」になり結局同じ値になるとはいえ、
+    # 「送っている」ことを型で示しておく。
+    def test_spoiler_text_is_empty_string_when_absent
+      body = build_body(source: {'text' => '本文'})
+
+      assert_equal('', body[:spoiler_text])
+    end
+
+    def test_sensitive_is_restored
+      assert_equal(true, build_body(status: {'sensitive' => true, 'media_attachments' => []})[:sensitive])
+      assert_equal(false, build_body(status: {'sensitive' => false, 'media_attachments' => []})[:sensitive])
+    end
+
+    # ⚠ false と nil を同一視しない。`.compact` で落とすと閲覧注意が意図せず動く。
+    def test_sensitive_is_false_not_nil_when_absent
+      body = build_body(status: {'media_attachments' => []})
+
+      assert_equal(false, body[:sensitive])
+      assert(body.key?(:sensitive))
+    end
+  end
+end

--- a/test/unit/controller/status_update_validation.rb
+++ b/test/unit/controller/status_update_validation.rb
@@ -1,0 +1,47 @@
+module Mulukhiya
+  # `PUT /api/:version/statuses/:id` の必須パラメータ検証 (#4589)。
+  #
+  # ⚠ **purpose ごとに必須が違う。** ALT 編集（nil / `''` / `media_update`）は
+  # `media_attributes` が必須だが、`tag` は**タグを付け替えた本文を送り直す経路**
+  # なので添付を持たない投稿にも来る。一律に要求すると本文だけのタグ書き換えが
+  # 422 になる（PR #4590 の Codex P2）。
+  class StatusUpdateValidationTest < TestCase
+    def validate(purpose, params)
+      return MastodonController.new!.validate_status_update!(purpose, params)
+    end
+
+    def test_unknown_purpose_is_rejected
+      assert_raise(Ginseng::ValidateError) do
+        validate('destroy', {media_attributes: [{id: '111'}]})
+      end
+    end
+
+    # nginx を経由しない直接アクセス（実質モロヘイヤ自身の転送）。
+    def test_blank_purpose_is_accepted
+      assert_nothing_raised {validate(nil, {media_attributes: [{id: '111'}]})}
+      assert_nothing_raised {validate('', {media_attributes: [{id: '111'}]})}
+    end
+
+    def test_media_update_requires_media_attributes
+      assert_nothing_raised do
+        validate('media_update', {media_attributes: [{id: '111', description: 'ゴメちゃん'}]})
+      end
+      assert_raise(Ginseng::ValidateError) {validate('media_update', {status: '本文'})}
+      assert_raise(Ginseng::ValidateError) {validate('media_update', {media_attributes: []})}
+    end
+
+    # ⚠ 本件の眼目。`tag` は `status` だけで通る。
+    def test_tag_accepts_status_without_media_attributes
+      assert_nothing_raised {validate('tag', {status: '本文 #キュアスタ'})}
+    end
+
+    def test_tag_accepts_media_attributes_without_status
+      assert_nothing_raised {validate('tag', {media_attributes: [{id: '111'}]})}
+    end
+
+    # 両方無いときだけ弾く（元の `body.empty?` と同じ線引き）。
+    def test_tag_rejects_empty_payload
+      assert_raise(Ginseng::ValidateError) {validate('tag', {id: '1'})}
+    end
+  end
+end


### PR DESCRIPTION
Closes #4589

pooza/capsicum#121 の着手前調査で見つけた、**投稿を破壊しうる**不具合の修正です。

## 何が起きていたか

`PUT /api/:version/statuses/:id` が SNS へ送っていたのは `status` と `media_attributes` だけでした。

⚠ **Mastodon の `UpdateStatusService` は「送らなかったパラメータ」を現状維持ではなく「空で更新」として扱います。** `options.key?` で分岐しており、コントローラ側の `update_options` がハッシュリテラルなので **キーは常に存在する**（値が nil になるだけ）ためです。

なので落としていた影響は「反映されない」では済みませんでした。

| 落としていたもの | 起きること |
| --- | --- |
| `media_ids` | `validate_media!` が `[]` を返し `media_attributes` のループが対象を見つけられず **ALT が適用されない**。さらに `ordered_media_attachment_ids = []` で **投稿から添付が全部外れる** |
| `spoiler_text` | **CW が消える**（`/source` が返しているのに未使用だった） |
| `sensitive` | **閲覧注意フラグが外れる** |

しかも `@media_attachments_changed` が立つので `significant_changes?` を通過し、**トランザクションはコミットされます**。

## 直し方

現状維持すべき値を `create_media_update_body` で明示的に送り直します。

- **本文と CW** … `/source` から。⚠ status entity の `content` は HTML なので使えません
- **添付の順序と閲覧注意** … `fetch_status` から（リクエストが 1 本増えます）

あわせて 2 点整理しました。

- **purpose の検証を先に行う。** 従来は `body.empty?` で「media_attributes 必須」を見ていましたが、現状維持の値を積むと body が空にならないので成立しません。`params[:media_attributes]` を直接見る形に変え、purpose の許容値も `STATUS_UPDATE_PURPOSES` に出しました
- ⚠ `poll` も同じ構造（空なら `previous_poll.destroy`）ですが、**Mastodon は添付とアンケートを同時に持てない**ため ALT 編集では到達しません。`tag` purpose を実装するときは別途注意が要ります（コメントで残しました）

## ⚠ 平坦化側の対応が別途要ります

ginseng-fediverse の `flatten_media_attributes` が `status` と `media_attributes` しか通さないため、**ここで積んでも落ちます**。pooza/ginseng-fediverse#245 で対応しました。**この PR は単独ではまだ直りません。**

## 現時点で実害は出ていないはずです

- capsicum はまだこの API を呼んでいない（それが pooza/capsicum#121）
- Purpose ヘッダ無しの直接アクセスは #4474 の nginx map が 405 で弾く
- `tag` purpose は #3877 待ちで未使用

**まだ誰も通っていない経路の潜在バグ**ですが、capsicum#121 を実装した瞬間に踏めるようになります。

## 検証について

`test/unit/controller/alt_edit_body.rb` を足しました（`fetch_status_source` / `fetch_status` をダブルにして body の中身を固定する）。

⚠ **手元でテストと rubocop を回せていません。** この Mac の MacPorts ruby が壊れており（`/opt/local/bin/ruby3.4` 不在）、`bundle` が起動しませんでした。CI での確認をお願いします。

**ステージング（dev24 / st2.mstdn.b-shock.org）での実地確認もまだです。** 「実際に投稿が壊れる／直ると壊れない」を通しで見るなら、ginseng-fediverse#245 とセットで適用してからになります。本番で試すと実ユーザーの投稿と同じ経路になるので行いません。

## 関連

- #4589（この Issue）/ pooza/ginseng-fediverse#245（平坦化側）
- pooza/capsicum#121（この修正が本番へ出るまでブロック。v1.58 へ送りました）
- #4162（PUT パススルーの実装元）/ #4474（nginx の 405）/ #4542（404 の alert 除外）
