### PR TITLE
security: プリフライトで host_validator が消え、GET が無検証になっていた (#4576)

### DIFF
--- a/app/lib/mulukhiya/media_file.rb
+++ b/app/lib/mulukhiya/media_file.rb
@@ -183,15 +183,28 @@ module Mulukhiya
         'tmp/media',
         "#{uri.to_s.sha256}#{File.extname(uri.path)}",
       )
-      options = {}
-      options[:host_validator] = params[:host_validator] if params[:host_validator]
       raise Ginseng::GatewayError, "Too large content '#{uri}'" unless
-        valid_content_length?(uri, options)
-      body = HTTP.new.get(uri, options).body.to_s
+        valid_content_length?(uri, request_options(params))
+      body = HTTP.new.get(uri, request_options(params)).body.to_s
       raise Ginseng::GatewayError, "Too large content '#{uri}'" if
         body.bytesize > download_max_bytes
       File.write(path, body)
       return new(path).file
+    end
+
+    # HTTP 呼び出しごとに**作り直す**オプション。
+    #
+    # ⚠⚠ **同じ hash を head と get で使い回してはいけない (pooza/ginseng-core#528)。**
+    # `Ginseng::HTTP#request` は `options.delete(:host_validator)` で**呼び出し側の
+    # hash を破壊する**ため、プリフライト（HEAD）を通した時点で validator が消え、
+    # **本命の GET が無検証で撃たれる**（＝ HTTParty の自動追従に戻り、リダイレクト先が
+    # 内部アドレスでも追従する）。実測でも validator の呼び出しは HEAD の 1 回だけだった。
+    # ⚠ **「プリフライトを足したせいで GET の検証が外れる」**という、#4523 が塞ごうとした
+    # ものの裏返し。gem 側の是正は pooza/ginseng-core#528 で、こちらは**それが入っても
+    # 壊れない書き方**にしておく。
+    def self.request_options(params)
+      return {} unless params[:host_validator]
+      return {host_validator: params[:host_validator]}
     end
 
     # 相手が申告した Content-Length が上限を超えていれば GET せずに弾く。

--- a/test/unit/lib/media_file_download.rb
+++ b/test/unit/lib/media_file_download.rb
@@ -58,6 +58,27 @@ module Mulukhiya
       assert_path_not_exist(path_for(URL))
     end
 
+    # ⚠⚠ **プリフライトを通したあとの GET も検証されること
+    # (pooza/ginseng-core#528)。**`Ginseng::HTTP#request` は
+    # `options.delete(:host_validator)` で呼び出し側の hash を壊すので、同じ hash を
+    # head と get で使い回すと **GET だけ無検証**になる（＝リダイレクト先が内部でも
+    # 追従する）。呼び出しごとに hash を作り直していることを、validator の
+    # **呼ばれた回数**で押さえる。
+    def test_validator_is_applied_to_both_head_and_get
+      hosts = []
+      RemoteHost.validator = lambda do |host|
+        hosts.push(host)
+        return '93.184.216.34'
+      end
+      stub_request(:head, URL).to_return(status: 200, headers: {'Content-Length' => '5'})
+      stub_request(:get, URL).to_return(status: 200, body: 'small')
+
+      download(URL)
+
+      assert_equal(2, hosts.size)
+      assert_equal(['media.example.com'], hosts.uniq)
+    end
+
     # HEAD 非対応 (405) は「判定不能」として GET へ倒す。正常系を塞がないこと。
     def test_head_not_supported_falls_back_to_get
       allow_all


### PR DESCRIPTION
⚠⚠ **#4576（PR #4611）で塞いだつもりの SSRF ガードが、GET 側で外れていました。**

## 何が起きていたか

`Ginseng::HTTP#request` は `options.delete(:host_validator)` で**呼び出し側の hash を破壊します**（pooza/ginseng-core#528）。`MediaFile.download` は同じ hash を HEAD プリフライトと本命の GET で使い回していたため、

```
before head: [:host_validator]
after  head: [:headers]          ← 消えている
validator が呼ばれた回数: 1      ← HEAD の 1 回だけ
```

**GET は HTTParty の自動追従に戻っていました**＝リダイレクト先が内部アドレスでも追従します。事前の `RemoteHost.validate!`（`Handler#upload`）が初段のホストを見ているので「任意の内部 URL を直接指定」はできませんが、**攻撃者の公開ホストが `302 Location: http://127.0.0.1:9200/` を返す**経路は開いたままでした。

⚠ **「プリフライトを足したせいで本命の検証が外れる」**という、#4523 が塞ごうとしたものの裏返しです。

## 直し方

呼び出しごとに hash を作り直します（`request_options`）。⚠ gem 側の是正（pooza/ginseng-core#528・別途 PR を出します）が入っても壊れない形です。

## テスト

回帰テストは **validator の呼ばれた回数**で押さえました。hash を共有する形へ戻すと **1 回になって落ちる**ことを確認済みです:

```
Failure: test_validator_is_applied_to_both_head_and_get
<2> expected but was <1>
```

`rake test` **1083 → 1084 tests / 0 failures / 0 errors**、omissions 321 / 310 のまま不変。`rake lint` 通過。

## ⚠ 他の呼び出し元は無事

`PronunciationDictionary#fetch_one` と `ProgramFetcher` は head と get で**別々の hash リテラル**を渡しているため影響しません（実装を確認済み）。**この形が正しい**ので、以後もそう書くこと。
