### PR TITLE
obs/bug: リモート辞書が 200-with-HTML を掴んだら黙らないようにする (#4573)

### DIFF
--- a/app/lib/mulukhiya/remote_dictionary.rb
+++ b/app/lib/mulukhiya/remote_dictionary.rb
@@ -10,10 +10,34 @@ module Mulukhiya
       raise Ginseng::ImplementError, "'#{__method__}' not implemented"
     end
 
+    # ⚠ **`present?` だけでは 200-with-HTML を弾けない (#4573)。**HTTParty の
+    # `parsed_response` は Content-Type が JSON でなければ **String をそのまま
+    # 返す**。GAS の `/exec` は失効やアクセス権の変化で **HTTP 200 のまま
+    # `text/html` のログイン誘導ページ**を返すため、HTTP 層は成功・`present?` も
+    # 通り、`String#to_h` / `String#each` の NoMethodError として parse の奥で
+    # 倒れて、外側の rescue が空の辞書に化けさせていた（美食丼の related 辞書 3 本が
+    # 10 分周期で全滅していたのに誰も気付けなかった）。
+    #
+    # 型は**サブクラスが期待する形**で見る。読み辞書の
+    # PronunciationDictionary#valid_schema? と同じく、外れたら型・Content-Type を
+    # 添えて logger.error を残す。
     def fetch
-      response = @http.get(uri).parsed_response
-      raise 'empty' unless response.present?
-      return response
+      response = @http.get(uri)
+      parsed = response.parsed_response
+      raise Ginseng::GatewayError, "empty response (#{uri})" unless parsed.present?
+      return parsed if valid_schema?(parsed)
+      log_invalid_schema(response, parsed)
+      raise Ginseng::GatewayError,
+        "unexpected response type '#{parsed.class.name}' (#{uri})"
+    end
+
+    # サブクラスが `parse` で前提にしている型。
+    def expected_class
+      return Enumerable
+    end
+
+    def valid_schema?(parsed)
+      return parsed.is_a?(expected_class)
     end
 
     def uri
@@ -63,6 +87,22 @@ module Mulukhiya
     end
 
     private
+
+    # ⚠ **本文そのものは残さない。**ログイン誘導ページには URL つきのトークンが
+    # 載りうる (#4511)。型・Content-Type・サイズがあれば「JSON のはずが HTML を
+    # 掴んでいる」は判別できる。
+    def log_invalid_schema(response, parsed)
+      logger.error(
+        message: 'dictionary fetch schema invalid',
+        url: uri.to_s,
+        type: parsed.class.name,
+        expected: expected_class.name,
+        content_type: response.headers['content-type'],
+        bytes: response.body.to_s.bytesize,
+      )
+    rescue => e
+      e.log(dic: uri.to_s)
+    end
 
     def create_entry(word)
       pattern = create_pattern(word)

--- a/app/lib/mulukhiya/remote_dictionary/mecab_remote_dictionary.rb
+++ b/app/lib/mulukhiya/remote_dictionary/mecab_remote_dictionary.rb
@@ -1,5 +1,10 @@
 module Mulukhiya
   class MecabRemoteDictionary < RemoteDictionary
+    # MeCab 辞書の行 (Array) の Array。
+    def expected_class
+      return Array
+    end
+
     def parse
       result = {}
       fetch.each do |v|

--- a/app/lib/mulukhiya/remote_dictionary/multi_field_remote_dictionary.rb
+++ b/app/lib/mulukhiya/remote_dictionary/multi_field_remote_dictionary.rb
@@ -1,5 +1,15 @@
 module Mulukhiya
   class MultiFieldRemoteDictionary < RemoteDictionary
+    # `[{field: 語, ...}, ...]` の Array。
+    def expected_class
+      return Array
+    end
+
+    # ⚠ **外側の rescue は 3 サブクラス揃えてある (#4573)。**以前ここだけ
+    # rescue が無く、同じ 200-with-HTML を掴んでも related / mecab は静かに
+    # `{}`、ここだけ NoMethodError が呼び出し元へ抜けていた。fail-open 自体は
+    # 残す（一過性の障害で辞書が消し飛ぶのを防ぐ意図は正しい）が、**倒れたことが
+    # 見えない**ほうを直す＝ fetch が型を検証して logger.error を残す。
     def parse
       result = {}
       fetch.each do |entry|
@@ -10,6 +20,9 @@ module Mulukhiya
         e.log(dic: uri.to_s, entry:)
       end
       return result
+    rescue => e
+      e.log(dic: uri.to_s)
+      return {}
     end
 
     def fields

--- a/app/lib/mulukhiya/remote_dictionary/related_remote_dictionary.rb
+++ b/app/lib/mulukhiya/remote_dictionary/related_remote_dictionary.rb
@@ -1,5 +1,10 @@
 module Mulukhiya
   class RelatedRemoteDictionary < RemoteDictionary
+    # `{語: [関連語, ...]}` の Hash。String (200-with-HTML) はここで弾く (#4573)。
+    def expected_class
+      return Hash
+    end
+
     def parse
       return fetch.to_h do |k, words|
         words = Array(words).map {|v| create_key(v)}

--- a/app/lib/mulukhiya/tagging_dictionary.rb
+++ b/app/lib/mulukhiya/tagging_dictionary.rb
@@ -10,6 +10,7 @@ module Mulukhiya
   class TaggingDictionary < Hash
     include Package
     include SNSMethods
+    include TaggingDictionaryLogMethods
 
     REDIS_KEY = 'tagging_dictionary'.freeze
     # キャッシュ payload の形式。envelope を変えたら上げる。旧形式は「無い」ものと
@@ -197,29 +198,6 @@ module Mulukhiya
       return cache.present?
     end
 
-    # どの取得回の辞書を使っているかをログに残す。実走のたびに世代が出るので、
-    # 「前の実行が温めたキャッシュを読んでいる」状態を後から突き合わせられる。
-    def log_generation
-      logger.info(
-        message: 'tagging dictionary refreshed',
-        redis_key: REDIS_KEY,
-        signature:,
-        generated_at: generated_at&.iso8601,
-        sources: sources.size,
-        entries: size,
-        ttl: cache_ttl,
-      )
-    end
-
-    def alert_empty_result
-      Ginseng::GatewayError.new('tagging dictionary fetch returned nothing').alert(
-        redis_key: REDIS_KEY,
-        sources: sources.count,
-        cached_entries: cache.to_h.size,
-        generated_at: generated_at&.iso8601,
-      )
-    end
-
     def build_payload(entries)
       return {
         version: CACHE_PAYLOAD_VERSION,
@@ -229,13 +207,22 @@ module Mulukhiya
       }
     end
 
+    # ⚠ **1 本も取れなかったソースは error で残す (#4573)。**サブクラスの parse は
+    # 失敗を握って `{}` を返すので、例外を数えても「死んでいるソース」は見えない。
+    # 空の辞書が返ることと正常に空であることは区別できないが、**タグ辞書として
+    # 設定されているソースが 0 件を返すのは実務上ほぼ壊れている**（美食丼の
+    # related 3 本が 10 分周期で全滅していたのに info ログに `words: 0` が並ぶだけ
+    # だった）。@empty_sources は log_generation の集計に使う。
     def fetch
       result = Concurrent::Array.new
+      @empty_sources = Concurrent::Array.new
       Parallel.each(RemoteDictionary.all, in_threads: Parallel.processor_count * 2) do |dic|
         words = dic.parse
-        logger.info(dic: dic.to_h.merge(words: words.count))
+        @empty_sources.push(dic.uri.to_s) if words.empty?
+        logger.send(words.empty? ? :error : :info, dic: dic.to_h.merge(words: words.count))
         result.push(words)
       rescue => e
+        @empty_sources.push(dic.uri.to_s)
         e.log(dic: dic.to_h)
       end
       return result

--- a/app/lib/mulukhiya/tagging_dictionary_log_methods.rb
+++ b/app/lib/mulukhiya/tagging_dictionary_log_methods.rb
@@ -1,0 +1,42 @@
+module Mulukhiya
+  # タグ辞書の観測ログ (#4583 / #4573)。TaggingDictionary 本体から切り出してある。
+  #
+  # ⚠ **切り出したのは行数合わせではなく、辞書の「取り込みロジック」と
+  # 「取り込みが健全だったかの記録」を混ぜないため。**タグ辞書は失敗を握って空を
+  # 返す層が何段もあるので、どこで何を残したかが本体のコードに埋もれると、
+  # #4573 のような「黙って空になる」をまた見落とす。
+  module TaggingDictionaryLogMethods
+    private
+
+    # どの取得回の辞書を使っているかをログに残す。実走のたびに世代が出るので、
+    # 「前の実行が温めたキャッシュを読んでいる」状態を後から突き合わせられる。
+    #
+    # ⚠ **空だったソースの本数も一緒に出す (#4573)。**1 行で「何本中何本が
+    # 死んでいるか」が読めないと、辞書が痩せていることに気付けない。1 本でも
+    # 空なら error で出す（更新自体は成功しているので message は変えない）。
+    def log_generation
+      empty = @empty_sources.to_a
+      payload = {
+        message: 'tagging dictionary refreshed',
+        redis_key: TaggingDictionary::REDIS_KEY,
+        signature:,
+        generated_at: generated_at&.iso8601,
+        sources: sources.size,
+        empty_sources: empty.size,
+        entries: size,
+        ttl: cache_ttl,
+      }
+      return logger.info(payload) if empty.empty?
+      logger.error(payload.merge(empty_source_urls: empty))
+    end
+
+    def alert_empty_result
+      Ginseng::GatewayError.new('tagging dictionary fetch returned nothing').alert(
+        redis_key: TaggingDictionary::REDIS_KEY,
+        sources: sources.count,
+        cached_entries: cache.to_h.size,
+        generated_at: generated_at&.iso8601,
+      )
+    end
+  end
+end

--- a/test/unit/lib/remote_dictionary_schema.rb
+++ b/test/unit/lib/remote_dictionary_schema.rb
@@ -1,0 +1,103 @@
+require 'webmock/test_unit'
+
+module Mulukhiya
+  # リモート辞書が 200-with-HTML を掴んだときのふるまい (#4573)。
+  #
+  # ⚠ **HTTParty の parsed_response は Content-Type が JSON でなければ String を
+  # そのまま返す。**GAS の /exec は失効すると HTTP 200 のまま text/html の
+  # ログイン誘導ページを返すので、HTTP 層は成功・present? も通り、String#to_h /
+  # String#each の NoMethodError として parse の奥で倒れていた。美食丼の related
+  # 辞書 3 本が 10 分周期で全滅していたのに誰も気付けなかったのがこれ。
+  class RemoteDictionarySchemaTest < TestCase
+    URL = 'https://script.example.com/macros/s/dummy/exec'.freeze
+    HTML = <<~HTML.freeze
+      <!DOCTYPE html><html><head><title>ログイン</title></head>
+      <body>アクセスするにはログインしてください。</body></html>
+    HTML
+
+    def setup
+      WebMock.disable_net_connect!
+    end
+
+    def teardown
+      super
+      WebMock.reset!
+      WebMock.allow_net_connect!
+    end
+
+    # 型が外れたら GatewayError。parse の奥の NoMethodError ではなく、
+    # 「何を期待して何が来たか」が message に出ること。
+    def test_fetch_raises_for_html_body
+      stub_html
+      error = assert_raise(Ginseng::GatewayError) {dictionary('related').fetch}
+
+      assert_include(error.message, 'String')
+    end
+
+    def test_fetch_raises_for_empty_body
+      stub_request(:get, URL).to_return(
+        status: 200,
+        body: '',
+        headers: {'Content-Type' => 'application/json'},
+      )
+
+      assert_raise(Ginseng::GatewayError) {dictionary('related').fetch}
+    end
+
+    # ⚠ **3 サブクラスとも fail-open で {}。**以前は multi_field だけ外側の
+    # rescue が無く、同じ入力で呼び出し元へ NoMethodError が抜けていた。
+    def test_parse_is_fail_open_for_all_types
+      stub_html
+      types = ['related', 'mecab', 'multi_field']
+
+      types.each {|type| assert_empty(dictionary(type).parse, "type=#{type}")}
+    end
+
+    # 期待する型は parse の前提と揃っていること。related は Hash、
+    # mecab / multi_field は Array。
+    def test_expected_class
+      assert_equal(Hash, dictionary('related').expected_class)
+      assert_equal(Array, dictionary('mecab').expected_class)
+      assert_equal(Array, dictionary('multi_field').expected_class)
+    end
+
+    # JSON として読めても、サブクラスが前提にしている型でなければ弾く
+    # (related の URL に一覧 JSON を向けてしまった等)。
+    def test_fetch_raises_for_wrong_json_type
+      stub_request(:get, URL).to_return(
+        status: 200,
+        body: [{'word' => 'キュアスタ'}].to_json,
+        headers: {'Content-Type' => 'application/json'},
+      )
+
+      assert_raise(Ginseng::GatewayError) {dictionary('related').fetch}
+    end
+
+    # 正常系まで塞いでいないこと。
+    def test_fetch_accepts_expected_type
+      stub_request(:get, URL).to_return(
+        status: 200,
+        body: {'キュアスタ' => ['プリキュア']}.to_json,
+        headers: {'Content-Type' => 'application/json'},
+      )
+      dic = dictionary('related')
+
+      assert_kind_of(Hash, dic.fetch)
+      assert_equal(['キュアスタ', 'プリキュア'], dic.parse['キュアスタ'][:words])
+    end
+
+    private
+
+    def stub_html
+      stub_request(:get, URL).to_return(
+        status: 200,
+        body: HTML,
+        headers: {'Content-Type' => 'text/html; charset=utf-8'},
+      )
+    end
+
+    def dictionary(type)
+      return RemoteDictionary.create('url' => URL, 'type' => type, 'fields' => ['word'])
+    end
+  end
+end


### PR DESCRIPTION
Fixes #4573

## 1. 型を検証する（Issue の項目 1）

`RemoteDictionary#fetch` は `present?` しか見ていなかった。⚠ **HTTParty の `parsed_response` は Content-Type が JSON でなければ String をそのまま返す**ので、GAS の `/exec` が失効して 200 + `text/html` を返すと、HTTP 層は成功・`present?` も通り、`String#to_h` / `String#each` の `NoMethodError` として **parse の奥で**倒れ、外側の rescue が飲んで**空の辞書**になっていた。

サブクラスが `parse` で前提にしている型を `expected_class` として持たせ、外れたら **型・Content-Type・サイズを添えて `logger.error`** を残してから `GatewayError` を上げる（読み辞書の `PronunciationDictionary#valid_schema?` と同じ形）。

| クラス | expected_class |
| --- | --- |
| `RelatedRemoteDictionary` | `Hash` |
| `MecabRemoteDictionary` | `Array` |
| `MultiFieldRemoteDictionary` | `Array` |

⚠ **本文そのものはログに残さない。**ログイン誘導ページには URL つきのトークンが載りうる（#4511）。型・Content-Type・バイト数があれば「JSON のはずが HTML を掴んでいる」は判別できる。

## 2. 見えるようにする（Issue の項目 2）

- **0 件を返したソースは `error` で残す。**⚠ サブクラスの `parse` は失敗を握って `{}` を返すので、**例外を数えても「死んでいるソース」は見えない**
- `refresh` の世代ログに `empty_sources` の本数を足し、1 本でもあれば URL 一覧つきの `error` にする。**1 行で「何本中何本が死んでいるか」が読める**

⚠ **Sentry への escalation はしない。**辞書の更新は 10 分周期なので `alert` に載せると 1 ソースあたり**日 144 件**のメール・Discord になる（#4594 で踏んだのと同型）。観測性そのものの設計は受け皿の #4577 で扱う。

## 3. 3 サブクラスのふるまいを揃える（Issue の項目 4）

`multi_field` だけ外側の rescue が無く、**同じ入力で片方だけ例外が呼び出し元へ抜けて**いた。fail-open 自体は残したうえで揃えた（一過性の障害で辞書が消し飛ぶのを防ぐ意図は正しい。直すべきは**倒れたことが見えない**ほう）。

## 付随: ClassLength

`TaggingDictionary` が `Metrics/ClassLength` の上限を超えたので、観測ログ 2 本を `TaggingDictionaryLogMethods` へ切り出した（`DaemonHealthMethods` と同じ形）。⚠ 行数合わせではなく、「取り込みロジック」と「取り込みが健全だったかの記録」を混ぜないため。

## テスト

新規 `test/unit/lib/remote_dictionary_schema.rb`（6 本）。WebMock で 200 + `text/html` を返させ、

- `fetch` が `GatewayError`（message に実際の型が出る）
- **3 サブクラスとも `parse` は `{}` で fail-open**（＝ multi_field だけ例外が抜ける非対称の回帰）
- `expected_class` が parse の前提と揃っている
- JSON として読めても型違いなら弾く / 正常系は塞いでいない

`rake test` は **1023 → 1029 tests / 0 failures / 0 errors**、omissions は **318 のまま不変**。`rake lint` 通過。

## スコープ外

GAS デプロイ URL の失効そのものと `mstdn.b-shock.org/api/dic/v1/service.json` の 302→404 は**運用側の是正**（Issue の記載どおり）。本 PR は製品側の 1 と 2 のみ。