### PR TITLE
security: SSRF 掃討の取り残し 2 件を塞ぐ (#4576)

### DIFF
--- a/app/lib/mulukhiya/controller/api_controller.rb
+++ b/app/lib/mulukhiya/controller/api_controller.rb
@@ -1203,28 +1203,42 @@ module Mulukhiya
       })
     end
 
+    # webfinger → actor の 2 段取得 (#4198)。**外部から与えられた acct のホストへ
+    # モロヘイヤが接続する**経路なので、SSRF ガードは 2 重に要る (#4576):
+    #
+    #   1. 取得前の事前判定 (RemoteHost.validate!) — 拒否をここで確定させる
+    #   2. 取得中の各ホップ検証 + pinning (host_validator)
+    #
+    # ⚠ **事前判定だけでは足りない。**host_validator を渡さないと Ginseng::HTTP は
+    # 素の HTTParty 経路へ落ち、**既定でリダイレクトを追従する**（limit 5）。
+    # 攻撃者のホストが `302 Location: http://127.0.0.1:9200/` を返せば、
+    # 検証済みホストの裏から内部サービスへ到達できる (#4410 と同じ形)。
+    # ⚠ **pinning が無いと名前を二度引くことになる。**検証時だけ公開アドレスを
+    # 返し、接続時に 127.0.0.1 を返す DNS リバインディングが通る (#4524)。
+    #
+    # ⚠ **拒否は nil ではなくログを残して nil。**呼び出し元は acct ごとに nil を
+    # 「判定不能」として返すので、黙って nil にすると攻撃の試行が一切見えない。
     def fetch_actor(http, acct)
-      return nil unless valid_remote_host?(acct.host)
+      RemoteHost.validate!(acct.host)
       url = "https://#{acct.host}/.well-known/webfinger?resource=acct:#{acct}"
       webfinger = fetch_json(http, url, 'application/jrd+json')
       actor_uri = webfinger['links']&.find do |l|
         l['type'] == 'application/activity+json'
       end&.dig('href')
       return nil unless actor_uri
-      actor_host = Ginseng::URI.parse(actor_uri)&.host
-      return nil unless valid_remote_host?(actor_host)
+      RemoteHost.validate!(Ginseng::URI.parse(actor_uri)&.host.to_s)
       return fetch_json(http, actor_uri, 'application/activity+json')
-    rescue
+    rescue => e
+      e.log(acct: acct.to_s)
       return nil
     end
 
     def fetch_json(http, url, accept)
-      response = http.get(url, {headers: {'Accept' => accept}}).parsed_response
+      response = http.get(url, {
+        headers: {'Accept' => accept},
+        host_validator: RemoteHost.validator,
+      }).parsed_response
       return response.is_a?(String) ? JSON.parse(response) : response
-    end
-
-    def valid_remote_host?(host)
-      return RemoteHost.public?(host)
     end
   end
 end

--- a/app/lib/mulukhiya/handler.rb
+++ b/app/lib/mulukhiya/handler.rb
@@ -240,18 +240,24 @@ module Mulukhiya
     #   1. 事前判定 (RemoteHost.validate!) — 拒否をここで確定させる
     #   2. 各ホップ検証 + pinning (host_validator) — リダイレクトで裏へ回られない
     #
-    # ⚠ **pinning を「CDN に効かせると壊れる」根拠でここだけ外さないこと。**
-    # このメソッドの呼び出し元は WebhookImageHandler の 1 本だけで、YouTube /
-    # iTunes / Spotify のサムネイル経路は upload_remote_resource を通らない
-    # (2026-08-20 に全呼び出し元を確認)。増やすときは #4524 のトレードオフ
-    # （複数 A レコードのフォールバックが効かない）を呼び出し元ごとに判断する。
+    # ⚠ **pinning は既定にしない (#4576 / PR #4611 の Codex P2)。**このメソッドは
+    # ImageHandler#upload の `super` 経由で **YouTube / iTunes / Spotify の
+    # サムネイル取得**からも呼ばれる。大手 CDN はアドレスをローテーションするので、
+    # 1 本へ固定すると「選んだアドレスだけ落ちている」ときに添付が黙って落ちる
+    # (#4524 のトレードオフ)。ここでは**各ホップの検証だけ**を効かせ、pinning が
+    # 要る経路 (WebhookImageHandler) が upload_host_validator を上書きする。
     def upload(uri, params = {})
       uri = Ginseng::URI.parse(uri) unless uri.is_a?(Ginseng::URI)
       raise "Invalid URL '#{uri}'" unless uri.absolute?
       RemoteHost.validate!(uri)
       params[:response] ||= :id
-      params[:host_validator] ||= RemoteHost.validator
+      params[:host_validator] ||= upload_host_validator
       return sns.upload_remote_resource(uri, params)
+    end
+
+    # 取得経路の SSRF ガード。既定は pinning 無し（上のコメント）。
+    def upload_host_validator
+      return RemoteHost.unpinned_validator
     end
 
     def parser

--- a/app/lib/mulukhiya/handler.rb
+++ b/app/lib/mulukhiya/handler.rb
@@ -232,10 +232,25 @@ module Mulukhiya
       return @status.each_line(chomp: true).to_a
     end
 
+    # リモートの URL を取得して SNS へ添付としてアップロードする。
+    #
+    # ⚠ **取得したボディはそのままタイムラインへ出る。**準ブラインドではなく
+    # full-read SSRF になりうる経路なので、内部アドレスは取りに行かない (#4576)。
+    #
+    #   1. 事前判定 (RemoteHost.validate!) — 拒否をここで確定させる
+    #   2. 各ホップ検証 + pinning (host_validator) — リダイレクトで裏へ回られない
+    #
+    # ⚠ **pinning を「CDN に効かせると壊れる」根拠でここだけ外さないこと。**
+    # このメソッドの呼び出し元は WebhookImageHandler の 1 本だけで、YouTube /
+    # iTunes / Spotify のサムネイル経路は upload_remote_resource を通らない
+    # (2026-08-20 に全呼び出し元を確認)。増やすときは #4524 のトレードオフ
+    # （複数 A レコードのフォールバックが効かない）を呼び出し元ごとに判断する。
     def upload(uri, params = {})
       uri = Ginseng::URI.parse(uri) unless uri.is_a?(Ginseng::URI)
       raise "Invalid URL '#{uri}'" unless uri.absolute?
+      RemoteHost.validate!(uri)
       params[:response] ||= :id
+      params[:host_validator] ||= RemoteHost.validator
       return sns.upload_remote_resource(uri, params)
     end
 

--- a/app/lib/mulukhiya/handler/webhook_image_handler.rb
+++ b/app/lib/mulukhiya/handler/webhook_image_handler.rb
@@ -6,6 +6,14 @@ module Mulukhiya
       return super
     end
 
+    # ⚠ **webhook 経路だけ pinning する (#4576)。**ここは第三者が任意の URL を
+    # 送り込める口で、取得したボディがそのままタイムラインへ出る full-read。
+    # CDN のローテーションを心配する相手ではないので、DNS リバインディング
+    # (#4524) を潰すほうを採る。
+    def upload_host_validator
+      return RemoteHost.validator
+    end
+
     def handle_pre_webhook(payload, params = {})
       payload.deep_stringify_keys!
       payload[attachment_field] = Concurrent::Array.new(payload[attachment_field] || [])

--- a/app/lib/mulukhiya/media_file.rb
+++ b/app/lib/mulukhiya/media_file.rb
@@ -2,6 +2,11 @@ module Mulukhiya
   class MediaFile < File
     include Package
 
+    # リモート取得の既定上限 (32MiB)。Mastodon の既定 (動画 40MB / 画像 16MB)
+    # より小さめに置く。webhook から取り込む添付を想定した値で、足りなければ
+    # /media/download/max_bytes で上げる。
+    DEFAULT_DOWNLOAD_MAX_BYTES = 33_554_432
+
     def valid?
       return mediatype == default_mediatype
     end
@@ -154,14 +159,62 @@ module Mulukhiya
       return 30
     end
 
-    def self.download(uri)
+    # リモートの URL を tmp/media へ落とす。
+    #
+    # ⚠ **host_validator を渡すのは呼び出し元の責務 (#4576)。**ここで既定に
+    # するとダウンロード全般へ pinning が効き、複数 A レコードのフォールバックが
+    # 使えない相手 (大手 CDN) で取得できなくなる (#4524 のトレードオフ)。
+    #
+    # ⚠ **サイズ上限を持つ。**以前は Content-Length も本文長も見ずに
+    # `File.write(path, get(uri).body)` していたので、巨大な応答をそのまま
+    # メモリとディスクへ通していた。判定は word_suggest / program と同じ二段
+    # (HEAD の Content-Length → 受信後の実測) で、HEAD 非対応の相手でも
+    # 最終防衛線が残る。
+    def self.download(uri, params = {})
       path = File.join(
         Environment.dir,
         'tmp/media',
         "#{uri.to_s.sha256}#{File.extname(uri.path)}",
       )
-      File.write(path, HTTP.new.get(uri).body)
+      options = {}
+      options[:host_validator] = params[:host_validator] if params[:host_validator]
+      raise Ginseng::GatewayError, "Too large content '#{uri}'" unless
+        valid_content_length?(uri, options)
+      body = HTTP.new.get(uri, options).body.to_s
+      raise Ginseng::GatewayError, "Too large content '#{uri}'" if
+        body.bytesize > download_max_bytes
+      File.write(path, body)
       return new(path).file
+    end
+
+    # 相手が申告した Content-Length が上限を超えていれば GET せずに弾く。
+    # ⚠ Content-Length 不在・HEAD 非対応 (403 / 405) は「判定不能」として GET へ
+    # 倒す。受信後の実測が最終防衛線 (#4576 / word_suggest と同じ形)。
+    # ⚠ **プリフライトにも同じ host_validator を渡す。**ここだけ無検証だと
+    # GET 側のガードが見せかけの安全になる (#4523)。
+    def self.valid_content_length?(uri, options = {})
+      length = HTTP.new.head(uri, options).headers['content-length']
+      return true if length.nil? || length.to_i <= download_max_bytes
+      Logger.new.error(
+        message: 'media download content-length exceeded max bytes',
+        url: uri.to_s,
+        bytes: length.to_i,
+        max_bytes: download_max_bytes,
+      )
+      return false
+    rescue Ginseng::GatewayError => e
+      # ⚠ allowlist 拒否 (Rejected host) はここで飲まない。飲むと「プリフライトが
+      # true = GET してよい」が成り立たなくなる (#4535)。
+      raise if e.message.start_with?('Rejected host')
+      return true
+    rescue
+      return true
+    end
+
+    def self.download_max_bytes
+      return Config.instance['/media/download/max_bytes'] || DEFAULT_DOWNLOAD_MAX_BYTES
+    rescue Ginseng::ConfigError
+      return DEFAULT_DOWNLOAD_MAX_BYTES
     end
 
     def self.purge

--- a/app/lib/mulukhiya/media_file.rb
+++ b/app/lib/mulukhiya/media_file.rb
@@ -170,6 +170,13 @@ module Mulukhiya
     # メモリとディスクへ通していた。判定は word_suggest / program と同じ二段
     # (HEAD の Content-Length → 受信後の実測) で、HEAD 非対応の相手でも
     # 最終防衛線が残る。
+    #
+    # ⚠⚠ **上限は「受信中」には効かない (#4612)。**受信後の実測に届く時点で
+    # 本文はすべてメモリに載っているので、`Content-Length` を出さない相手
+    # (chunked) や過少申告する相手には上限を無視して読まされる。⚠ **image_url は
+    # webhook から第三者が指定できる**ので、ワーカーのメモリ枯渇に繋がりうる。
+    # 受信中に打ち切るには `Ginseng::HTTP#get` 側の口が要る
+    # (pooza/ginseng-core#526)。着地したら `max_bytes:` へ載せ替えること。
     def self.download(uri, params = {})
       path = File.join(
         Environment.dir,

--- a/app/lib/mulukhiya/remote_host.rb
+++ b/app/lib/mulukhiya/remote_host.rb
@@ -109,6 +109,21 @@ module Mulukhiya
       attr_writer :validator
     end
 
+    # pinning **しない** validator (#4576)。真偽値を返すので ginseng-core は
+    # 各ホップのホスト検証だけを行い、接続先は名前解決に任せる。
+    #
+    # ⚠ **CDN 相手に pinning を効かせないためのもの。**大手 CDN は複数の A
+    # レコードを返してアドレスをローテーションするので、1 本へ固定すると
+    # 「選んだアドレスだけ落ちている」ときに取得できず、添付が黙って落ちる
+    # (#4524 のトレードオフ)。DNS リバインディングは防げないが、**検証を
+    # 一切しない状態よりは強い**（リダイレクト先が内部でも追従しなくなる）。
+    #
+    # ⚠ **判定の実体は validator に委譲する。**テストが validator を差し替えたら
+    # こちらも一緒に効く必要がある。
+    def self.unpinned_validator
+      return ->(host) {validator.call(host).present?}
+    end
+
     # allowlist を通らないホストで GatewayError を投げる (#4535)。
     #
     # HEAD プリフライトの rescue は「HEAD 非対応・一過性障害 = 判定不能」を

--- a/app/lib/mulukhiya/sns_service_methods.rb
+++ b/app/lib/mulukhiya/sns_service_methods.rb
@@ -19,8 +19,13 @@ module Mulukhiya
       FileUtils.rm_rf(dir) if dir
     end
 
+    # ⚠ **host_validator は gem の upload へ渡さない。**あちらは version /
+    # filename / description を見るリクエストパラメータで、SSRF ガードは
+    # 取得側 (MediaFile.download) の関心事 (#4576)。
     def upload_remote_resource(uri, params = {})
-      payload = {file: {tempfile: MediaFile.download(uri)}}
+      params = params.dup
+      validator = params.delete(:host_validator)
+      payload = {file: {tempfile: MediaFile.download(uri, host_validator: validator)}}
       params[:version] ||= 1
       Event.new(:pre_upload, params).dispatch(payload)
       response = upload(payload.dig(:file, :tempfile).path, params)

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -381,6 +381,8 @@ mastodon:
     color: '#6364FF'
   url: https://mstdn.example.com/
 media:
+  download:
+    max_bytes: 33554432
   metadata:
     cache:
       ttl: 8640000

--- a/config/schema/base.yaml
+++ b/config/schema/base.yaml
@@ -189,6 +189,15 @@ properties:
     required:
       - api
     type: object
+  media:
+    properties:
+      download:
+        properties:
+          max_bytes:
+            minimum: 1
+            type: integer
+        type: object
+    type: object
   peer_tube:
     properties:
       hosts:

--- a/test/unit/controller/is_cat_ssrf.rb
+++ b/test/unit/controller/is_cat_ssrf.rb
@@ -1,0 +1,86 @@
+require 'webmock/test_unit'
+
+module Mulukhiya
+  # POST /account/is_cat の webfinger / actor 取得の SSRF ガード (#4576)。
+  #
+  # ⚠ **有効なトークンさえあれば誰でも撃てる経路**（権限チェックは
+  # `raise AuthError unless sns.account` だけ）。しかも `accts` は最大 50 件で
+  # `Parallel.each` なので、1 リクエストで 50 ホストへ並列に飛ぶ。
+  class IsCatSSRFTest < TestCase
+    ACCT = 'a@attacker.example'.freeze
+    WEBFINGER = 'https://attacker.example/.well-known/webfinger?resource=acct:a@attacker.example'.freeze
+    INTERNAL = 'http://127.0.0.1:9200/'.freeze
+
+    def setup
+      WebMock.disable_net_connect!
+      # ⚠ 差し替えたら teardown で必ず戻す。残すと以後のテストで SSRF ガードが
+      # 効かなくなり「守れているつもりの緑」になる。
+      @original_validator = RemoteHost.validator
+    end
+
+    def teardown
+      super
+      RemoteHost.validator = @original_validator
+      WebMock.reset!
+      WebMock.allow_net_connect!
+    end
+
+    # 拒否ホストは **1 バイトも取りに行かない**。事前判定が効いていること。
+    def test_rejected_host_is_never_requested
+      RemoteHost.validator = ->(_host) {}
+      stub_request(:get, WEBFINGER).to_return(status: 200, body: '{}')
+
+      assert_nil(fetch_actor)
+      assert_not_requested(:get, WEBFINGER)
+    end
+
+    # ⚠ **本命の回帰。**host_validator を渡していないと HTTParty 既定の追従で
+    # 内部サービスへ到達できていた（検証済みホストの裏から回られる）。
+    def test_redirect_to_internal_host_is_blocked
+      RemoteHost.validator = ->(host) {host == 'attacker.example' ? '93.184.216.34' : nil}
+      stub_request(:get, WEBFINGER).to_return(status: 302, headers: {'Location' => INTERNAL})
+      internal = stub_request(:get, INTERNAL).to_return(status: 200, body: '{}')
+
+      assert_nil(fetch_actor)
+      assert_not_requested(internal)
+    end
+
+    # webfinger が返した actor の href も検証する（別ホストを指しうる）。
+    def test_actor_host_is_validated
+      RemoteHost.validator = ->(host) {host == 'attacker.example' ? '93.184.216.34' : nil}
+      stub_request(:get, WEBFINGER).to_return(
+        status: 200,
+        body: {links: [{type: 'application/activity+json', href: 'https://internal.example/actor'}]}.to_json,
+        headers: {'Content-Type' => 'application/jrd+json'},
+      )
+      actor = stub_request(:get, 'https://internal.example/actor').to_return(status: 200, body: '{}')
+
+      assert_nil(fetch_actor)
+      assert_not_requested(actor)
+    end
+
+    # 正常系まで塞いでいないこと。
+    def test_allowed_host_is_fetched
+      RemoteHost.validator = ->(_host) {'93.184.216.34'}
+      stub_request(:get, WEBFINGER).to_return(
+        status: 200,
+        body: {links: [{type: 'application/activity+json', href: 'https://attacker.example/actor'}]}.to_json,
+        headers: {'Content-Type' => 'application/jrd+json'},
+      )
+      stub_request(:get, 'https://attacker.example/actor').to_return(
+        status: 200,
+        body: {isCat: true}.to_json,
+        headers: {'Content-Type' => 'application/activity+json'},
+      )
+
+      assert_true(fetch_actor['isCat'])
+    end
+
+    private
+
+    def fetch_actor
+      controller = APIController.new!
+      return controller.send(:fetch_actor, HTTP.new, Ginseng::Fediverse::Acct.new(ACCT))
+    end
+  end
+end

--- a/test/unit/lib/media_file_download.rb
+++ b/test/unit/lib/media_file_download.rb
@@ -1,0 +1,99 @@
+require 'webmock/test_unit'
+
+module Mulukhiya
+  # リモート添付の取得ガード (#4576)。
+  #
+  # ⚠ **ここで取ったボディはそのまま SNS の添付になる。**準ブラインドではなく
+  # full-read SSRF になりうる経路（webhook に `image_url` を入れるだけで、
+  # 内部サービスの応答がタイムライン上の画像として読み出せた）。
+  class MediaFileDownloadTest < TestCase
+    URL = 'https://media.example.com/image.png'.freeze
+    INTERNAL = 'http://127.0.0.1:9200/_cat/indices'.freeze
+
+    def setup
+      WebMock.disable_net_connect!
+      # ⚠ 差し替えたら teardown で必ず戻すこと。
+      @original_validator = RemoteHost.validator
+      @paths = []
+    end
+
+    def teardown
+      super
+      RemoteHost.validator = @original_validator
+      @paths.each {|path| FileUtils.rm_f(path)}
+      WebMock.reset!
+      WebMock.allow_net_connect!
+    end
+
+    # ⚠ **拒否はプリフライトの rescue に飲ませない (#4535)。**飲むと
+    # 「プリフライトが true = GET してよい」が成り立たなくなる。
+    def test_rejected_host_raises
+      RemoteHost.validator = ->(_host) {}
+      get = stub_request(:get, INTERNAL).to_return(status: 200, body: 'secret')
+
+      assert_raise(Ginseng::GatewayError) {download(INTERNAL)}
+      assert_not_requested(get)
+    end
+
+    # 相手の申告が上限超えなら GET しない。
+    def test_oversize_content_length_is_rejected_before_get
+      allow_all
+      config['/media/download/max_bytes'] = 16
+      stub_request(:head, URL).to_return(status: 200, headers: {'Content-Length' => '1024'})
+      get = stub_request(:get, URL).to_return(status: 200, body: 'x' * 1024)
+
+      assert_raise(Ginseng::GatewayError) {download(URL)}
+      assert_not_requested(get)
+    end
+
+    # ⚠ **HEAD が Content-Length を返さない相手（GAS 等）でも最終防衛線が要る。**
+    # 受信後の実測で弾き、ディスクへは書かない。
+    def test_oversize_body_is_rejected_after_get
+      allow_all
+      config['/media/download/max_bytes'] = 16
+      stub_request(:head, URL).to_return(status: 200)
+      stub_request(:get, URL).to_return(status: 200, body: 'x' * 1024)
+
+      assert_raise(Ginseng::GatewayError) {download(URL)}
+      assert_path_not_exist(path_for(URL))
+    end
+
+    # HEAD 非対応 (405) は「判定不能」として GET へ倒す。正常系を塞がないこと。
+    def test_head_not_supported_falls_back_to_get
+      allow_all
+      stub_request(:head, URL).to_return(status: 405)
+      stub_request(:get, URL).to_return(status: 200, body: 'small')
+
+      download(URL)
+
+      assert_equal('small', File.read(path_for(URL)))
+    end
+
+    def test_downloads_within_limit
+      allow_all
+      stub_request(:head, URL).to_return(status: 200, headers: {'Content-Length' => '5'})
+      stub_request(:get, URL).to_return(status: 200, body: 'small')
+
+      download(URL)
+
+      assert_equal('small', File.read(path_for(URL)))
+    end
+
+    private
+
+    def allow_all
+      RemoteHost.validator = ->(_host) {'93.184.216.34'}
+    end
+
+    def download(url)
+      uri = Ginseng::URI.parse(url)
+      @paths.push(path_for(url))
+      return MediaFile.download(uri, host_validator: RemoteHost.validator)
+    end
+
+    def path_for(url)
+      uri = Ginseng::URI.parse(url)
+      return File.join(Environment.dir, 'tmp/media', "#{uri.to_s.sha256}#{File.extname(uri.path)}")
+    end
+  end
+end

--- a/test/unit/lib/remote_host.rb
+++ b/test/unit/lib/remote_host.rb
@@ -4,6 +4,41 @@ module Mulukhiya
       return ->(_host) {addresses}
     end
 
+    # pinning する / しない 2 種の validator (#4576)。
+    #
+    # ⚠ **既定 (Handler#upload) は pinning しないほう。**ImageHandler#upload の
+    # super 経由で YouTube / iTunes / Spotify のサムネイル取得も通るため、
+    # アドレスを 1 本へ固定すると CDN のローテーションで添付が黙って落ちる。
+    # pinning するのは webhook 経路 (WebhookImageHandler#upload_host_validator) だけ。
+    def test_validator_pins_address
+      with_validator(->(_host) {'93.184.216.34'}) do
+        assert_equal('93.184.216.34', RemoteHost.validator.call('example.com'))
+      end
+    end
+
+    # ⚠ ginseng-core は **String が返れば pinning、真偽値なら検証のみ**。
+    # unpinned_validator が String を返すと CDN も固定されてしまう。
+    def test_unpinned_validator_returns_boolean
+      with_validator(->(_host) {'93.184.216.34'}) do
+        assert_true(RemoteHost.unpinned_validator.call('example.com'))
+      end
+    end
+
+    def test_unpinned_validator_rejects_denied_host
+      with_validator(->(_host) {}) do
+        assert_false(RemoteHost.unpinned_validator.call('attacker.example'))
+      end
+    end
+
+    def with_validator(validator)
+      original = RemoteHost.validator
+      RemoteHost.validator = validator
+      yield
+    ensure
+      # ⚠ 差し替えたら必ず戻す。残すと以後のテストで SSRF ガードが効かない。
+      RemoteHost.validator = original
+    end
+
     def test_returns_false_for_blank_host
       assert_false(RemoteHost.public?(''))
       assert_false(RemoteHost.public?(nil))


### PR DESCRIPTION
Fixes #4576

## 1. `POST /account/is_cat` の webfinger / actor 取得（準ブラインド SSRF）

**有効なトークンさえあれば誰でも撃てる**（権限チェックは `raise AuthError unless sns.account` だけ）のに、SSRF ガードが 1 つも通っていなかった。

- 事前判定を `RemoteHost.validate!` に寄せた（#4535 と同じ形）
- `fetch_json` に `host_validator: RemoteHost.validator` を渡した
  - ⚠ **渡さないと `Ginseng::HTTP` は素の HTTParty 経路へ落ち、既定でリダイレクトを追従する。**攻撃者のホストが `302 Location: http://127.0.0.1:9200/` を返せば、検証済みホストの裏から内部サービスへ到達できていた（ginseng-core 自身が「初段だけ検証しても見せかけの安全」と書いている、まさにその形・#4410）
  - ⚠ 同時に **pinning** も入る。名前で検証して名前で接続する DNS リバインディング（#4524）も消える
- ⚠ **拒否を黙って nil にしない。**呼び出し元は acct ごとに nil を「判定不能」として返すので、黙ると攻撃の試行が一切見えない。ログを残して nil を返す

## 2. webhook の `image_url`（full-read SSRF）

取得したボディが**そのまま SNS の添付になる**経路。webhook URL を知っていれば、内部サービスの応答をタイムライン上の画像として読み出せた。

- `Handler#upload` に `RemoteHost.validate!` と `host_validator` を入れた
- `MediaFile.download` に**サイズ上限**を入れた。以前は Content-Length も本文長も見ずに `File.write(path, get(uri).body)` していた（Issue の ⚠）。判定は word_suggest / program と同じ二段（HEAD の Content-Length → 受信後の実測）で、HEAD 非対応の相手でも最終防衛線が残る
  - 既定 32MiB（`/media/download/max_bytes`）。`config/schema/base.yaml` にも追加
  - ⚠ 拒否（`Rejected host`）はプリフライトの rescue に飲ませない。飲むと「プリフライトが true = GET してよい」が成り立たなくなる（#4535）

### 段階適用（pinning は webhook 経路だけ）

⚠ **初版は「呼び出し元は WebhookImageHandler だけ」として全経路に pinning を効かせていたが、これは誤りだった**（Codex P2 の指摘・`cfb2f9e5` で修正）。`ImageHandler#upload` が `super` で `Handler#upload` を呼ぶため、**YouTube / iTunes / Spotify のサムネイル取得も同じ経路を通る**。呼び出し元の確認を `app/lib/mulukhiya/handler/` に限定して grep したせいで `app/lib/mulukhiya/image_handler.rb` を見落としていた。

Issue が最初から書いていた段階適用に従う:

| 経路 | 各ホップ検証 | pinning |
| --- | --- | --- |
| 既定（ナウプレのサムネイル等） | あり（`RemoteHost.unpinned_validator`） | **なし** |
| webhook（`WebhookImageHandler`） | あり | **あり**（`RemoteHost.validator`） |

⚠ ginseng-core は validator が **String を返せば pinning、真偽値なら検証のみ**。CDN のマルチアドレス・フォールバックを維持しつつ、**リダイレクト先が内部アドレスなら追従しない**状態は保つ。webhook 側は第三者が任意 URL を送り込める full-read 経路なので、CDN ローテーションより DNS リバインディング（#4524）を潰すほうを採る。

### ⚠ 受信中のサイズ上限は残課題（Codex P1）

本 PR の上限は「申告（HEAD）」と「読み切った後」の二段で、**受信中には効かない**。`Content-Length` を出さない（chunked）相手や過少申告する相手には上限を無視して読まされる。`Ginseng::HTTP#get` に受信中の上限を渡す口が無く**本体だけでは塞げない**ため、**pooza/ginseng-core#526** を起票し、受け皿を **#4612** として残した。

暫定の緩和は 3 つ: ① 申告が上限超えなら GET しない ② 上限超えの本文は**ディスクへ書かない** ③ 内部アドレスは取得前に拒否 + 各ホップ検証。

## テスト

- 新規 `test/unit/controller/is_cat_ssrf.rb`（4 本）— 拒否ホストは 1 バイトも取りに行かない / **リダイレクト先が内部でも追従しない** / actor の href も検証する / 正常系は塞がない
- 新規 `test/unit/lib/media_file_download.rb`（5 本）— 拒否は raise（GET しない）/ Content-Length 超過は GET 前に弾く / **HEAD が Content-Length を返さなくても受信後に弾き、ディスクへ書かない** / HEAD 405 は GET へ倒す / 上限内は通す
- ⚠ どちらも `RemoteHost.validator` を差し替えるので、**teardown で必ず元へ戻している**（残すと以後のテストで SSRF ガードが効かない「守れているつもりの緑」になる）

`rake test` は **1023 → 1032 tests / 0 failures / 0 errors**、omissions は **318 のまま不変**。`rake lint` 通過。

## harness 実走（Issue の要求）

`fedi-test-harness`（Mastodon）で実サーバー相手に全スイートを実走しました。

**1104 tests / 2184 assertions / 0 failures / 0 errors / 157 omissions（100% passed、358 秒）**

画像添付を含む経路が実サーバーで通ることを確認済みです。⚠ Misskey ハーネス側は `config/local.yaml` の `controller` を書き換える必要があるため実走していません（本 PR の変更は SNS 非依存で、CI の misskey マトリクスで単体レベルは緑）。