### PR TITLE
fix: デーモンの /health が「触れなかった」を「死んでいる」と断定しないようにする

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-core.git
-  revision: e48aeea725f438aded0f272606ac4b98e232e753
+  revision: ab02f5e36eb3848ebd5556c25ecdc9c166e6da93
   branch: main
   specs:
-    ginseng-core (1.16.2)
+    ginseng-core (1.17.0)
       activesupport (>= 7.0.7.1)
       addressable (>= 2.9.0)
       cgi (>= 0.4.2)

--- a/app/lib/mulukhiya/daemon/listener_daemon.rb
+++ b/app/lib/mulukhiya/daemon/listener_daemon.rb
@@ -2,6 +2,7 @@ module Mulukhiya
   class ListenerDaemon < Ginseng::Daemon
     include Package
     include SNSMethods
+    extend DaemonHealthMethods
 
     def start(args = [])
       save_config
@@ -29,8 +30,7 @@ module Mulukhiya
     def self.health
       pid_path = File.join(Environment.dir, 'tmp/pids/ListenerDaemon.pid')
       if File.exist?(pid_path)
-        pid = File.read(pid_path).to_i
-        raise "PID '#{pid}' was dead" unless Process.alive?(pid)
+        assert_pid_alive!(File.read(pid_path).to_i)
       else
         unless system('pgrep', '-f', 'listener_daemon.rb',
           out: File::NULL, err: File::NULL)

--- a/app/lib/mulukhiya/daemon/sidekiq_daemon.rb
+++ b/app/lib/mulukhiya/daemon/sidekiq_daemon.rb
@@ -3,6 +3,7 @@ require 'sidekiq/api'
 module Mulukhiya
   class SidekiqDaemon < Ginseng::Daemon
     include Package
+    extend DaemonHealthMethods
 
     def command
       return CommandLine.new([
@@ -51,9 +52,7 @@ module Mulukhiya
         retry: stats.retry_size,
         status: pids.present? ? 'OK' : 'NG',
       }
-      pids.each do |pid|
-        raise "PID '#{pid}' not alive" unless Process.alive?(pid)
-      end
+      pids.each {|pid| assert_pid_alive!(pid)}
       return values
     rescue => e
       return {error: e.message, status: 'NG'}

--- a/app/lib/mulukhiya/daemon_health_methods.rb
+++ b/app/lib/mulukhiya/daemon_health_methods.rb
@@ -1,0 +1,26 @@
+module Mulukhiya
+  # デーモンの `/health` が pid の生死を見るときの共通処理。
+  #
+  # ⚠ **「触れなかった」を「死んでいる」と断定しない** (pooza/ginseng-core#510)。
+  # 以前は `Process.alive?` の false をそのまま `"was dead"` と報告していたが、
+  # `Errno::EPERM`（プロセスは存在するが、シグナルを送る権限が無い）でも false に
+  # なるため、**原因を誤って伝えていた**。ginseng-core 1.17.0 の `alive_state` は
+  # `:alive` / `:dead` / `:unknown` を返し分けるので、報告もそれに合わせる。
+  #
+  # ⚠ **`:unknown` も NG のままでよい。**モロヘイヤのデーモンは `/health` を返す
+  # プロセスと同じユーザーで動くので、触れないということは **pid が再利用されて
+  # 他人のプロセスになっている**＝うちのデーモンは動いていない。変えるのは
+  # 「なぜ NG なのか」の説明だけ。
+  module DaemonHealthMethods
+    def assert_pid_alive!(pid)
+      case Process.alive_state(pid)
+      when :alive
+        return true
+      when :dead
+        raise "PID '#{pid}' was dead"
+      else
+        raise "PID '#{pid}' is not ours (signal not permitted)"
+      end
+    end
+  end
+end

--- a/test/unit/lib/daemon_health_methods.rb
+++ b/test/unit/lib/daemon_health_methods.rb
@@ -1,0 +1,58 @@
+module Mulukhiya
+  # デーモンの `/health` が pid の生死をどう報告するか。
+  #
+  # ⚠ **芯は「触れなかった」を「死んでいる」と断定しないこと**
+  # （pooza/ginseng-core#510）。`Errno::EPERM` でも `Process.alive?` は false に
+  # なるので、以前は `"was dead"` と原因を誤って伝えていた。
+  class DaemonHealthMethodsTest < TestCase
+    class Subject
+      extend DaemonHealthMethods
+    end
+
+    def test_alive_pid_passes
+      assert(Subject.assert_pid_alive!(Process.pid))
+    end
+
+    def test_dead_pid_says_dead
+      error = assert_raise(RuntimeError) {Subject.assert_pid_alive!(unused_pid)}
+
+      assert_match(/was dead/, error.message)
+    end
+
+    # ⚠ **`:unknown` も NG のままでよい**（デーモンは `/health` を返すプロセスと
+    # 同じユーザーで動くので、触れない＝うちのデーモンではない）。変わるのは
+    # 「なぜ NG なのか」の説明だけ。
+    def test_foreign_pid_says_not_ours
+      omit 'root では EPERM にならない' if Process.uid.zero?
+      omit '触れない他ユーザーのプロセスが見つからない' unless (pid = foreign_pid)
+
+      error = assert_raise(RuntimeError) {Subject.assert_pid_alive!(pid)}
+
+      assert_match(/not ours/, error.message)
+      # ⚠ 「dead」と言わないことまで見る。ここが退行すると原因の誤報が戻る。
+      assert_not_match(/dead/, error.message)
+    end
+
+    private
+
+    def unused_pid
+      (2**15).downto(2) do |pid|
+        Process.kill(0, pid)
+      rescue Errno::ESRCH
+        return pid
+      rescue Errno::EPERM # rubocop:disable Lint/SuppressedException
+      end
+      return nil
+    end
+
+    def foreign_pid
+      [1, 2].each do |pid|
+        Process.kill(0, pid)
+      rescue Errno::EPERM
+        return pid
+      rescue StandardError # rubocop:disable Lint/SuppressedException
+      end
+      return nil
+    end
+  end
+end


### PR DESCRIPTION
ginseng-core 1.17.0（pooza/ginseng-core#509 / #510 / #511）へ追随する。
**3 件はいずれも「例外を安全側でない値・順序に読み替える」同型**で、モロヘイヤに実害がある。

## モロヘイヤのコードを直す分

`Process.alive?` は `Errno::EPERM`（プロセスは存在するが、**シグナルを送る権限が無い**）でも
false になる。⚠ `listener_daemon.rb` / `sidekiq_daemon.rb` の `/health` はこれを
`raise "PID '#{pid}' was dead"` と報告していたので、**原因を誤って伝えていた**。

1.17.0 で入った `Process.alive_state`（`:alive` / `:dead` / `:unknown`）で分岐し、
説明を分ける（`DaemonHealthMethods#assert_pid_alive!`）。

⚠ **`:unknown` も NG のままにする。**モロヘイヤのデーモンは `/health` を返すプロセスと
同じユーザーで動くので、触れない＝ **pid が再利用されて他人のプロセスになっている**
＝うちのデーモンは動いていない。**変えるのは「なぜ NG なのか」の説明だけ。**

## gem を上げるだけで効く分

| | |
| --- | --- |
| **#509** | `Daemon#run_stop` が `remove_pid` → `Process.kill` の順だったため、`EPERM` のとき **プロセスは生きたまま・pid ファイルだけ消えて**、次の start が 2 本目を立てていた。⚠ listener / sidekiq / puma の **3 デーモンすべて**が該当。`run_restart` も `run_stop if alive?` だったので、EPERM で停止を飛ばしたまま start へ進む経路があった |
| **#511** | `gem_fresh?` が確かめられなかったときに `true`（＝最新）を返していた。⚠⚠ **`rake bundle:check` は CI のステップ**（[test.yml:48](.github/workflows/test.yml#L48)）なので、**gem 鮮度ゲートが黙って no-op になりうる**状態だった（#4503 と同型） |

## 検証

`rake test` **1014 tests / 0 failures / 0 errors / 318 omissions**（omissions は develop と同数、新規 3 件はすべて実走）。
`rake lint` 通過。`rake bundle:check` は 1.17.0 の新しい `gem_fresh?` でも通ることを手元で確認済み。

## 参考: ginseng-core の CI について分かったこと

⚠ **ginseng-core の CI はテストに到達していなかった。**ワークフロー名が `test` だが
ステップは `bundle:check` / `cert check` / `rubocop` の 3 つだけで、**`rake test` が入っていない**。
赤の実体は `cert check`（`cert/cacert.pem` が古かった）で、lint すら skipped になっていた。
`cacert.pem` を更新して 3 バージョンとも緑にしたうえで pooza/ginseng-core#508 へ書いてある。