### PR TITLE
chore: RuboCop 設定と規約の正本を ginseng-style へ寄せる (#4601)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,9 +11,6 @@ AllCops:
   Exclude:
     - bin/diag/**/*
   TargetRubyVersion: 4.0
-# モロヘイヤ固有の緩和。assert_path_exists への言い換えを強制しない。
-Minitest/RefutePathExists:
-  Enabled: false
 Sequel:
   Exclude:
     - '*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,124 +1,19 @@
+# 正本は pooza/ginseng-style の config/rubocop.yml。ここにはモロヘイヤ固有の差分だけを書く。
+# ⚠ 共通に見える緩和をここに足さないこと。共通化したい場合は pooza/ginseng-style に Issue を立てる。
+# ⚠ `bundle exec rubocop` で実行すること（inherit_gem は gem のパス解決に Bundler を使う）。
+inherit_gem:
+  ginseng-style: config/rubocop.yml
+
 plugins:
-  - rubocop-performance
-  - rubocop-minitest
-  - rubocop-rake
   - rubocop-sequel
 
 AllCops:
-  AllowSymlinksInCacheRootDirectory: true
-  DisplayCopNames: true
   Exclude:
-    - '**/._*'
-    - '**/.git/**/*'
-    - public/**/*
-    - config/**/*
-    - tmp/**/*
-    - '**/old/**/*'
     - bin/diag/**/*
-  Include:
-    - '**/*.rb'
-    - '**/Rakefile'
-    - '**/config.ru'
-  NewCops: enable
   TargetRubyVersion: 4.0
-Layout/ArgumentAlignment:
-  EnforcedStyle: with_fixed_indentation
-Layout/ArrayAlignment:
-  EnforcedStyle: with_fixed_indentation
-Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-Layout/EndAlignment:
-  EnforcedStyleAlignWith: variable
-Layout/EndOfLine:
-  EnforcedStyle: lf
-Layout/FirstArgumentIndentation:
-  EnforcedStyle: consistent
-Layout/FirstArrayElementIndentation:
-  EnforcedStyle: consistent
-Layout/FirstHashElementIndentation:
-  EnforcedStyle: consistent
-Layout/LineContinuationLeadingSpace:
-  EnforcedStyle: leading
-Layout/LineEndStringConcatenationIndentation:
-  EnforcedStyle: indented
-Layout/LineLength:
-  Exclude:
-    - test/**/*
-  Max: 100
-Layout/MultilineMethodCallIndentation:
-  EnforcedStyle: indented
-Layout/MultilineOperationIndentation:
-  EnforcedStyle: indented
-Layout/ParameterAlignment:
-  EnforcedStyle: with_fixed_indentation
-Layout/SpaceBeforeBlockBraces:
-  EnforcedStyle: space
-Layout/SpaceInsideBlockBraces:
-  EnforcedStyle: no_space
-  EnforcedStyleForEmptyBraces: no_space
-  SpaceBeforeBlockParameters: false
-Layout/SpaceInsideHashLiteralBraces:
-  EnforcedStyle: no_space
-Lint/AssignmentInCondition:
-  Enabled: false
-Lint/UnusedMethodArgument:
-  Enabled: false
-Metrics/AbcSize:
-  Exclude:
-    - test/**/*
-  Max: 30
-Metrics/BlockLength:
-  Exclude:
-    - test/**/*
-    - '**/contract/*'
-    - '**/controller/*'
-    - app/task/**/*.rb
-    - '*.gemspec'
-Metrics/ClassLength:
-  Exclude:
-    - test/**/*
-    - '**/contract/*'
-    - '**/controller/*'
-    - '**/service/*'
-  Max: 200
-Metrics/CyclomaticComplexity:
-  Exclude:
-    - test/**/*
-    - '**/contract/*'
-  Max: 10
-Metrics/MethodLength:
-  Exclude:
-    - test/**/*
-  Max: 20
-Metrics/ModuleLength:
-  Exclude:
-    - test/**/*
-    - '**/contract/*'
-    - '**/controller/*'
-    - '**/service/*'
-  Max: 200
-Metrics/PerceivedComplexity:
-  Exclude:
-    - test/**/*
-    - '**/contract/*'
-  Max: 10
-Minitest/MultipleAssertions:
-  Enabled: false
+# モロヘイヤ固有の緩和。assert_path_exists への言い換えを強制しない。
 Minitest/RefutePathExists:
   Enabled: false
-Minitest/ReturnInTestMethod:
-  Enabled: false
-Minitest/TestFileName:
-  Enabled: false
-Naming/RescuedExceptionsVariableName:
-  PreferredName: e
-Rake:
-  Exclude:
-    - '*'
-  Include:
-    - Rakefile
-    - '*.rake'
-    - app/task/**/*.rb
 Sequel:
   Exclude:
     - '*'
@@ -128,44 +23,4 @@ Sequel:
 Sequel/ConcurrentIndex:
   Enabled: false
 Sequel/IrreversibleMigration:
-  Enabled: false
-Style/AsciiComments:
-  Enabled: false
-Style/ConditionalAssignment:
-  Enabled: false
-Style/Documentation:
-  Enabled: false
-Style/EmptyMethod:
-  EnforcedStyle: expanded
-Style/FormatString:
-  EnforcedStyle: percent
-Style/FormatStringToken:
-  EnforcedStyle: template
-Style/FrozenStringLiteralComment:
-  Enabled: false
-Style/IdenticalConditionalBranches:
-  Exclude:
-    - test/**/*
-Style/IfUnlessModifier:
-  Exclude:
-    - test/**/*
-Style/RedundantReturn:
-  Enabled: false
-Style/RescueModifier:
-  Enabled: false
-Style/RescueStandardError:
-  Enabled: false
-Style/StringLiterals:
-  EnforcedStyle: single_quotes
-Style/SymbolArray:
-  EnforcedStyle: brackets
-Style/TrailingCommaInArguments:
-  EnforcedStyleForMultiline: comma
-Style/TrailingCommaInArrayLiteral:
-  EnforcedStyleForMultiline: comma
-Style/TrailingCommaInHashLiteral:
-  EnforcedStyleForMultiline: comma
-Style/WordArray:
-  EnforcedStyle: brackets
-Style/YodaCondition:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -29,14 +29,13 @@ gem 'sidekiq', '~>8.1'
 gem 'sidekiq-scheduler', '~>6.0.1'
 group :development do
   gem 'bundler-audit'
+  # RuboCop 設定の正本。本体と minitest/performance/rake プラグインもこの gem が抱える。
+  gem 'ginseng-style', github: 'pooza/ginseng-style', branch: 'main', require: false
   gem 'ostruct' # https://github.com/pooza/mulukhiya-toot-proxy/issues/4229
   gem 'rack-test'
   gem 'rails-erb-lint'
   gem 'ricecream'
-  gem 'rubocop'
-  gem 'rubocop-minitest'
-  gem 'rubocop-performance'
-  gem 'rubocop-rake'
+  # ⚠ rubocop-sequel はモロヘイヤ固有のプラグインなので、正本ではなくここに置く。
   gem 'rubocop-sequel'
   gem 'slim_lint'
   gem 'test-unit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,7 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-style.git
-  revision: f66220bd71fe08cedbfdb797e022c5b33f98af91
+  revision: 2474936f5598640c9cf8464f71195c2bb03e4309
   branch: main
   specs:
     ginseng-style (1.0.0)
@@ -390,9 +390,9 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.38.0, < 2.0)
-    rubocop-performance (1.26.1)
+    rubocop-performance (1.27.0)
       lint_roller (~> 1.1)
-      rubocop (>= 1.75.0, < 2.0)
+      rubocop (>= 1.89.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
     rubocop-rake (0.7.1)
       lint_roller (~> 1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,17 @@ GIT
       redis-client
 
 GIT
+  remote: https://github.com/pooza/ginseng-style.git
+  revision: f66220bd71fe08cedbfdb797e022c5b33f98af91
+  branch: main
+  specs:
+    ginseng-style (1.0.0)
+      rubocop
+      rubocop-minitest
+      rubocop-performance
+      rubocop-rake
+
+GIT
   remote: https://github.com/pooza/ginseng-web.git
   revision: 7f0afdc237786e96e7f847e052bb76246a317bf2
   branch: main
@@ -485,6 +496,7 @@ DEPENDENCIES
   ginseng-piefed!
   ginseng-postgres!
   ginseng-redis!
+  ginseng-style!
   ginseng-web!
   ginseng-youtube!
   icalendar
@@ -498,10 +510,6 @@ DEPENDENCIES
   rails-erb-lint
   ricecream
   rspotify!
-  rubocop
-  rubocop-minitest
-  rubocop-performance
-  rubocop-rake
   rubocop-sequel
   ruby-progressbar
   ruby-vips

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1367,21 +1367,14 @@ capsicum 側で先行運用しており、v1.18 のレビューでは 5 観点�
 
 5観点並列レビュー導入（5.19.0〜）以降、レビュー由来の小粒 Issue（仕様補足・docs 修正・単発バリデーション）が大量に発生するようになり、件数では実態を反映しなくなった。**サイズラベル + 重み予算**で管理する。
 
-#### サイズラベル
+#### サイズラベルと重み予算
 
-| ラベル | 想定差分 | 重み |
-| --- | --- | --- |
-| `size:S` | 50 行未満 / 単発バリデーション・小バグ修正・docs 修正 | 1 |
-| `size:M` | 50〜200 行 / 新メソッド・リファクタ単位・契約変更 | 3 |
-| `size:L` | 200 行超 / 新エンドポイント・スキーマ変更・複数ファイル横断 | 8 |
+⚠ **正本は [pooza/ginseng-style](https://github.com/pooza/ginseng-style) の `docs/workflow.md`**（`size:S` = 1 / `size:M` = 3 / `size:L` = 8、1 マイルストーンの目安 20〜25 重み）。
 
-新規 Issue 起票時にいずれかを付ける。既存 Issue にも遡及付与する。
+モロヘイヤ固有の補足:
 
-#### 重み予算
-
-- 1 マイルストーンの目安: **20〜25 重み**（従来「10 件前後」と接続する感覚値。M を基準に S が混在する想定）
+- 目安の 20〜25 は、従来「10 件前後」と接続する感覚値（M を基準に S が混在する想定）
 - 上限を超えそうな Issue は次のマイナーバージョンへ送る（緑送り扱い）
-- 計画書は作成せず、Issue ＋ マイルストーン ＋ 重み合計で管理する
 
 #### 主軸宣言（任意）
 
@@ -1566,12 +1559,17 @@ SSH経由で操作可能。接続情報は `~/.ssh/config` で管理（リポジ
 
 ## コーディング規約
 
-- rubocop, slim_lint, erb_lint に準拠
-- 機能追加・バグ修正には対応するテストを書くこと（CIで実行可能な範囲で。DB依存・外部API依存のテストは無理に書かなくてよい）
-- テスト: test-unit (Mulukhiya::TestCase 基底クラス)
-- モック: WebMock (`require 'webmock/test_unit'` でtest-unitと統合済み。デフォルトはネット許可、モック使用テストで `WebMock.disable_net_connect!` を明示呼出)
-- 設定アクセス: `config['/path/to/key']` (Ginsengのスラッシュ記法)
-- ハンドラー設定: `handler_config(:key)` (5.0でシンボル記法に統一完了、ネストはYAML構造で表現)
+⚠ **Ruby の書き方・テストの基本方針・表記規約の正本は [pooza/ginseng-style](https://github.com/pooza/ginseng-style) の `docs/`。** RuboCop 設定も同リポジトリの `config/rubocop.yml` を `inherit_gem` している（モロヘイヤの `.rubocop.yml` には固有の差分だけがある）。以下はモロヘイヤ固有の項目だけを置く。
+
+- `docs/ruby.md` — 暗黙の return を使わない／論理的 2 スペース／`return` に多行チェインを繋がない理由／`disable?` パターン／文字列のエンコーディング
+- `docs/writing.md` — 用語・パスとキーの書き方・⚠ マーカーの使い方
+- `docs/workflow.md` — Issue 駆動・ブランチ・サイズラベルと重み予算・`ginseng-*` の変更手順
+
+### モロヘイヤ固有
+
+- slim_lint, erb_lint にも準拠する（`rake lint` に含まれる）
+- テストの基底クラスは `Mulukhiya::TestCase`
+- ハンドラー設定: `handler_config(:key)`（5.0でシンボル記法に統一完了、ネストはYAML構造で表現）
 
 ### テスト作成ガイド
 
@@ -1616,17 +1614,10 @@ CIでは `config/local.yaml` に `controller: mastodon|misskey` のみ設定さ�
 
 ### RuboCopに含まれない個人規約
 
-以下はユーザーから都度指示される。指示があり次第ここに追記する。
-
-- メソッド末尾でも `return` を省略しない（暗黙のreturnを使わない）
-- インデントは常に2スペース。見栄えのための位置揃え（代入の右辺にcase/if式を置いて深くインデントする等）は使わない。`x = case ...` ではなく、各分岐内で個別に代入する
+⚠ **正本は [pooza/ginseng-style](https://github.com/pooza/ginseng-style) の `docs/ruby.md`。** 新しい指示が出たらそちらへ追記する（モロヘイヤだけの話ではないため）。
 
 ### ドキュメント表記規約
 
-- **設定ファイルのパス**: ディレクトリを含めて表記する（`local.yaml` → `config/local.yaml`）
-- **設定キーの参照**: Ginseng のスラッシュ記法で表記する（`service:` や `sidekiq.auth.user` ではなく `/service`、`/sidekiq/auth/user`）
-- **サーバーの呼称**: 「インスタンス」ではなく「サーバー」を使う
-- **UI の呼称**: 「UI」ではなく「WebUI」を使う
-- **IP の表記**: 単独で使わず「IP アドレス」と表記する。**理由: 「IP」はプロトコルの名前であって、アドレスを指す語ではない。**略した結果べつの概念を指してしまう省略は避ける（JavaScript を Java と呼んではいけないのと同じ）。⚠ **文書では例外なく守る。**コード内のコメントは目を瞑るが、揃えられるなら揃える
+⚠ **正本は [pooza/ginseng-style](https://github.com/pooza/ginseng-style) の `docs/writing.md`**（用語・パスとキーの書き方・⚠ マーカーの使い方・クロスリポジトリの Issue 参照）。以下はモロヘイヤ固有の呼称だけを置く。
+
 - **ボットの呼称**: 英名（`info_bot` 等）ではなく日本語の役割名（「お知らせボット」等）を使う
-- **ファイル参照**: サンプルファイルやテンプレート等への参照はマークダウンリンクにする


### PR DESCRIPTION
Closes #4601

RuboCop 設定と規約の正本を [pooza/ginseng-style](https://github.com/pooza/ginseng-style) へ寄せる。

## 変更

| ファイル | 内容 |
| --- | --- |
| `.rubocop.yml` | 171 行 → 26 行。`inherit_gem` で正本を継承し、固有の差分だけ残す |
| `Gemfile` | development group から `rubocop` / `rubocop-minitest` / `rubocop-performance` / `rubocop-rake` を外し、`ginseng-style` を追加。⚠ `rubocop-sequel` は固有なので残す |
| `docs/CLAUDE.md` | 重複していた規約 3 節をポインタに置換 |

モロヘイヤ側に残した固有の差分は 4 つ。

- `AllCops/TargetRubyVersion: 4.0`
- `AllCops/Exclude` の `bin/diag/**/*`
- `rubocop-sequel` プラグインと `Sequel/*`
- `Minitest/RefutePathExists`（固有の緩和）

## 検証

- ✅ `bundle exec rubocop` … **471 files / no offenses**。移行前と同一
- ✅ cop のロードも同一 … Minitest 55 / Performance 52 / Rake 5 / Sequel 6（利用側の `plugins` は継承分を潰さず合成される）
- ✅ `rake lint` が通る（erb / slim / rubocop / yaml / bundler-audit）
- `Gemfile.lock` の差分は `rubocop*` が直接依存から `ginseng-style` の依存へ移っただけ

## ⚠ 注意

`inherit_gem` は gem のパス解決に Bundler を使うので、**`bundle exec rubocop` で実行する**必要がある。`.rubocop.yml` の先頭にもコメントで書いた。CI（`.github/workflows`）とローカルの `rake lint` はどちらも `bundle exec` 経由なので影響なし。

## docs で残したもの・移したもの

内容を持たずポインタにしたのは「RuboCopに含まれない個人規約」「ドキュメント表記規約」「サイズラベルと重み予算」。⚠ **モロヘイヤ固有の記述は残している** — `handler_config(:key)` 記法、`Mulukhiya::TestCase`、CI スキップ条件、Handler 経由の間接 DB 依存、ボットの呼称、重み予算の経緯、5 観点レビューの観点表。

関連: pooza/ginseng-style#1（利用側リポジトリ全体のロールアウト）
