### PR TITLE
feat: Slack 互換 webhook でリクエストごとの公開範囲を受け付ける (#4599)

### DIFF
--- a/app/lib/mulukhiya/contract/slack_webhook_contract.rb
+++ b/app/lib/mulukhiya/contract/slack_webhook_contract.rb
@@ -3,6 +3,14 @@ module Mulukhiya
     params do
       required(:digest).value(:string)
       required(:text).value(:string)
+      # 公開範囲はリクエストごとに指定できる (#4599)。未指定ならアカウント設定
+      # (/webhook/visibility) の既定に倒れる。
+      #
+      # ⚠ **値の妥当性はここで見ない。**未知の値は Parser.visibility_name が
+      # public へ丸めるので、契約で弾くと「既定へ倒す」設計と二重管理になる。
+      # ⚠ **maybe にしてあるのは後方互換のため。**`"visibility": null` を送っていた
+      # クライアントが、この項目を足したことで 422 になるのを避ける。
+      optional(:visibility).maybe(:string)
     end
   end
 end

--- a/app/lib/mulukhiya/webhook_payload/slack_webhook_payload.rb
+++ b/app/lib/mulukhiya/webhook_payload/slack_webhook_payload.rb
@@ -55,6 +55,7 @@ module Mulukhiya
     def values
       values = {status_field => text}
       values[spoiler_field] = header if header
+      values[visibility_field] = raw['visibility'] if raw['visibility'].present?
       values['attachments'] = images
       return values
     end

--- a/docs/api.md
+++ b/docs/api.md
@@ -1323,6 +1323,38 @@ Webhook エンドポイントは `/mulukhiya/webhook` 配下で提供される�
 | `/mulukhiya/webhook/{digest}` | POST | Webhook 検証 | Slack 互換ペイロードを処理 |
 | `/mulukhiya/webhook/admin` | POST | HMAC-SHA256 / Misskey Secret | 管理 Webhook（アカウント承認等） |
 
+##### POST /mulukhiya/webhook/{digest}
+
+Slack 互換のペイロードを投稿に変換する。`text` / `blocks` / `attachments` に対応。
+
+| 名前 | 型 | 必須 | 説明 |
+|------|-----|------|------|
+| `text` | string | 必須 | 本文。Slack のリンク記法 `<url\|label>` は Markdown リンクへ変換される |
+| `spoiler_text` | string | 任意 | CW（`blocks` を使う場合は `header` ブロックが優先） |
+| `blocks` | array | 任意 | Slack Block Kit。`header` / `section` / `context` / `rich_text` / `image` を解釈 |
+| `attachments` | array | 任意 | Slack legacy attachments。`image_url` / `thumb_url` は添付画像として取り込む |
+| `visibility` | string | 任意 | この投稿の公開範囲（5.34.0〜、#4599） |
+
+`visibility` を省略すると、アカウント設定（WebUI「Slack互換webhook」セクション、`/webhook/visibility`）の
+既定が使われる。**未知の値は `public` へ丸められる**（エラーにはしない）。
+
+| 指定 | Mastodon | Misskey |
+|------|----------|---------|
+| `public` | `public` | `public` |
+| `unlisted` | `unlisted` | `home` |
+| `private` | `private` | `followers` |
+| `direct` | `direct` | `specified` |
+
+⚠ **SNS 側の呼称（`home` / `followers` / `specified`）でも指定できる**が、`public` / `unlisted` /
+`private` / `direct` の 4 語は**両系で同じ意味に解決される**ので、こちらを使うほうが移植性が高い。
+
+```json
+{
+  "text": "告知です",
+  "visibility": "public"
+}
+```
+
 ### Annict 連携（エピソードブラウザ）
 
 Annict（アニメ視聴記録サービス）と連携し、作品・エピソードの検索やタグ付けを行う。

--- a/test/unit/lib/slack_webhook_visibility.rb
+++ b/test/unit/lib/slack_webhook_visibility.rb
@@ -1,0 +1,83 @@
+module Mulukhiya
+  # Slack 互換 webhook のリクエストごとの公開範囲 (#4599)。
+  #
+  # ⚠ **SlackWebhookPayloadTest とは分けてある。**あちらは `SlackService.config?`
+  # を前提に disable? するので、Slack を設定していない環境ではクラスごと omission
+  # になる。ここで見るのは「payload が組む Hash」と「契約が受け付ける形」だけで
+  # Slack の設定を必要としないため、常に実走させる (#4503 の教訓)。
+  class SlackWebhookVisibilityTest < TestCase
+    # ⚠ **Webhook#post が `body[visibility_field] || visibility` で既定へ倒す**ので、
+    # payload 側は「指定が来たときだけキーを載せる」のが正しい。載せてしまうと
+    # アカウント設定の既定が上書きされる。
+    def test_values_includes_requested_visibility
+      values = payload(visibility: 'unlisted').values
+
+      assert_equal('unlisted', values[visibility_field])
+    end
+
+    def test_values_omits_visibility_when_not_given
+      assert_not_operator(payload.values, :key?, visibility_field)
+    end
+
+    # 空文字は「指定なし」として扱う。ここでキーを載せると visibility_name が
+    # public へ丸めてしまい、アカウント設定の既定を黙って踏み潰す。
+    def test_values_omits_blank_visibility
+      assert_not_operator(payload(visibility: '').values, :key?, visibility_field)
+    end
+
+    def test_values_keeps_text_and_spoiler
+      values = payload(visibility: 'private').values
+
+      assert_equal('本文', values[status_field])
+      assert_equal('ネタバレ注意', values[spoiler_field])
+    end
+
+    def test_contract_accepts_visibility
+      assert_empty(contract_errors('visibility' => 'private'))
+    end
+
+    # ⚠ **後方互換。**この項目を足したことで、`"visibility": null` を送っていた
+    # クライアントが 422 になってはいけない。
+    def test_contract_accepts_null_visibility
+      assert_empty(contract_errors('visibility' => nil))
+    end
+
+    def test_contract_accepts_missing_visibility
+      assert_empty(contract_errors)
+    end
+
+    # ⚠ **未知の値は契約で弾かず、既定へ丸める。**この保証があるので、
+    # SlackWebhookContract 側で値の妥当性を見る必要がない。
+    def test_unknown_visibility_falls_back_to_public
+      assert_equal(
+        parser_class.visibility_name(:public),
+        parser_class.visibility_name('bogus'),
+      )
+    end
+
+    def test_known_visibility_is_preserved
+      [:public, :unlisted, :private, :direct].each do |name|
+        assert_equal(
+          parser_class.visibility_name(name),
+          parser_class.visibility_name(parser_class.visibility_name(name)),
+        )
+      end
+    end
+
+    private
+
+    def payload(values = {})
+      return SlackWebhookPayload.new({
+        'text' => '本文',
+        'spoiler_text' => 'ネタバレ注意',
+      }.merge(values.deep_stringify_keys))
+    end
+
+    def contract_errors(values = {})
+      return SlackWebhookContract.new.exec({
+        'digest' => 'a' * 64,
+        'text' => '本文',
+      }.merge(values))
+    end
+  end
+end


### PR DESCRIPTION
Fixes #4599

## 何が起きていたか

`Webhook#post` は以前から「来れば尊重する」形で書かれていた:

```ruby
body[visibility_field] = parser_class.visibility_name(body[visibility_field] || visibility)
```

落としていたのは `SlackWebhookPayload#values` で、`status` / `spoiler_text` / `attachments` しか返していなかった。

⚠ **`Webhook#command` が出力する curl サンプルは `{text:, visibility:}` を含む**ので、**効くように見えて効かない**状態だった。

## 入れたもの

- `SlackWebhookContract` に `optional(:visibility)` を追加
  - ⚠ **`maybe(:string)` にしたのは後方互換のため。**`"visibility": null` を送っていたクライアントが、この項目を足したことで 422 になってはいけない
  - ⚠ **値の妥当性は契約で見ない。**未知の値は `Parser.visibility_name` が `public` へ丸める既存の保証があり、契約でも弾くと二重管理になる
- `SlackWebhookPayload#values` は **指定が来たときだけ**キーを載せる
  - ⚠ 常に載せると `body[visibility_field] || visibility` の右辺に到達せず、**アカウント設定（`/webhook/visibility`）の既定を黙って踏み潰す**。空文字も「指定なし」扱い
- `docs/api.md` に `POST /mulukhiya/webhook/{digest}` のボディ仕様を追加
  - `public` / `unlisted` / `private` / `direct` の 4 語が **Mastodon / Misskey 両系で同じ意味に解決される**ことを表にした（Misskey では `home` / `followers` / `specified` へ写る）

## テスト

新規 `test/unit/lib/slack_webhook_visibility.rb`（8 本）。

⚠ **既存の `SlackWebhookPayloadTest` に相乗りしなかったのは、あちらが `SlackService.config?` で `disable?` するから。**Slack を設定していない CI ではクラスごと omission になり、ゲートを守れない（#4503 の「守れているつもりの緑」）。ここで見るのは payload が組む Hash と契約が受け付ける形だけで、Slack の設定を必要としない。

- 指定が values に載る / 未指定・空文字では載らない（＝既定へ倒れる）
- 契約が文字列・null・未指定のいずれも受け付ける
- 未知の値が `public` へ丸められる・既知の 4 語が冪等に解決される

`rake test` は **1023 → 1032 tests / 0 failures / 0 errors**、omissions は **318 のまま不変**。`rake lint` 通過。