### PR TITLE
security: 壊れたバイト列でログのマスクが外れる穴を塞ぐ (#4616)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-core.git
-  revision: ab02f5e36eb3848ebd5556c25ecdc9c166e6da93
+  revision: 779e8958e93de066e761037b758b055607429494
   branch: main
   specs:
-    ginseng-core (1.17.0)
+    ginseng-core (1.19.0)
       activesupport (>= 7.0.7.1)
       addressable (>= 2.9.0)
       cgi (>= 0.4.2)
@@ -30,7 +30,7 @@ GIT
       net-smtp
       nokogiri (>= 1.18.9)
       optparse
-      rake (< 13.4)
+      rake (!= 13.4.0)
       sanitize (>= 6.0.2)
       securerandom
       set
@@ -359,7 +359,7 @@ GEM
       loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rainbow (3.1.1)
-    rake (13.3.1)
+    rake (13.4.2)
     redis-client (0.30.1)
       connection_pool
     regexp_parser (2.12.0)

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1441,7 +1441,32 @@ Issue #4233 の APIController 段階的リファクタは「1〜2 マイルス�
 - `cd ~/repos/chubo2 && git fetch origin` + `git log HEAD..origin/main --oneline` でリモートとの差分を確認
 - `docs/infra-note.md` に変更があれば MEMORY.md のインフラセクションに反映が必要か判断
 - chubo2 の `gh issue list --state open` で open Issue の変動を確認
-- ginseng-\* は**こちらが送った Issue / PR の進捗だけ**見る（一覧の棚卸しはしない）
+- ginseng-\* は**こちらが送った Issue / PR の進捗**と、**下の「ピンのずれ」**だけ見る（一覧の棚卸しはしない）
+
+##### ginseng-\* のピンのずれを見る（2026-08-21 追加）
+
+⚠⚠ **ginseng-\* は依頼が無くても自走で更新される**（2026-08-21 ユーザー明示）。
+`Gemfile.lock` は git gem の **revision 固定**なので、**向こうが直しても `bundle update` するまで
+こちらには 1 バイトも届かない**。「Issue が close された」は**取り込み済みを意味しない**。
+
+```sh
+# ロック済み revision と各リポジトリの main HEAD を突き合わせる
+ruby -e 'File.read("Gemfile.lock").scan(%r{github\.com/pooza/(ginseng-\w+)\.git\s+revision: (\h+)}) {|n,r|
+  head = `gh api repos/pooza/#{n}/commits/main --jq .sha`.strip
+  puts "#{n}\t#{head.start_with?(r) ? "同一" : "ずれ #{r[0,8]} -> #{head[0,8]}"}" }'
+```
+
+- **ずれていたら「何が変わったか」を読む**: `gh api repos/pooza/ginseng-X/compare/<locked>...main --jq '.commits[].commit.message'`。
+  ⚠ **モロヘイヤが触る面**（`HTTP` / `Logger` / `Controller` / `TagContainer` / `Environment`）に
+  当たるかで判断する
+- **判断は 3 択**: ① すぐ取り込む（実害がある・依頼した修正の着地）② 次のマイルストーンで取り込む
+  ③ 見送る。**②③ は理由を台帳に 1 行残す**（次の同期で同じ調査をしないため）
+- ⚠ **`bundle update`（引数なし）は 8 本まとめて動く。**依頼した修正の取り込みは
+  **`bundle update <gem>` と gem 単位で**行う（赤が出たときの切り分けができなくなる）
+- ⚠ **取り込んだら `rake lint` と `rake test` を必ず通す。**「向こうが直した」は
+  「こちらで動く」ではない。逆向き（gem がこちらの値を捨てる）で 2 回踏んでいる（#4589 / #4594）
+- ⚠ **`Gemfile.lock` のルーチン最新化とは別物として扱う。**ルーチンは PR 不要（[[feedback_gemfile-lock-routine]]）
+  だが、**自走更新が混じるようになったので差分を読まずに上げない**
 
 #### 6-2. 30 日ごとの棚卸し
 

--- a/test/unit/lib/logger_mask_boundary.rb
+++ b/test/unit/lib/logger_mask_boundary.rb
@@ -1,0 +1,79 @@
+module Mulukhiya
+  # gem 境界のテスト (#4616)。
+  #
+  # ログのマスクは **モロヘイヤの config（`/logger/mask_fields` /
+  # `/logger/mask_query_params`）と ginseng-core の実装の合わせ技**で成立している。
+  # かつて `Logger#mask_url` は不正なバイト列を含む値で `ArgumentError` を上げ、
+  # それが `create_message` の rescue まで飛んで **素の src がそのまま返る ＝
+  # マスクが丸ごと外れる**状態だった (pooza/ginseng-core#518)。
+  #
+  # ⚠⚠ **`Controller#before` は受信 params をそのまま `logger.info` に載せる**ので、
+  # **外から壊れたバイト列を 1 つ混ぜるだけでその行のマスクを外せた。**#4511 で
+  # 掃討したはずのトークン平文が、この経路で戻っていたことになる。
+  #
+  # ⚠ `log_scrub` の側（`SCRUBBED_LOG_PARAMS`）は gem を通らないので、この退行を
+  # 捕まえられない。**gem が「何を出力するか」**を押さえるのはこのファイルの役目。
+  # bundle update で黙って戻る類なので、上流の実装ではなく境界の契約として残す。
+  #
+  # ⚠ **モロヘイヤの実 config で実測した 1.17.0 の出力**（同じ入力・同じ config）:
+  #
+  # ```
+  # {"password":"hoge","url":"https://example.com/?access_token=SECRET&s=\xE3\x81ho"}
+  # ```
+  #
+  # **`password` も `access_token` も平文**で、行そのものも妥当な UTF-8 ではなかった。
+  # 1.19.0 では同じ入力が `[FILTERED]` ＋ `_encoding_error: true` になる。
+  class LoggerMaskBoundaryTest < TestCase
+    # ⚠ **不正な UTF-8 バイト列。**`"\xE3\x81"` は 3 バイト文字の途中で切れている。
+    BROKEN = "\xE3\x81ho".dup.force_encoding(Encoding::UTF_8).freeze
+
+    def setup
+      @logger = Logger.new
+    end
+
+    def entry(src)
+      return @logger.create_entry(src)
+    end
+
+    # 眼目。壊れたバイト列が混ざっても、マスクは外れない。
+    def test_mask_survives_broken_bytes
+      line = entry(password: 'hoge', url: "https://example.com/?access_token=SECRET&s=#{BROKEN}")
+
+      assert_not_match(/hoge/, line)
+      assert_not_match(/SECRET/, line)
+    end
+
+    # ⚠ 行が消えるのも困る（ログは最後の観測手段）。落とさずに 1 行出すこと。
+    def test_broken_bytes_still_produce_a_line
+      line = entry(url: "https://example.com/?s=#{BROKEN}")
+
+      assert_true(line.present?)
+      assert_true(line.valid_encoding?)
+    end
+
+    # ⚠ 直したことを隠さない。JSON として読む側が「直った行」と分かる印。
+    def test_broken_bytes_are_flagged
+      assert_match(/_encoding_error/, entry(url: "https://example.com/?s=#{BROKEN}"))
+    end
+
+    # ⚠ **`logger.info(url)` はいちばん自然な呼び方**なので経路として太い
+    # (pooza/ginseng-core#529)。Hash 以外でもマスクを通ること。
+    def test_masks_bare_string
+      assert_not_match(/SECRET/, entry('https://example.com/?access_token=SECRET'))
+    end
+
+    # 壊れていない側の退行検知（上の 4 本が「全部伏せる」で通ってしまわないように）。
+    def test_masks_normal_input
+      line = entry(password: 'hoge', url: 'https://example.com/?access_token=SECRET&q=1')
+
+      assert_not_match(/hoge/, line)
+      assert_not_match(/SECRET/, line)
+      assert_match(/example\.com/, line)
+    end
+
+    # マスク対象外まで消さない（ログが役に立たなくなるため）。
+    def test_keeps_other_values
+      assert_match(/note-id/, entry(note: 'note-id'))
+    end
+  end
+end

--- a/test/unit/model/listener.rb
+++ b/test/unit/model/listener.rb
@@ -44,10 +44,20 @@ module Mulukhiya
       assert_equal(expected, @listener.verify_peer?)
     end
 
+    # ⚠ **nil は正解**（#4586 / pooza/ginseng-core#512、ginseng-core 1.19.0 で着地）。
+    # `Faye::WebSocket::SslVerifier` は `root_cert_file` が nil なら
+    # `cert_store.set_default_paths` ＝ **システムの CA ストア**に倒れる。
+    #
+    # 🔴 **駄目なのは「存在しないパス」のほう。**同 verifier は値があると
+    # `cert_store.add_file(path)` を呼ぶので、**無いファイルを渡すと接続時に落ちる**。
+    # かつて gem が `ENV['SSL_CERT_FILE']` に `<root>/cert/cacert.pem` を無条件で立てており
+    # （このリポジトリに `cert/` は無い）、**ここがその地雷を踏む唯一の経路**だった。
+    # 1.19.0 は存在しないパスを立てなくなったので nil に倒れる。
     def test_root_cert_file
       require_listener!
+      path = @listener.root_cert_file
 
-      assert_path_exist(@listener.root_cert_file)
+      assert_true(path.nil? || File.exist?(path), "存在しないパスを渡している: #{path}")
     end
 
     def test_keepalive


### PR DESCRIPTION
Fixes #4616

`ginseng-core` を **1.17.0 → 1.19.0**（`ab02f5e` → `779e895`）へ更新する。

## 🔴 起票より重かった — 「ログが消える」ではなく「マスクが外れる」

依頼した [ginseng-core#518](https://github.com/pooza/ginseng-core/issues/518) は「不正なバイト列でログ 1 行が消える」で起票したが、向こうの調査で**もっと悪い経路**が出た。

`Logger#mask_url` は値を正規表現にかけるので、**不正なバイト列があると `ArgumentError`** が上がる。それが `create_message` の `rescue` まで飛び、**素の src がそのまま返る ＝ `mask_fields` も `mask_query_params` も効かない**まま syslog へ出ていた。

⚠⚠ **`Controller#before` は受信 params をそのまま `logger.info` に載せる**（[controller.rb](../blob/develop/app/lib/mulukhiya/controller.rb)）。つまり **外から壊れたバイト列を 1 つ混ぜるだけで、その行のマスクを外せた。**#4511 で掃討したはずのトークン平文が、この経路で戻っていたことになる。

**モロヘイヤの実 config で 1.17.0 を実測した出力**（同じ入力・同じ config）:

```
{"password":"hoge","url":"https://example.com/?access_token=SECRET&s=<壊れたバイト列>"}
leaked_password=true leaked_token=true valid_utf8=false
```

1.19.0 では同じ入力が `[FILTERED]` ＋ `_encoding_error: true` になる。

## 回帰テスト

`test/unit/lib/logger_mask_boundary.rb`（**gem 境界の契約テスト**）を追加した。

⚠ **`log_scrub` の側（`SCRUBBED_LOG_PARAMS`）は gem を通らないので、この退行を捕まえられない。**gem が「何を出力するか」を押さえるのがこのファイルの役目で、`bundle update` で黙って戻る類なので上流の実装ではなく境界の契約として残している（#4594 の `mastodon_upload_error_boundary.rb` と同じ立て付け）。

6 本: 壊れたバイト列でもマスクが外れないこと / 行が消えないこと / `_encoding_error` が付くこと / **裸の String でもマスクされること**（`logger.info(url)` は最も自然な呼び方。[ginseng-core#529](https://github.com/pooza/ginseng-core/issues/529)）/ 壊れていない入力の退行検知 / マスク対象外を消さないこと。

## `ListenerTest#test_root_cert_file` の是正（gem 更新に伴う）

⚠ **これは gem 更新が「実害のある地雷を外した」結果で、退行ではない。**

`Faye::WebSocket::SslVerifier` は `root_cert_file` が値を持つと `cert_store.add_file(path)` を呼び、**無いファイルを渡すと接続時に落ちる**。値が nil なら `set_default_paths` ＝ システムの CA ストアに倒れる。

旧 gem は `Ginseng::HTTP#initialize` で `ENV['SSL_CERT_FILE'] ||= <root>/cert/cacert.pem` を無条件に立てていたが、**このリポジトリに `cert/` は無い**。`Listener#root_cert_file` は config キーが無いので `ENV['SSL_CERT_FILE']` に倒れる ＝ **ここが存在しないパスを掴む唯一の経路**だった（#4586 の実害面。[ginseng-core#512](https://github.com/pooza/ginseng-core/issues/512) で着地）。

1.19.0 は存在しないパスを立てないので nil に倒れる。テストは `assert_path_exist` から **「nil か、存在するパス」＝ 存在しないパスを渡していないこと**へ変えた。

⚠ **`cert/cacert.pem` を持つかどうかは #4617 の話**で、本 PR では扱わない（上流の 1. により**持たない状態が無害**になったため）。

## 同じ `bundle update` に乗ってくるもの（載せ替えは本 PR では扱わない）

⚠ **gem 側の変更が入ることと、こちらの載せ替え作業を 5.34.0 でやることは別。**

- `#514` **timeout が実際に HTTParty へ渡るようになった**（既定 30 秒）。⚠ アプリ側の `/http/timeout/seconds` は **#4593** で別途
- `#526` / `#534` / `#538` `max_bytes`（`get` / `post` / `put` / `delete`）。⚠ `MediaFile.download` の載せ替えは **#4612**
- `#528` / `#533` `host_validator` を options から delete しなくなった（使い回しでの無検証を解消）
- `#525` / `#549` 429 の `Retry-After` に従い、長すぎる待ちは諦める
- `#516` `format: uri` が**絶対 URI を要求**するようになった。⚠ 向こうで利用アプリ 3 つの実設定と突き合わせ、新規エラー 0 件を確認済み
- `#529` どの形で渡してもマスクを通し、通せなければ**中身を出さない**（fail closed）

なお `rake` のピンが `< 13.4` → `!= 13.4.0` に緩んだ分、`rake 13.3.1 → 13.4.2` も動く。

## 検証

- **fedi-test-harness（Mastodon v4.7.0）実走で 1162 tests / 2261 assertions / 0 failures / 0 errors / 159 omissions。**
  ⚠ 同じハーネス・同じ HEAD の**更新前ベースラインは 1156 / 2250 / 0 / 0 / 159**（本日 `verified` 昇格時の実走）。差は**本 PR で足した 6 本**だけで、**omissions は増減なし**
- ⚠ **`ListenerTest` の 1 error は本 PR 内で是正済み**（上記）。それ以外に新規の赤は無い
- `rake lint` 緑（rubocop / erb-lint / slim-lint / bundler-audit）
- ⚠ **修正前の gem で新テストが落ちることは確認済み**。1.17.0 には `create_entry` が無く、同等の seam（`create_message(...).to_json`）で**平文の漏洩を再現**した（上の実測出力）

## 同梱: 同期手順の更新（`c97266fa`）

⚠ **ginseng-\* は依頼が無くても自走で更新される**ようになった（2026-08-21 ユーザー明示）。`Gemfile.lock` は revision 固定なので**向こうが直しても `bundle update` するまで届かない**＝「Issue が close された」は取り込み済みを意味しない。実際に**8 本すべて**がロック済み revision より先へ進んでいた。

同期手順 §6-1 に「ピンのずれを見る」を追加した（突き合わせの 1 行・判断の 3 択・**`bundle update` は gem 単位で**・取り込んだら lint と test を必ず通す）。
