### PR TITLE
fix: inherit_mode を足して継承した Exclude を取り戻す (#4606)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,13 @@ inherit_gem:
 plugins:
   - rubocop-sequel
 
+# ⚠⚠ inherit_mode が無いと、下の Exclude が継承した配列を**置換する**
+# （マージされない）。config/**/* や、CI が gem を展開する vendor/**/* の除外が
+# 丸ごと消える。⚠ rubocop は緑のまま通るので気づけない（#4606）。
+inherit_mode:
+  merge:
+    - Exclude
+
 AllCops:
   Exclude:
     - bin/diag/**/*


### PR DESCRIPTION
closes #4606

#4602 で `inherit_gem` に移した際、**継承した `AllCops/Exclude` が置換されて消えていた**。`inherit_mode` を足して取り戻す。

## 🔴 何が起きていたか

`inherit_gem` した先で `AllCops/Exclude` を書くと、**マージではなく置換になる**。いまの `.rubocop.yml` は `Exclude: [bin/diag/**/*]` なので、正本が持つ `**/._*` / `**/.git/**/*` / `config/**/*` / `public/**/*` / `tmp/**/*` / `**/old/**/*` / `vendor/**/*` が**すべて効いていなかった**。

`origin/develop` に probe ファイルを置いた実測:

```
config/probe/probe.rb        ← 除外されるべきものが lint 対象に入っていた
tmp/probe/probe.rb
vendor/bundle/x/probe.rb
```

⚠⚠ **`rubocop` は緑のまま通る。** 対象が増えているだけで違反が出ていないので、気づけない。

⚠ とくに `vendor/**/*` は「**CI が bundler-cache で gem を展開する場所**」の除外。効いていないと gem 側の `.rubocop.yml` まで読みに行って落ちる。モロヘイヤの CI は bundler-cache を使っていないので**表面化していなかった**だけ。

## ✅ 検証

- probe ファイルで `config/` `tmp/` `vendor/` が lint 対象から外れることを確認（修正前は 3 件とも対象に入っていた）
- `--list-target-files` は **472 件で変化なし**、`bundle exec rubocop` も緑のまま（472 files, no offenses）

## ⚠ 正本側

同じ罠を踏まないよう pooza/ginseng-style#17 で README と `config/rubocop.yml` に書き、配布前の検証に **`--list-target-files` の差分ゼロ**を足した。⚠ **`--show-cops` の差分ゼロだけでは検出できない**（cop の顔ぶれは変わらないため）。この件は `makoto2` の移行中に別の形（lint 対象が 87 → 1 ファイル）で顕在化して見つかった。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
