### PR TITLE
obs: /health に接続プールの使用状況を出す (#4351 Gate 2 の前提)

### DIFF
--- a/app/lib/mulukhiya/dbms/postgres.rb
+++ b/app/lib/mulukhiya/dbms/postgres.rb
@@ -45,11 +45,36 @@ module Mulukhiya
     def self.health
       return {status: 'OK', skipped: true} unless config?
       instance.connection.fetch('SELECT 1 AS ok').first
-      return {status: 'OK'}
+      return {status: 'OK'}.merge(pool)
     rescue Sequel::PoolTimeout => e
-      return {error: e.message, status: 'WARN', reason: 'pool_exhausted'}
+      return {error: e.message, status: 'WARN', reason: 'pool_exhausted'}.merge(pool)
     rescue => e
       return {error: e.message, status: 'NG'}
+    end
+
+    # 接続プールの使用状況 (#4351 Gate 2)。
+    #
+    # ⚠ **枯渇してからでは遅い。**従来の health は `Sequel::PoolTimeout` を掴んだ
+    # ときだけ `pool_exhausted` を出す＝**もう詰まっている**状態しか見えず、
+    # 「詰まりに近づいている」を観測できなかった。2026-05-19 の全サーバー投稿不可は
+    # 重い media_catalog SQL による接続プール枯渇が最有力で（#4323 / pooza/chubo2#37）、
+    # media_catalog を再有効化する前にここが見えている必要がある。
+    #
+    # ⚠ **`waiting` が本命の指標。**Sequel の TimedQueueConnectionPool は
+    # 「使用中の本数」を持たないが、`num_waiting`（接続を待って**ブロックしている
+    # スレッド数**）は持つ。これが 0 を超えたら、プールが要求に足りていない。
+    # `allocated` が `max` に張り付いているだけなら正常（作った接続を使い回す設計）。
+    def self.pool
+      pool = instance.connection.pool
+      return {pool: {
+        max: pool.max_size,
+        allocated: pool.size,
+        waiting: pool.respond_to?(:num_waiting) ? pool.num_waiting : nil,
+      }.compact}
+    rescue => e
+      # 観測が取れないこと自体で health を落とさない。
+      e.log
+      return {}
     end
   end
 end

--- a/test/unit/dbms/postgres.rb
+++ b/test/unit/dbms/postgres.rb
@@ -1,10 +1,39 @@
 module Mulukhiya
   class PostgresTest < TestCase
+    class FakePool
+      attr_reader :max_size, :size, :num_waiting
+
+      def initialize(max: 10, size: 3, waiting: 0)
+        @max_size = max
+        @size = size
+        @num_waiting = waiting
+      end
+    end
+
+    # 「使用中の本数」しか持たない旧来のプール実装 (num_waiting なし) を模す。
+    class FakeLegacyPool < FakePool
+      undef_method :num_waiting
+    end
+
     class FakeConnection
       attr_reader :disconnected
+      attr_writer :pool
+
+      def initialize(pool = nil)
+        @pool = pool
+      end
 
       def disconnect
         @disconnected = true
+      end
+
+      def pool
+        raise 'no pool' unless @pool
+        return @pool
+      end
+
+      def fetch(_sql)
+        return [{ok: 1}]
       end
     end
 
@@ -19,6 +48,13 @@ module Mulukhiya
     def teardown
       Singleton.__init__(Postgres)
       super
+    end
+
+    def stub_instance(pool)
+      Postgres.instance_variable_set(
+        :@singleton__instance__,
+        FakeInstance.new(FakeConnection.new(pool)),
+      )
     end
 
     def test_connected_reflects_singleton_state
@@ -41,6 +77,45 @@ module Mulukhiya
       assert_nil(Postgres.reconnect)
       assert(conn.disconnected)
       assert_false(Postgres.connected?)
+    end
+
+    # ⚠ **枯渇してからでは遅い (#4351 Gate 2)。**従来の health は PoolTimeout を
+    # 掴んだときだけ pool_exhausted を出す＝もう詰まっている状態しか見えなかった。
+    def test_pool_reports_capacity_and_waiting
+      stub_instance(FakePool.new(max: 10, size: 3, waiting: 0))
+
+      assert_equal({pool: {max: 10, allocated: 3, waiting: 0}}, Postgres.pool)
+    end
+
+    # ⚠ waiting が本命の指標。allocated が max に張り付くのは正常（使い回す設計）で、
+    # 待ちが立ったときだけプールが要求に足りていない。
+    def test_pool_reports_waiting_threads
+      stub_instance(FakePool.new(max: 10, size: 10, waiting: 4))
+
+      assert_equal(4, Postgres.pool.dig(:pool, :waiting))
+    end
+
+    # num_waiting を持たないプール実装ではキーごと落とす（nil を出さない）。
+    def test_pool_omits_waiting_when_unsupported
+      stub_instance(FakeLegacyPool.new(max: 10, size: 3))
+
+      assert_equal({pool: {max: 10, allocated: 3}}, Postgres.pool)
+    end
+
+    # ⚠ 観測が取れないこと自体で health を落とさない。
+    def test_pool_is_empty_when_unavailable
+      stub_instance(nil)
+
+      assert_empty(Postgres.pool)
+    end
+
+    def test_health_includes_pool
+      config['/postgres/dsn'] = 'postgres://example.invalid/dummy'
+      stub_instance(FakePool.new(max: 10, size: 2, waiting: 0))
+      health = Postgres.health
+
+      assert_equal('OK', health[:status])
+      assert_equal({max: 10, allocated: 2, waiting: 0}, health[:pool])
     end
 
     # 既存インスタンスが無い (ブート時 DSN 無し) 場合は切断をスキップして繋ぎ直す。


### PR DESCRIPTION
#4351 Gate 2（media_catalog の overlay flip）の観測に必要な分。

## なぜ要るか

⚠ **枯渇してからでは遅い。**いまの `/health` は `Sequel::PoolTimeout` を掴んだときだけ `pool_exhausted` を出す＝**もう詰まっている**状態しか見えず、「詰まりに近づいている」を観測できない。

本番 zugoga の現状:

```json
"postgres": {"status": "OK"}
```

2026-05-19 の全サーバー投稿不可は、重い media_catalog SQL による**接続プール枯渇**が最有力（#4323 / pooza/chubo2#37）。Gate 2 の rollback 判断をこの指標で行う以上、先に見えるようにしておく。

## 出すもの

```json
"postgres": {"status": "OK", "pool": {"max": 10, "allocated": 3, "waiting": 0}}
```

⚠ **`waiting` が本命。**Sequel の `TimedQueueConnectionPool` は「使用中の本数」を持たないが、`num_waiting`（接続を待って**ブロックしているスレッド数**）は持つ。**0 を超えたらプールが要求に足りていない。**`allocated` が `max` に張り付いているだけなら正常（作った接続を使い回す設計）。

⚠ **観測が取れないこと自体で health を落とさない。**pool 取得の失敗は握ってキーごと省く。`num_waiting` を持たない実装でも `nil` を出さない。

## テスト

`test/unit/dbms/postgres.rb` に 5 本追加（capacity / waiting / 非対応プール / 取得失敗 / health への合流）。⚠ 既存のフェイク実装に乗せてあるので **DB 無しの CI でも実走する**（omission は 321 / 310 のまま不変）。

`rake test` **1078 → 1083 tests / 0 failures / 0 errors**。`rake lint` 通過。
