### PR TITLE
perf: media_catalog をローカルアカウント駆動の LATERAL merge にする (#4393)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,9 @@ jobs:
         # 意図してテストを増やしたときは、この数値を実測に合わせて更新する。
         include:
           - controller: mastodon
-            omission_baseline: 318
+            omission_baseline: 321
           - controller: misskey
-            omission_baseline: 307
+            omission_baseline: 310
     services:
       redis:
         image: redis:7

--- a/app/query/mastodon/media_catalog.sql.erb
+++ b/app/query/mastodon/media_catalog.sql.erb
@@ -1,48 +1,107 @@
+<%#
+  media_catalog (#4393)。ローカルアカウント駆動の LATERAL merge。
+
+  ⚠ **駆動表を media_attachments から accounts へ移すのが肝。**
+  素直に書くと、プランナは `ORDER BY attachments.id DESC LIMIT n` の短絡見積りで
+  media_attachments の backward PK scan を選び、selectivity 0.271% の
+  `statuses.local` を probe で捨てる。**index を足しても probe が速くなるだけ**で、
+  候補 A / 候補 B / MATERIALIZED はいずれも届かなかった（#4323 / #4351）。
+  ローカルアカウント（zugoga 実測 19 件）ごとに id DESC の top-N を取り、
+  それを merge して全体の top-N を採る形にすると、走査量が桁で落ちる。
+
+  ⚠ **フィルタは LATERAL の内側に置くこと。**外側に置くと「絞る前の top-N」を
+  確定させてしまい、条件で消えた分だけ全体の件数が足りなくなる（A 案の先読み窓と
+  同じ穴。rule 付きで顕在化しうる）。内側で絞ってから top-N を取れば
+  merge-top-N として厳密に正しい。
+
+  ⚠ **内側の LIMIT は limit + offset。**ページ送り（OFFSET）を使う呼び出しでは、
+  捨てるぶんまで各アカウントから取らないと足りなくなる。
+
+  ⚠ **accounts の条件は内外どちらにも要る。**内側（local_accounts）は枝刈りで、
+  外側は従来どおり statuses.account_id 側で見るための保険。Mastodon では添付の
+  account_id と投稿の account_id は一致する（zugoga 本番で差分 0 行を確認済み）が、
+  出力するアカウント列は従来と同じく **statuses 側から引く**。
+
+  2026-08-20 zugoga 本番実測（現行 → 本クエリ）:
+    page1 26,415ms → 56.7ms / cursor 23,234ms → 5.7ms /
+    only_person 25,998ms → 6.5ms / rule つき 8,900ms → 837ms /
+    rule ヒット無し 2,244ms → 14.0ms（いずれも照合の差分 0 行）
+-%>
+<% offset = params[:cursor] ? 0 : (params[:page] ? ((params[:page] - 1) * params[:limit]) : 0) %>
 SELECT
-  attachments.id,
-  attachments.file_file_name AS name,
-  attachments.file_content_type AS type,
-  attachments.file_file_size AS file_size,
-  attachments.file_meta AS meta,
-  attachments.description,
-  attachments.created_at,
-  statuses.id AS status_id,
-  statuses.text AS status_text,
-  statuses.visibility,
+  picked.id,
+  picked.name,
+  picked.type,
+  picked.file_size,
+  picked.meta,
+  picked.description,
+  picked.created_at,
+  picked.status_id,
+  picked.status_text,
+  picked.visibility,
   accounts.username,
   accounts.display_name
-FROM
-  media_attachments AS attachments
-  INNER JOIN statuses ON attachments.status_id = statuses.id
-  INNER JOIN accounts ON statuses.account_id = accounts.id
-WHERE (statuses.local = true)
-  AND (statuses.reblog_of_id IS null)
-  AND (statuses.visibility < 2)
-  AND (statuses.deleted_at IS null)
-  <% if params[:rule] %>
-    <% params[:rule].keywords.each do |keyword| %>
-      AND (concat_ws(E'\t', statuses.text, statuses.spoiler_text, attachments.description) LIKE '%<%= escape(keyword) %>%')
+FROM (
+  SELECT accounts.id AS account_id
+  FROM accounts
+  WHERE (accounts.domain IS null)
+    AND (accounts.silenced_at IS null)
+    AND (accounts.suspended_at IS null)
+    <% unless params[:only_person].to_i.zero? %>
+      AND ((accounts.actor_type = 'Person') OR (accounts.actor_type IS null))
     <% end %>
-    <% params[:rule].negative_keywords.each do |keyword| %>
-      AND (coalesce(statuses.text, '') NOT LIKE '%<%= escape(keyword) %>%')
-      AND (coalesce(statuses.spoiler_text, '') NOT LIKE '%<%= escape(keyword) %>%')
-      AND (coalesce(attachments.description, '') NOT LIKE '%<%= escape(keyword) %>%')
+    <% if test_account %>
+      AND (accounts.id <> '<%= test_account.id %>')
     <% end %>
-  <% end %>
+) AS local_accounts
+CROSS JOIN LATERAL (
+  SELECT
+    attachments.id,
+    attachments.file_file_name AS name,
+    attachments.file_content_type AS type,
+    attachments.file_file_size AS file_size,
+    attachments.file_meta AS meta,
+    attachments.description,
+    attachments.created_at,
+    statuses.id AS status_id,
+    statuses.text AS status_text,
+    statuses.visibility,
+    statuses.account_id AS status_account_id
+  FROM media_attachments AS attachments
+    INNER JOIN statuses ON attachments.status_id = statuses.id
+  WHERE (attachments.account_id = local_accounts.account_id)
+    AND (statuses.local = true)
+    AND (statuses.reblog_of_id IS null)
+    AND (statuses.visibility < 2)
+    AND (statuses.deleted_at IS null)
+    <% if params[:rule] %>
+      <% params[:rule].keywords.each do |keyword| %>
+        AND (concat_ws(E'\t', statuses.text, statuses.spoiler_text, attachments.description) LIKE '%<%= escape(keyword) %>%')
+      <% end %>
+      <% params[:rule].negative_keywords.each do |keyword| %>
+        AND (coalesce(statuses.text, '') NOT LIKE '%<%= escape(keyword) %>%')
+        AND (coalesce(statuses.spoiler_text, '') NOT LIKE '%<%= escape(keyword) %>%')
+        AND (coalesce(attachments.description, '') NOT LIKE '%<%= escape(keyword) %>%')
+      <% end %>
+    <% end %>
+    <% if params[:cursor] %>
+      AND (attachments.id < '<%= params[:cursor] %>')
+    <% end %>
+  ORDER BY attachments.id DESC
+  LIMIT <%= params[:limit] + offset %>
+) AS picked
+  INNER JOIN accounts ON picked.status_account_id = accounts.id
+WHERE (accounts.silenced_at IS null)
+  AND (accounts.suspended_at IS null)
   <% unless params[:only_person].to_i.zero? %>
     AND ((accounts.actor_type = 'Person') OR (accounts.actor_type IS null))
   <% end %>
-  AND (accounts.silenced_at IS null)
-  AND (accounts.suspended_at IS null)
   <% if test_account %>
     AND (accounts.id <> '<%= test_account.id %>')
   <% end %>
-  <% if params[:cursor] %>
-    AND (attachments.id < '<%= params[:cursor] %>')
-  <% end %>
 ORDER BY
-  attachments.id DESC
+  picked.id DESC
 LIMIT <%= params[:limit] %>
 <% unless params[:cursor] %>
-  OFFSET <%= params[:page] ? ((params[:page] - 1) * params[:limit]) : 0 %>
+  OFFSET <%= offset %>
 <% end %>

--- a/test/unit/lib/attachment.rb
+++ b/test/unit/lib/attachment.rb
@@ -132,5 +132,45 @@ module Mulukhiya
       assert_boolean(attachment_class.cursor_pagination?)
       assert_equal(!Environment.misskey_type?, attachment_class.cursor_pagination?)
     end
+
+    # ⚠ **ページ送りの継ぎ目 (#4393)。**media_catalog はローカルアカウント駆動の
+    # LATERAL merge で、**アカウントごとに top-N を取ってから全体の top-N を採る**。
+    # 内側の LIMIT が足りないと、境界のレコードが**黙って落ちる**。
+    def test_catalog_cursor_has_no_overlap
+      return unless @attachment
+      first = attachment_class.catalog(limit: 2, skip_cache: true)
+      # ⚠ harness は media がほぼ test_account 持ちで、除外すると 1 件しか残らない。
+      # silent skip にせず precondition を明示する（seed の追加は chubo2#64）。
+      omit('ページ送りを検証できるだけの media が未 seed（chubo2#64）') unless first[:has_next]
+      following = attachment_class.catalog(limit: 2, cursor: first[:next_cursor], skip_cache: true)
+      first_ids = first[:items].map {|v| v[:id]}
+      following_ids = following[:items].map {|v| v[:id]}
+
+      assert_equal(first_ids.sort.reverse, first_ids)
+      assert_empty(first_ids & following_ids)
+      assert_operator(following_ids.max, :<, first_ids.min) if following_ids.present?
+    end
+
+    # ⚠ **OFFSET とカーソルが同じ並びを指すこと。**LATERAL の内側 LIMIT は
+    # `limit + offset` でないと、2 ページ目以降で件数が足りなくなる。
+    def test_catalog_page_offset_matches_cursor
+      return unless @attachment
+      first = attachment_class.catalog(limit: 2, skip_cache: true)
+      omit('ページ送りを検証できるだけの media が未 seed（chubo2#64）') unless first[:has_next]
+      by_cursor = attachment_class.catalog(limit: 2, cursor: first[:next_cursor], skip_cache: true)
+      by_offset = attachment_class.catalog(limit: 2, page: 2, skip_cache: true)
+
+      assert_equal(by_cursor[:items].map {|v| v[:id]}, by_offset[:items].map {|v| v[:id]})
+    end
+
+    # only_person は絞り込みなので、結果は常に全体の部分集合。
+    def test_catalog_only_person_is_subset
+      return unless @attachment
+      all_ids = attachment_class.catalog(limit: 10, skip_cache: true)[:items].map {|v| v[:id]}
+      person_ids = attachment_class.catalog(limit: 10, only_person: 1, skip_cache: true)
+        .fetch(:items).map {|v| v[:id]}
+
+      assert_empty(person_ids - all_ids)
+    end
   end
 end


### PR DESCRIPTION
Fixes #4393 / #4351 Gate 2 の前提

zugoga 本番で `bin/diag/media_catalog_subsecond.sql` を流し、3 案を並べて計測した結果 **B 案（ローカルアカウント駆動の LATERAL merge）で go**。計測の全文は [#4323 のコメント](https://github.com/pooza/mulukhiya-toot-proxy/issues/4323#issuecomment-5349297730)。

## 実測（zugoga 本番・`EXPLAIN (ANALYZE, BUFFERS)` / `LIMIT 101`）

| パターン | 現行 | **本実装** |
| --- | --- | --- |
| page1 | 26,415ms | **56.7ms** |
| only_person | 25,998ms | **6.5ms** |
| cursor | 23,234ms | **5.7ms** |
| rule つき（`ラーメン`） | 8,900ms | **837ms** |
| rule ヒット無し | 2,244ms | **14.0ms** |

⚠ **現行のベースラインは劣化していた。**#4351 Gate 1 の時点では「候補 A 適用後 約 10s」だったが、いま測ると 23〜26s。「10s だから Gate 2 保留」（2026-06-06）の前提はさらに厳しい側に振れていた。

## なぜ効くか

⚠ 素直に書くと、プランナは `ORDER BY attachments.id DESC LIMIT n` の短絡見積りで `media_attachments` の backward PK scan を選び、selectivity 0.271% の `statuses.local` を probe で捨てる。**index を足しても probe が速くなるだけ**で、候補 A / 候補 B / `WITH ... MATERIALIZED` はいずれも届かなかった（#4323 / #4351 で 2 度確認済み）。

駆動表を `accounts`（zugoga 実測 **19 件**）へ移し、アカウントごとに `id DESC` の top-N を取って merge すると走査量が桁で落ちる。

⚠ **追加 index は不要だった。**Mastodon 本体が持つ `index_media_attachments_on_account_id_and_status_id`（`(account_id, status_id DESC)`）で成立する。#4353 の恒久化対象は増えない。

## 正確性 — 「速いが違う結果」を採らないための実測

⚠ **フィルタは LATERAL の内側に置いた。**外側に置くと「絞る前の top-N」を確定させてしまい、条件で消えた分だけ全体の件数が足りなくなる。これは棄却した A 案の先読み窓と同じ穴で、**A 案は本番の照合で 44 行取りこぼした**（速さ 1,593ms より、こちらが決め手）。

⚠ **内側の LIMIT は `limit + offset`。**本番で**わざと誤り版（内側 `limit` のみ）を作って照合**したところ、**page2 で 14 行取りこぼした**。正しい版は差分 0 行。

zugoga 本番での照合はいずれも **差分 0 行**:

| 照合 | 結果 |
| --- | --- |
| page1 | 0 行 |
| only_person | 0 行 |
| rule つき | 0 行 |
| **page2（OFFSET 101）** | 0 行 |

## 検証

- `rake test` **1075 → 1078 tests / 0 failures / 0 errors**
- ⚠ **CI の omission baseline を 318→321 / 307→310 へ上げた。**ゲートを緩めたのではなく、**DB を持たない CI では `AttachmentTest` がクラスごと omission になる**ため、追加した 3 件がそのまま omission に乗る
- **fedi-test-harness（Mastodon）実走 1150 tests / 2243 assertions / 0 failures / 0 errors / 159 omissions**
  - ⚠ ページ送りの 2 件は harness の media が**ほぼ `test_account` 持ち**で、除外すると 1 件しか残らないため `omit`（silent skip にはしていない）。seed 追加は chubo2#64。**同じ条件で新旧クエリを直接叩いて件数が一致すること（どちらも 1 件）は確認済み**

## この後

#4351 Gate 2（overlay flip + 24 時間観測）へ進める。⚠ 観測には **DB 接続プール使用率**を必ず含める（2026-05-19 の全サーバー投稿不可障害の再発監視）。**本 PR 自体は overlay を触らないので、マージしても本番の挙動は変わらない**（`media_catalog` は zugoga でも無効のまま）。
