### PR TITLE
画像アップロードの 401 がアラート抑止をすり抜けるのを止める

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,10 +42,10 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-fediverse.git
-  revision: dae831dbce6871c1465851dc3c6df925dda99da3
+  revision: 8031dd9ccef1aea11b73af312de429e37375bfe9
   branch: main
   specs:
-    ginseng-fediverse (1.8.27)
+    ginseng-fediverse (1.8.28)
 
 GIT
   remote: https://github.com/pooza/ginseng-piefed.git

--- a/app/lib/mulukhiya/controller/mastodon_controller.rb
+++ b/app/lib/mulukhiya/controller/mastodon_controller.rb
@@ -203,6 +203,14 @@ module Mulukhiya
     # ⚠ **413 を silent_statuses に並べない** (#4537)。ここへ来る時点で 413 は
     # 下の分岐で処理済みなので効かず、並べてあると「413 も抑止対象」と誤読する。
     # 401 の抑止は handle_gateway_error の既定に含まれている。
+    #
+    # ⚠ **このメソッドに届くかどうかは gem 側の実装に握られている** (#4594)。
+    # ginseng-fediverse 1.8.28 より前の `MastodonService#upload` は上流の
+    # `GatewayError` を `ValidateError` に詰め替えていたため、呼び出し元の
+    # `rescue Ginseng::GatewayError` を素通りし、401 の抑止も下の 413 分岐も
+    # **一度も到達していなかった**（ボットの無効トークン連打がそのまま管理者への
+    # アラートメールになった）。境界は
+    # `test/unit/service/mastodon_upload_error_boundary.rb` で押さえてある。
     def handle_upload_gateway_error(error)
       return handle_gateway_error(error) unless error.source_status == 413
       @renderer.message = {error: 'アップロードしたファイルがサーバーの上限サイズを超過しています。'}

--- a/test/unit/controller/gateway_error_transparency.rb
+++ b/test/unit/controller/gateway_error_transparency.rb
@@ -154,6 +154,48 @@ module Mulukhiya
       )
     end
 
+    # 画像アップロード (POST /api/:version/media) の失敗 (#4594)。
+    #
+    # ⚠ ここが通るのは **ginseng-fediverse 1.8.28 以降**。それ以前は
+    # MastodonService#upload が上流の GatewayError を ValidateError に詰め替えて
+    # いたため、source_status ごと失われて以下がすべて到達しなかった
+    # (pooza/ginseng-fediverse#246)。モロヘイヤ側のコードだけ読んでも
+    # 気づけない類なので、経路を正で押さえておく。
+    def test_upload_alert_is_suppressed_for_unauthorized
+      error = build_error(401, {error: 'The access token is invalid'}.to_json)
+
+      assert_false(alerted?(error) {upload_controller.handle_upload_gateway_error(error)})
+    end
+
+    # 413 はユーザーのファイルサイズ超過。モロヘイヤ側の文言を出し alert しない。
+    def test_upload_size_limit_returns_own_message
+      controller = upload_controller
+      error = build_error(413, '<html><body>413 Request Entity Too Large</body></html>')
+
+      assert_false(alerted?(error) {controller.handle_upload_gateway_error(error)})
+      assert_equal(413, @upload_renderer.status)
+      assert_includes(fetch(@upload_renderer.message, 'error'), '上限サイズを超過')
+    end
+
+    # ⚠ 黙らせるのは 401 / 413 だけ。上流の 5xx まで抑止すると、
+    # 「アップロードが全滅している」を Sentry で拾えなくなる。
+    def test_upload_alert_fires_for_server_error
+      error = build_error(500, {error: 'Internal Server Error'}.to_json)
+
+      assert_true(alerted?(error) {upload_controller.handle_upload_gateway_error(error)})
+    end
+
+    # クライアントへ返るのは上流のステータス。ValidateError の 422 ではない。
+    def test_upload_passes_upstream_status_through
+      controller = upload_controller
+      error = build_error(422, {error: 'Validation failed: File type is invalid'}.to_json)
+
+      controller.handle_upload_gateway_error(error)
+
+      assert_equal(422, @upload_renderer.status)
+      assert_equal('Validation failed: File type is invalid', fetch(@upload_renderer.message, 'error'))
+    end
+
     def test_user_fault_codes_covers_known_misskey_codes
       ['TOO_MANY_DRAFTS', 'ALREADY_FAVORITED', 'NO_SUCH_NOTE', 'MAX_FILE_SIZE_EXCEEDED'].each do |code|
         assert_includes(MisskeyController::USER_FAULT_CODES, code)
@@ -161,6 +203,15 @@ module Mulukhiya
     end
 
     private
+
+    # アップロード経路は MastodonController が持つ。renderer は差し替えた側を
+    # @upload_renderer で握っておく（公開アクセサが無いため）。
+    def upload_controller
+      controller = MastodonController.new!
+      @upload_renderer = Ginseng::Web::JSONRenderer.new
+      controller.instance_variable_set(:@renderer, @upload_renderer)
+      return controller
+    end
 
     def build_error(code, body)
       error = Ginseng::GatewayError.new("Bad response #{code}")

--- a/test/unit/service/mastodon_upload_error_boundary.rb
+++ b/test/unit/service/mastodon_upload_error_boundary.rb
@@ -1,0 +1,72 @@
+module Mulukhiya
+  # gem 境界のテスト (#4594)。
+  #
+  # `MastodonService#upload` が上流の失敗をどの例外クラスで返してくるかは、
+  # モロヘイヤのアラート抑止が効くかどうかを直接左右する。かつて
+  # ginseng-fediverse は `GatewayError` を `ValidateError` に詰め替えており、
+  # `mastodon_controller.rb` の `rescue Ginseng::GatewayError` を素通りしていた
+  # (pooza/ginseng-fediverse#246)。その結果 401 の抑止も 413 の文言も一度も
+  # 到達せず、ボットの無効トークン連打が管理者へのアラートメールになった。
+  #
+  # ⚠ `gateway_error_transparency` の `handle_upload_gateway_error` 側テストは
+  # gem を通らないので、この退行を捕まえられない。**gem が何を投げてくるか**を
+  # 押さえるのはこのファイルの役目。bundle update で黙って壊れる類なので、
+  # 上流の実装ではなく境界の契約として残す。
+  class MastodonUploadErrorBoundaryTest < TestCase
+    # 上流のレスポンスを添えた GatewayError を投げる http のスタブ。
+    class FailingHTTP
+      Response = Struct.new(:code, :body)
+
+      def initialize(code, body)
+        @response = Response.new(code, body)
+      end
+
+      def upload(*)
+        error = Ginseng::GatewayError.new("Bad response #{@response.code}")
+        error.response = @response
+        raise error
+      end
+    end
+
+    def upload(code, body = '{}')
+      service = Ginseng::Fediverse::MastodonService.new(Ginseng::URI.parse('https://precure.ml/'))
+      service.instance_variable_set(:@http, FailingHTTP.new(code, body))
+      return service.upload('/path/to/image.jpg')
+    end
+
+    # 眼目。これが GatewayError でないと controller の rescue に掛からない。
+    def test_upload_failure_is_a_gateway_error
+      assert_raise(Ginseng::GatewayError) {upload(401)}
+    end
+
+    # ⚠ ValidateError は RequestError の子で GatewayError の子ではない。
+    def test_upload_failure_is_not_a_validate_error
+      error = assert_raise(Ginseng::GatewayError) {upload(401)}
+
+      assert_false(error.is_a?(Ginseng::ValidateError))
+    end
+
+    # source_status が取れないと silent_statuses の判定ができない。
+    def test_source_status_reaches_the_controller
+      error = assert_raise(Ginseng::GatewayError) {upload(401)}
+
+      assert_equal(401, error.source_status)
+    end
+
+    # 413 は「上限サイズ超過」の利用者向け文言の分岐条件。
+    def test_size_limit_status_reaches_the_controller
+      error = assert_raise(Ginseng::GatewayError) {upload(413)}
+
+      assert_equal(413, error.source_status)
+    end
+
+    # 上流が返した理由もプロキシの中で失われないこと。
+    def test_upstream_reason_reaches_the_controller
+      error = assert_raise(Ginseng::GatewayError) do
+        upload(422, {error: 'Validation failed: File type is invalid'}.to_json)
+      end
+
+      assert_equal('Validation failed: File type is invalid', error.source_body['error'])
+    end
+  end
+end


### PR DESCRIPTION
Fixes #4594

## 経緯

2026-08-17 22:15 から、キュアスタ！本番 (gomander) で `POST /api/v1/media` の 401 が管理者へのアラートメールとして飛び続けた。発生源は Tencent Cloud の分散 IP からのボットで、`/oauth/token` に失敗した無効トークンのままアップロードを連打していた。**上流が 401 を返すのは正常な挙動**であり、モロヘイヤ側には抑止の作りもあったのに、一切効いていなかった。

## 原因

`ginseng-fediverse` の `MastodonService#upload` が上流の `GatewayError` を `ValidateError` に詰め替えていた（pooza/ginseng-fediverse#246）。`ValidateError < RequestError < Error` で `GatewayError` の子ではないため、

1. `mastodon_controller.rb` の `rescue Ginseng::GatewayError` に引っかからない
2. → `handle_upload_gateway_error` / `handle_gateway_error(silent_statuses: [401])` に到達せず、401 抑止が素通り
3. → Sinatra の `error do |e|` に落ちて `e.alert` が無条件で走る

モロヘイヤ側のコードだけ読んでも辿り着けない類（#4589 と同型）。

## 直ったこと

| | 修正前 | 修正後 |
|---|---|---|
| 401 のアラート抑止 | 効かない | 効く |
| 413 の「上限サイズ超過」文言 | **導入以来一度も出ていない** | 出る |
| クライアントへ返るステータス | 常に 422 | 上流のまま |
| 上流のエラー理由 | `"UploadError (Bad response NNN)"` の文字列のみ | JSON ボディを透過 |

## 変更

- `bundle update ginseng-fediverse`（1.8.27 → 1.8.28）
- `test/unit/service/mastodon_upload_error_boundary.rb` を追加（**gem 境界**）
  `handle_upload_gateway_error` 側のテストは gem を通らないので、この退行を捕まえられない。gem が何を投げてくるかを押さえるのはこちらの役目。`bundle update` で黙って壊れる類なので契約として残す。
- `gateway_error_transparency.rb` に `handle_upload_gateway_error` の正テストを追加
  401 が実際に抑止されること / 413 で自前の文言と 413 が返ること / 5xx では黙らないこと / 上流ステータスが透過されること。
- `handle_upload_gateway_error` に、届くかどうかが gem 側に握られている旨の注意書きを追加。

`1023 tests, 1421 assertions, 0 failures, 0 errors` / rubocop 通過。

## 別件（インフラ層）

ボット自体はレンジ単位でのブロックが必要。UA も送信元 IP も毎回変わるが、送信元は Tencent Cloud (AS132203 / AS45090 / AS139341) に収まっている。chubo2 側で扱う。