### PR TITLE
bug: Idempotency-Key を上流へ中継する (#4598)

### DIFF
--- a/app/lib/mulukhiya/controller.rb
+++ b/app/lib/mulukhiya/controller.rb
@@ -19,6 +19,12 @@ module Mulukhiya
       'i', 'access_token'
     ].freeze
 
+    # 上流へそのまま中継してよい受信ヘッダ (#4598)。
+    #
+    # ⚠ **`@headers` の丸投げはしない。**`Host` / `Content-Length` / `Cookie` /
+    # `X-Mulukhiya` まで混ざる。転送してよいものだけを 1 本の許可リストに置く。
+    FORWARDED_HEADERS = ['Idempotency-Key'].freeze
+
     set :root, Environment.dir
     enable :method_override
 
@@ -86,6 +92,23 @@ module Mulukhiya
 
     def api_version
       return params[:version].sub(/^v/, '').to_i
+    end
+
+    # 上流へ中継する受信ヘッダ (#4598)。
+    #
+    # ⚠ **モロヘイヤ側で生成しない。**付いてこなければ付けずに転送する。本文の
+    # ハッシュ等から自前で作ると、実況で意図的に連投される同一本文を上流が
+    # 畳んでしまい、**投稿が黙って消える**。
+    #
+    # ⚠ **`Idempotency-Key` は Mastodon API の仕様**で、Misskey には相当物が無い。
+    # 送っても無害だが、「効いているつもり」を作らないために送らない。
+    #
+    # ⚠ **上流の畳み込みは TTL 1 時間・アカウント単位**（mastodon の
+    # `PostStatusService` が `idempotency:status:<account>:<key>` を setex する）。
+    # 秒〜分の再送には効くが、それを超える再実行では効かない。
+    def forwarded_headers
+      return {} unless controller_class.name == 'mastodon'
+      return @headers.to_h.slice(*FORWARDED_HEADERS)
     end
 
     def verify_token_integrity!

--- a/app/lib/mulukhiya/controller/mastodon_controller.rb
+++ b/app/lib/mulukhiya/controller/mastodon_controller.rb
@@ -23,7 +23,10 @@ module Mulukhiya
       verify_token_integrity!
       tags = TootParser.new(params[:status]).tags
       Event.new(:pre_toot, {reporter:, sns:}).dispatch(params)
-      reporter.response = sns.toot(params)
+      # ⚠ **クライアントの Idempotency-Key を上流へ渡す (#4598)。**渡さないと、
+      # 応答だけ失われたときの再送が二重投稿になる。ハンドラで本文が書き換わって
+      # いても、キーが一致すれば上流は既存の投稿を返すので問題にならない。
+      reporter.response = sns.toot(params, {headers: forwarded_headers})
       verify_account_integrity!(reporter.response)
       Event.new(:post_toot, {reporter:, sns:}).dispatch(params)
       @renderer.message = reporter.response.parsed_response

--- a/app/lib/mulukhiya/controller/webhook_controller.rb
+++ b/app/lib/mulukhiya/controller/webhook_controller.rb
@@ -22,7 +22,7 @@ module Mulukhiya
         @renderer.status = 422
         @renderer.message = payload.errors
       else
-        reporter = webhook.post(payload)
+        reporter = webhook.post(payload, {headers: forwarded_headers})
         @renderer.message = reporter.response.parsed_response
         @renderer.status = reporter.response.code
       end

--- a/app/lib/mulukhiya/webhook.rb
+++ b/app/lib/mulukhiya/webhook.rb
@@ -44,12 +44,16 @@ module Mulukhiya
       return @json
     end
 
-    def post(payload)
+    # ⚠ **params は上流への中継用 (#4598)。**webhook の口は Slack 互換なので
+    # ボディに idempotency の概念が無く、`Idempotency-Key` は HTTP ヘッダで
+    # 受けて素通しする。許可リストは Controller::FORWARDED_HEADERS が正本で、
+    # ここでは受け取ったものをそのまま gem へ渡すだけ。
+    def post(payload, params = {})
       body = payload.to_h
       body[visibility_field] = parser_class.visibility_name(body[visibility_field] || visibility)
       reporter = Reporter.new
       Event.new(:pre_webhook, {reporter:, sns:}).dispatch(body)
-      reporter.response = sns.post(body)
+      reporter.response = sns.post(body, params)
       Event.new(:post_webhook, {reporter:, sns:}).dispatch(body)
       return reporter
     end

--- a/docs/api.md
+++ b/docs/api.md
@@ -204,6 +204,22 @@ SNS における「発言の責任」の観点から、本文の自由な編集�
 > 内部リクエストか、nginx を経由せず :3008 を直接叩いた場合だけ。**capsicum のような外部
 > クライアントは `media_update` の明示が必須。**素の `PUT` は本体の編集要求として 405 で弾かれる。
 
+### Idempotency-Key ヘッダ
+
+再送で二重投稿にならないようにするヘッダ（5.34.0〜、#4598）。**Mastodon のみ。**
+
+- クライアントが付けた `Idempotency-Key` を、モロヘイヤが**そのまま上流へ中継する**
+- 対象は `POST /api/v{version}/statuses`（プロキシ経路）と `POST /mulukhiya/webhook/{digest}`（Slack 互換 webhook）
+- ⚠ **モロヘイヤは自分では生成しない。**付いてこなければ付けずに転送する（本文から自動生成すると、実況の意図的な連投が畳まれて投稿が消える）
+- ⚠ **中継するのはこのヘッダだけ。**`Host` / `Cookie` / `Authorization` 等は転送しない
+- ハンドラで本文が書き換わっても影響しない。キーが一致すれば上流は既存の投稿を返す
+
+⚠ **上流の畳み込みは TTL 1 時間・アカウント単位**（Mastodon の `PostStatusService` が
+`idempotency:status:{account}:{key}` を `setex` する）。**秒〜分の再送には効くが、それを超える
+再実行では効かない。**「1 時間以上あとに同じキーで投げれば重複しない」ことは期待できない。
+
+⚠ **Misskey には相当する仕組みが無い**ため、このヘッダは送信されない。
+
 ### パイプライン処理
 
 以下の処理が**透過的に**適用される。クライアントは標準 API を呼ぶだけでよい。
@@ -1322,6 +1338,10 @@ Webhook エンドポイントは `/mulukhiya/webhook` 配下で提供される�
 | `/mulukhiya/webhook/{digest}` | GET | Webhook 存在確認 | ヘルスチェック |
 | `/mulukhiya/webhook/{digest}` | POST | Webhook 検証 | Slack 互換ペイロードを処理 |
 | `/mulukhiya/webhook/admin` | POST | HMAC-SHA256 / Misskey Secret | 管理 Webhook（アカウント承認等） |
+
+⚠ **`POST /mulukhiya/webhook/{digest}` も `Idempotency-Key` を上流へ中継する**（Mastodon のみ、#4598）。
+Slack 互換ペイロードに idempotency の概念は無いので、**ボディではなく HTTP ヘッダで指定する**。
+挙動と TTL の前提は「[Idempotency-Key ヘッダ](#idempotency-key-ヘッダ)」を参照。
 
 ### Annict 連携（エピソードブラウザ）
 

--- a/test/unit/controller/forwarded_headers.rb
+++ b/test/unit/controller/forwarded_headers.rb
@@ -1,0 +1,74 @@
+module Mulukhiya
+  # 上流へ中継する受信ヘッダの許可リスト (#4598)。
+  #
+  # ⚠ **`Idempotency-Key` はモロヘイヤを通ると消えていた。**プロキシ経路
+  # (`POST /api/:version/statuses`) も Slack 互換 webhook もヘッダを渡しておらず、
+  # クライアントが正しくキーを付けていても上流の畳み込みが働かない＝応答だけ
+  # 失われたときの再送が二重投稿になっていた。
+  class ForwardedHeadersTest < TestCase
+    KEY = 'Idempotency-Key'.freeze
+
+    def test_forwards_idempotency_key
+      assert_equal(expected(KEY => 'abc123'), forwarded(KEY => 'abc123'))
+    end
+
+    # ⚠ **丸投げしない。**Host / Content-Length / Cookie / X-Mulukhiya /
+    # Authorization を上流へ中継すると、経路の識別やトークンの扱いが壊れる。
+    def test_drops_everything_else
+      headers = {
+        'Authorization' => 'Bearer secret',
+        'Cookie' => 'session=1',
+        'Host' => 'mstdn.example.com',
+        'Content-Length' => '42',
+        'X-Mulukhiya' => 'true',
+        'User-Agent' => 'capsicum',
+      }
+
+      assert_empty(forwarded(headers))
+    end
+
+    def test_keeps_only_the_allowed_header
+      headers = {KEY => 'abc123', 'Cookie' => 'session=1', 'X-Mulukhiya' => 'true'}
+
+      assert_equal(expected(KEY => 'abc123'), forwarded(headers))
+    end
+
+    # ⚠ **モロヘイヤ側で生成しない。**本文のハッシュ等から自前で作ると、実況で
+    # 意図的に連投される同一本文を上流が畳んで投稿が黙って消える。
+    def test_does_not_generate_key
+      assert_empty(forwarded({}))
+      assert_empty(forwarded('User-Agent' => 'capsicum'))
+    end
+
+    # ⚠ **Idempotency-Key は Mastodon API の仕様。**Misskey には相当物が無いので
+    # 送らない（送っても無害だが「効いているつもり」を作らない）。
+    def test_forwards_only_on_mastodon
+      forwarded = forwarded(KEY => 'abc123')
+
+      if controller_class.name == 'mastodon'
+        assert_equal({KEY => 'abc123'}, forwarded)
+      else
+        assert_empty(forwarded)
+      end
+    end
+
+    # webhook 経路も同じ許可リストを通す。⚠ 引数が省略可能でないと、
+    # AnnictService の `webhook.post(payload)` が壊れる。
+    def test_webhook_post_accepts_forwarded_headers
+      assert_equal([[:req, :payload], [:opt, :params]], Webhook.instance_method(:post).parameters)
+    end
+
+    private
+
+    # Mastodon 以外の環境では常に空になる。
+    def expected(headers)
+      return controller_class.name == 'mastodon' ? headers : {}
+    end
+
+    def forwarded(headers)
+      controller = MastodonController.new!
+      controller.instance_variable_set(:@headers, headers)
+      return controller.forwarded_headers
+    end
+  end
+end


### PR DESCRIPTION
Fixes #4598

## 何が起きていたか

モロヘイヤを経由すると、クライアントが付けた `Idempotency-Key` が上流の Mastodon へ**届かない**。Mastodon が受理した後に応答だけ失われると（タイムアウト・逆プロキシの 502/503）、クライアントの再送が**同じ内容の投稿をもう 1 つ**作る。

| 経路 | 症状 |
| --- | --- |
| `POST /api/:version/statuses` | `sns.toot(params)` がヘッダを渡していなかった（`@headers` は `before` で揃っているのに未使用） |
| `POST /mulukhiya/webhook/:digest` | `Webhook#post` が `sns.post(body)` を呼ぶだけで、ヘッダを渡す経路が無かった |

## 実装（Issue の方針どおり）

- **許可リスト 1 本で転送する。**`Controller::FORWARDED_HEADERS`（`Idempotency-Key` のみ）を `forwarded_headers` が `slice` する。⚠ `@headers` の丸投げはしない（`Host` / `Content-Length` / `Cookie` / `X-Mulukhiya` / `Authorization` が混ざる）
- **webhook 経路は HTTP ヘッダで受ける。**Slack ペイロードに idempotency の概念は無いので、`SlackWebhookContract`（`digest` + `text` 必須）には触っていない
- ⚠ **モロヘイヤ側で生成しない。**付いてこなければ付けずに転送する。**本文のハッシュ等から自前で作ると、実況で意図的に連投される同一本文を上流が畳んで投稿が黙って消える**
- ⚠ **Mastodon 限定。**Misskey には相当物が無いので送らない（送っても無害だが「効いているつもり」を作らない）

`Webhook#post(payload, params = {})` の第 2 引数は**省略可能**にしてある。`AnnictService` の `webhook.post(payload)` を壊さないため。

## gem 側は変更不要

`MastodonService#post(body, params)` は既に `headers: create_headers(params[:headers])` を通しており、**`PUT /api/:version/statuses/:id` がこの経路を本番で使い続けている**（`{headers: @headers}`）。#4589 / #4594 のような「gem が値を捨てる」型ではないことを実装を読んで確認済み。

## テスト

新規 `test/unit/controller/forwarded_headers.rb`（6 本）。

- `Idempotency-Key` が転送される / **それ以外（Authorization・Cookie・Host・Content-Length・X-Mulukhiya・User-Agent）は落ちる**
- **付いてこないときに生成しない**
- Mastodon 環境でだけ転送する（`controller_class.name` で分岐するので **両マトリクスで実走**し、omission を増やさない）
- `Webhook#post` の第 2 引数が省略可能（`AnnictService` の呼び出しを壊さない契約）

`rake test` は **1023 → 1029 tests / 0 failures / 0 errors**、omissions は **318 のまま不変**。`rake lint` 通過。

## docs

`docs/api.md` に「Idempotency-Key ヘッダ」節を追加。⚠ **上流の畳み込みは TTL 1 時間・アカウント単位**（Mastodon の `PostStatusService` が `idempotency:status:{account}:{key}` を `setex`）で、**秒〜分の再送には効くが、それを超える再実行では効かない**ことを明記した。webhook 節からも参照している。

## スコープ外

`PUT /api/:version/statuses/:id` の `@headers` 丸投げは Issue の記載どおり触っていない（gem 側が `headers['Authorization'] ||= ...` で受信側を優先するため事故は起きていない）。許可リストへ揃える整理は別途。