### PR TITLE
番組表: next_on を「書いたとおりの日付」で読む (#4558)

### DIFF
--- a/app/lib/mulukhiya/program.rb
+++ b/app/lib/mulukhiya/program.rb
@@ -311,6 +311,12 @@ module Mulukhiya
     # (JST) へ変換された Time が返る。そのまま strftime すると
     # `2026-08-08 23:30:00` が 2026-08-09 になってしまうので、UTC 側で日付を採る
     # = 書いたとおりの日付を拾う (#4537)。
+    #
+    # ⚠ **YAML の next_on はここへ来る前に String へ正規化されている**
+    # (`ProgramFetcher#parse_yaml`・#4558)。ここでの `getutc` は最後の保険で、
+    # **明示オフセット付きの Time には日付が 1 日ずれる**（materialize 済みの
+    # Time からはゾーンレスと区別できない）。next_on の読み方を直すときは
+    # この層ではなく parse_yaml を触ること。
     def format_date(value)
       return value.strftime('%Y-%m-%d') if value.is_a?(Date) # DateTime も含む
       return value.getutc.strftime('%Y-%m-%d') if value.is_a?(Time)

--- a/app/lib/mulukhiya/program_fetcher.rb
+++ b/app/lib/mulukhiya/program_fetcher.rb
@@ -23,7 +23,21 @@ module Mulukhiya
     PERMITTED_YAML_CLASSES = [Symbol, Date, Time].freeze
     NEXT_ON_KEY = 'next_on'.freeze
     # 先頭の YYYY-MM-DD だけを採る。時刻・ゾーンが続いていてもよい (#4558)。
-    LEADING_DATE_PATTERN = /\A(\d{4}-\d{2}-\d{2})(?:[Tt ].*)?\z/
+    #
+    # ⚠ **後続は「Psych が Time にできる形」だけを許す (PR #4607 の Codex P2)。**
+    # `.*` で受けると `next_on: 2026-08-08 garbage` や `2026-08-08 25:99:99` まで
+    # 日付へ書き換えてしまう。これらは**元は無効な String のままで、
+    # ProgramCalendar が fail-closed していた**もの。書き換えると意図しない話数を
+    # 予告・通知しうるので、**壊れた値は壊れたまま残す**（#4585 の shift_next_on と
+    # 同じ方針）。時・分・秒は範囲まで見る（`25:99:99` を通さないため）。
+    LEADING_DATE_PATTERN = /
+      \A(\d{4}-\d{2}-\d{2})
+      (?:[Tt\ ]\s*
+        (?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d
+        (?:\.\d+)?
+        (?:\s*(?:[Zz]|[+-](?:[01]\d|2[0-3])(?::?[0-5]\d)?))?
+      )?\s*\z
+    /x
 
     def initialize
       @http = HTTP.new

--- a/app/lib/mulukhiya/program_fetcher.rb
+++ b/app/lib/mulukhiya/program_fetcher.rb
@@ -21,6 +21,9 @@ module Mulukhiya
     # エディタ経由なら to_yaml が '2026-08-08' とクォートするので無害。
     # 許可クラスは Ginseng::Config::PERMITTED_YAML_CLASSES に揃えてある。
     PERMITTED_YAML_CLASSES = [Symbol, Date, Time].freeze
+    NEXT_ON_KEY = 'next_on'.freeze
+    # 先頭の YYYY-MM-DD だけを採る。時刻・ゾーンが続いていてもよい (#4558)。
+    LEADING_DATE_PATTERN = /\A(\d{4}-\d{2}-\d{2})(?:[Tt ].*)?\z/
 
     def initialize
       @http = HTTP.new
@@ -151,9 +154,68 @@ module Mulukhiya
 
     def load_from_yaml
       return {} unless yaml_exist?
-      programs = YAML.safe_load_file(YAML_PATH, permitted_classes: PERMITTED_YAML_CLASSES) || {}
+      programs = parse_yaml(File.read(YAML_PATH))
       warm_cache(programs)
       return programs
+    end
+
+    # next_on を「書いたとおりの日付」の String として読む (#4558)。
+    #
+    # ⚠ **Psych が Time にしてしまってからでは、ゾーンレスと明示オフセットを
+    # 区別できない。**ゾーンレスの `2026-08-08 18:00:00` は UTC として読まれた
+    # うえでローカルへ変換され `2026-08-09 03:00:00 +0900` になる。これは
+    # 明示的に `2026-08-09 03:00:00 +09:00` と書いた場合と**同じオブジェクト**で、
+    # `utc?` でも `utc_offset` でも判別できない（実測: どちらも
+    # `utc? == false` / `utc_offset == 32400`）。前者は getutc 側の日付、後者は
+    # 書いたままの日付が正しいので、オブジェクトを見るかぎり両立しない。
+    #
+    # そこで **materialize する前に** AST 上で next_on のスカラーを、先頭の
+    # `YYYY-MM-DD` だけを持つ引用符付きスカラーへ差し替える。時刻もゾーンも
+    # 日付の解釈に関与しなくなり、
+    #
+    #   - `next_on: 2026-08-08 00:30:00 +09:00` が 1 日前へずれる (#4558 項目 2)
+    #   - Time が Redis 往復で `"2026-08-08 18:00:00 +0900"` という無効値に化ける
+    #     (#4558 項目 1。`to_json` は `to_s` 相当なので JSON にすると型が消える)
+    #
+    # の両方が同時に消える。⚠ **`PERMITTED_YAML_CLASSES` から Time を外す方向は
+    # 採らない**（#4537 が塞いだ「クォート忘れで番組表全体が読めなくなる」
+    # footgun が戻る）。ここで潰すのは next_on だけで、他のキーの型は触らない。
+    def parse_yaml(source)
+      # ⚠ Document 単体は to_yaml できない (STREAM-START が無いと Emitter が
+      # 落ちる) ので、Stream として読む。
+      ast = YAML.parse_stream(source)
+      return {} unless ast.children.present?
+      normalize_next_on_nodes(ast)
+      # ⚠ AST を直に to_ruby すると permitted_classes が効かない（無制限の
+      # ToRuby になる）。一度 YAML へ書き戻して safe_load へ通す。
+      return YAML.safe_load(ast.to_yaml, permitted_classes: PERMITTED_YAML_CLASSES) || {}
+    end
+
+    def normalize_next_on_nodes(node)
+      if node.is_a?(Psych::Nodes::Mapping)
+        node.children.each_slice(2) do |key, value|
+          normalize_next_on_scalar(value) if next_on_key?(key)
+        end
+      end
+      node.children&.each {|child| normalize_next_on_nodes(child)}
+      return node
+    end
+
+    def next_on_key?(node)
+      return node.is_a?(Psych::Nodes::Scalar) && node.value == NEXT_ON_KEY
+    end
+
+    # 先頭が YYYY-MM-DD の形をしていない値（`20260808` や `毎週日曜` 等）は
+    # 触らない。妥当性の判定は contract / ProgramCalendar の側にあり、ここで
+    # 壊れた値を別の壊れた値へ書き換えない (#4585 の shift_next_on と同じ方針)。
+    def normalize_next_on_scalar(node)
+      return unless node.is_a?(Psych::Nodes::Scalar)
+      return unless (matches = node.value.match(LEADING_DATE_PATTERN))
+      node.value = matches[1]
+      node.plain = false
+      node.quoted = true
+      node.style = Psych::Nodes::Scalar::SINGLE_QUOTED
+      node.tag = nil
     end
 
     # 読み経路のキャッシュ温め (#4575)。

--- a/test/unit/lib/program_yaml_normalize.rb
+++ b/test/unit/lib/program_yaml_normalize.rb
@@ -1,0 +1,99 @@
+module Mulukhiya
+  # var/program.yaml の next_on 正規化 (#4558)。
+  #
+  # ⚠ **ProgramTest とは分けてある。**あちらは `controller_class.livecure?` が
+  # false だとクラスごと omission になり、CI には var/program.yaml も
+  # /program/urls も無いので常に false（#4585 で踏んだ）。ここで見るのは
+  # 「YAML のテキストをどう読むか」だけで実データも Redis も要らないため、
+  # 常に実走させる（#4503 の「守れているつもりの緑」を作らない）。
+  class ProgramYAMLNormalizeTest < TestCase
+    def setup
+      @fetcher = ProgramFetcher.new
+    end
+
+    # ゾーンレスの手書き。Psych は UTC として読むので、素の strftime では
+    # 翌日になる。書いたとおりの日付が返ること (#4537 の意図)。
+    def test_zoneless_timestamp_keeps_written_date
+      assert_equal('2026-08-08', next_on('2026-08-08 18:00:00'))
+    end
+
+    def test_zoneless_late_night_timestamp_keeps_written_date
+      assert_equal('2026-08-08', next_on('2026-08-08 23:30:00'))
+    end
+
+    # ⚠ **本命の回帰 (#4558 項目 2)。**明示オフセット付きは getutc で 1 日前へ
+    # ずれていた（`2026-08-08 00:30:00 +09:00` → `2026-08-07`）。深夜アニメの枠を
+    # 素直に書くと踏む形。
+    def test_explicit_offset_timestamp_keeps_written_date
+      assert_equal('2026-08-08', next_on('2026-08-08 00:30:00 +09:00'))
+    end
+
+    # 負のオフセットは逆方向へずれていた。
+    def test_negative_offset_timestamp_keeps_written_date
+      assert_equal('2026-08-08', next_on('2026-08-08 22:00:00 -05:00'))
+    end
+
+    def test_iso8601_timestamp_keeps_written_date
+      assert_equal('2026-08-08', next_on('2026-08-08T00:30:00+09:00'))
+    end
+
+    def test_plain_date_becomes_string
+      assert_equal('2026-08-08', next_on('2026-08-08'))
+    end
+
+    def test_quoted_date_is_unchanged
+      assert_equal('2026-08-08', next_on("'2026-08-08'"))
+    end
+
+    # ⚠ **本命の回帰 (#4558 項目 1)。**Time のままキャッシュへ入れると
+    # `to_json` が `to_s` 相当で書き出すため、2 回目以降の読み出しで
+    # `"2026-08-08 18:00:00 +0900"` という日付として読めない値になっていた。
+    # Redis 往復と同じ JSON の往復で値が変わらないこと。
+    def test_survives_json_round_trip
+      programs = parse("a:\n  next_on: 2026-08-08 18:00:00\n")
+
+      assert_equal(programs, JSON.parse(programs.to_json))
+      assert_equal('2026-08-08', JSON.parse(programs.to_json).dig('a', 'next_on'))
+    end
+
+    # 日付として読めない値は触らない。壊れた値を別の壊れた値へ書き換えず、
+    # 判定は contract / ProgramCalendar に任せる。
+    def test_leaves_non_date_scalar
+      assert_equal(20_260_808, next_on('20260808'))
+      assert_equal('毎週日曜', next_on('毎週日曜'))
+    end
+
+    # 実在しない日付も素通し（エディタが「不正」バッジを出す側の担当）。
+    def test_leaves_impossible_date
+      assert_equal('2026-02-31', next_on('2026-02-31'))
+    end
+
+    # ⚠ **潰すのは next_on だけ。**start_time の 60 進数解釈 (`20:30` → 73800) は
+    # Program#coerce_scalars の担当なので、ここで型を変えてはいけない。
+    def test_keeps_other_keys_untouched
+      entry = parse("a:\n  next_on: 2026-08-08\n  start_time: 20:30\n  series: A\n")['a']
+
+      assert_equal(73_800, entry['start_time'])
+      assert_equal('A', entry['series'])
+    end
+
+    def test_entry_without_next_on_is_kept
+      assert_equal({'series' => 'A'}, parse("a:\n  series: A\n")['a'])
+    end
+
+    def test_empty_source_becomes_empty_hash
+      assert_empty(parse(''))
+      assert_empty(parse("---\n"))
+    end
+
+    private
+
+    def parse(source)
+      return @fetcher.send(:parse_yaml, source)
+    end
+
+    def next_on(value)
+      return parse("a:\n  next_on: #{value}\n").dig('a', 'next_on')
+    end
+  end
+end

--- a/test/unit/lib/program_yaml_normalize.rb
+++ b/test/unit/lib/program_yaml_normalize.rb
@@ -68,6 +68,36 @@ module Mulukhiya
       assert_equal('2026-02-31', next_on('2026-02-31'))
     end
 
+    # ⚠ **日付で始まるだけの壊れた値を、有効な日付へ「直して」しまわないこと**
+    # (PR #4607 の Codex P2)。これらは Psych も Time にできず String のまま残る値で、
+    # ProgramCalendar は fail-closed していた。書き換えると意図しない話数を
+    # 予告・通知しうる。
+    def test_leaves_date_with_garbage_suffix
+      assert_equal('2026-08-08 garbage', next_on('2026-08-08 garbage'))
+    end
+
+    def test_leaves_out_of_range_time
+      assert_equal('2026-08-08 25:99:99', next_on('2026-08-08 25:99:99'))
+    end
+
+    # 秒が無い形は Psych も Time にしない（＝日付として確定していない）。
+    def test_leaves_time_without_seconds
+      assert_equal('2026-08-08 18:00', next_on('2026-08-08 18:00'))
+    end
+
+    # ⚠ 逆に、Psych が Time にできる形は取りこぼさないこと。
+    def test_normalizes_fractional_seconds_with_offset
+      assert_equal('2026-08-08', next_on('2026-08-08 18:00:00.123 +09:00'))
+    end
+
+    def test_normalizes_zulu_timestamp
+      assert_equal('2026-08-08', next_on('2026-08-08 18:00:00Z'))
+    end
+
+    def test_normalizes_compact_offset
+      assert_equal('2026-08-08', next_on('2026-08-08t18:00:00+0900'))
+    end
+
     # ⚠ **潰すのは next_on だけ。**start_time の 60 進数解釈 (`20:30` → 73800) は
     # Program#coerce_scalars の担当なので、ここで型を変えてはいけない。
     def test_keeps_other_keys_untouched

--- a/views/program.slim
+++ b/views/program.slim
@@ -240,13 +240,31 @@ html lang='ja' data-theme='light'
           return minutesA < minutesB ? -1 : 1
         }
 
+        // YYYY-MM-DD として実在する日付か (#4558)。
+        // ⚠ Number.isNaN だけでは足りない。Date.UTC(2026, 1, 31) は 3/3 へ
+        // 繰り上がるので NaN にならず、存在しない日付が通ってしまう。
+        // ⚠ 端末のタイムゾーンを混ぜてはいけないので UTC で組む。
+        const isValidDateValue = value => {
+          const text = String(value)
+          if (!/^\d{4}-\d{2}-\d{2}$/.test(text)) return false
+          const [year, month, day] = text.split('-').map(Number)
+          const date = new Date(Date.UTC(year, month - 1, day))
+          return date.getUTCFullYear() === year &&
+            date.getUTCMonth() + 1 === month &&
+            date.getUTCDate() === day
+        }
+
         // まとめコピーの日付見出し。UTC で組んで UTC で曜日を読むので、端末の
         // タイムゾーンによらず next_on の日付そのものの曜日になる。
         // 日付として読めない値はそのまま出す (見出しごと消さない)。
+        //
+        // ⚠ **曜日を付けるのは実在する日付のときだけ (#4558)。**一覧では
+        // 「不正」バッジを出しているのに、コピーした見出しには
+        // `2026-02-31 (火)` と一見もっともらしい曜日が付いていた。
         const formatDateHeading = value => {
+          if (!isValidDateValue(value)) return String(value)
           const [year, month, day] = String(value).split('-').map(Number)
           const date = new Date(Date.UTC(year, month - 1, day))
-          if (Number.isNaN(date.getTime())) return String(value)
           return `${value} (${WEEKDAYS[date.getUTCDay()]})`
         }
 
@@ -407,17 +425,12 @@ html lang='ja' data-theme='light'
             // 日付として読めない next_on。サーバーは fail-closed で通知を出さない
             // ので、一覧でも「過去日」ではなく「不正」として区別する。文字列比較
             // だけだと 2026-02-31 を過去日、2026/08/08 を未来日と誤って読む。
+            // ⚠ 判定の実体は isValidDateValue に 1 本化してある (#4558)。
+            // まとめコピーの見出しと判定がずれると、「一覧では不正なのに
+            // コピーにはそれらしい曜日が付く」が再発する。
             isInvalidNextOn (nextOn) {
               if (!nextOn) return false
-              const value = String(nextOn)
-              if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return true
-              // 実在する日付か。2026-02-31 は Date が 3/3 へ繰り上げるので往復で見る。
-              // ⚠ ここは端末のタイムゾーンを混ぜてはいけないので UTC で組む。
-              const [year, month, day] = value.split('-').map(Number)
-              const date = new Date(Date.UTC(year, month - 1, day))
-              return date.getUTCFullYear() !== year ||
-                date.getUTCMonth() + 1 !== month ||
-                date.getUTCDate() !== day
+              return !isValidDateValue(nextOn)
             },
             // 今日 (JST) を YYYY-MM-DD で。⚠ ブラウザのローカル日付では組まない。
             // ProgramCalendar は next_on を +09:00 固定で解釈するので、国外の端末で


### PR DESCRIPTION
Fixes #4558

## ⚠ Issue の推奨案では項目 2 を閉じられない

Issue は「`load_from_yaml` で coerce 済みを `update_cache` に渡す」を推していたが、**それだと項目 2 が残る**。

`Time` になった**後**では、ゾーンレスと明示オフセットを区別できない（実測）:

| YAML のテキスト | Psych が返す Time | `utc?` | `utc_offset` |
| --- | --- | --- | --- |
| `2026-08-08 18:00:00`（ゾーンレス） | `2026-08-09 03:00:00 +0900` | false | 32400 |
| `2026-08-09 03:00:00 +09:00`（明示） | `2026-08-09 03:00:00 +0900` | false | 32400 |

**同じオブジェクト**になる。前者は `getutc` 側の日付（`2026-08-08`）、後者は書いたままの日付（`2026-08-09`）が正しいので、オブジェクトを見るかぎり両立しない。

## 直し方: materialize する前に潰す

`ProgramFetcher#parse_yaml` を追加し、**AST 上で `next_on` のスカラーを「先頭の `YYYY-MM-DD` だけを持つ引用符付きスカラー」へ差し替えてから** `safe_load` する。時刻もゾーンも日付の解釈に関与しなくなるので、

- **項目 1**（`Time` が `to_json` で `"2026-08-08 18:00:00 +0900"` に化け、2 回目以降の読み出しで無効値になる）
- **項目 2**（`2026-08-08 00:30:00 +09:00` が `2026-08-07` へずれる）

が同時に消える。副産物として Issue が挙げていた「一度入ると save をまたいで `Time` のまま残る」も消える（読んだ時点で String になるため）。

⚠ **AST を直に `to_ruby` すると `permitted_classes` が効かない**（無制限の `ToRuby` になる）ので、一度 YAML へ書き戻して `safe_load` へ通している。
⚠ **潰すのは `next_on` だけ。**`start_time: 20:30` の 60 進数解釈は従来どおり `Program#coerce_scalars` の担当。
⚠ **`PERMITTED_YAML_CLASSES` から `Time` は外さない**（#4537 が塞いだ「クォート忘れで番組表全体が読めなくなる」footgun が戻る）。
⚠ 日付として読めない値（`20260808` / `毎週日曜` / `2026-02-31`）は**触らない**。壊れた値を別の壊れた値へ書き換えない。

`Program#format_date` は最後の保険として残し、「next_on の読み方を直すならこの層ではなく `parse_yaml`」というコメントを足した。

## 項目 3（まとめコピーの曜日）

`formatDateHeading` に往復判定が無く、一覧では「不正」バッジを出しているのに見出しには `2026-02-31 (火)` と**一見もっともらしい曜日**が付いていた（`Date.UTC(2026, 1, 31)` は 3/3 へ繰り上がるので `NaN` にならない）。

判定を `isValidDateValue` へ 1 本化し、`isInvalidNextOn` もそこへ委譲した。⚠ 2 つの判定がずれると同じ症状が再発するため。

## テスト

新規 `test/unit/lib/program_yaml_normalize.rb`（13 本）。

⚠ **`ProgramTest` に相乗りしなかったのは、あちらが `controller_class.livecure?` で `disable?` するから。**CI には `var/program.yaml` も `/program/urls` も無いので常に false で、クラスごと omission になる（#4585 で踏んだ）。ここで見るのは YAML のテキストの読み方だけで、実データも Redis も要らない。

- ゾーンレス / 明示 `+09:00` / 負のオフセット / ISO8601 / 素の日付 / クォート済み → すべて `'2026-08-08'`
- **JSON 往復（＝ Redis キャッシュ表現）で値が変わらない**
- 日付でない値・実在しない日付は素通し / `start_time` の型は不変 / 空ファイルは `{}`

`rake test` は **1023 → 1036 tests / 0 failures / 0 errors**、omissions は **318 のまま不変**。`rake lint` 通過。
⚠ `views/program.slim` は #4578 のため `rake lint` の対象外なので個別に `slim-lint` を掛け、**指摘 54 件で前後不変**（すべて既存の `LineLength`）を確認した。