### PR TITLE
fix: ALT 編集の PUT が Mastodon で 500 になるのを止める (#4621)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,10 +42,10 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-fediverse.git
-  revision: 8031dd9ccef1aea11b73af312de429e37375bfe9
+  revision: 0129fa5ec6e129ba7bdd89c10ba4b706d680c313
   branch: main
   specs:
-    ginseng-fediverse (1.8.28)
+    ginseng-fediverse (1.8.29)
 
 GIT
   remote: https://github.com/pooza/ginseng-piefed.git

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-core.git
-  revision: 779e8958e93de066e761037b758b055607429494
+  revision: 4a029e9c4d4c14f82c86c3836db830c3144a0e98
   branch: main
   specs:
     ginseng-core (1.19.0)

--- a/app/lib/mulukhiya/controller/mastodon_controller.rb
+++ b/app/lib/mulukhiya/controller/mastodon_controller.rb
@@ -75,7 +75,7 @@ module Mulukhiya
       reporter.response = sns.update_status(
         params[:id],
         create_status_update_body(purpose, params),
-        {headers: @headers},
+        {headers: upstream_headers},
       )
       @renderer.message = reporter.response.parsed_response
       @renderer.status = reporter.response.code
@@ -181,8 +181,9 @@ module Mulukhiya
     # 添付とアンケートを同時に持てないため ALT 編集では到達しない。`tag` purpose
     # を実装するときは別途注意すること。
     def create_media_update_body(params)
-      source = sns.fetch_status_source(params[:id], {headers: @headers})
-      status = sns.fetch_status(params[:id], {headers: @headers})
+      headers = upstream_headers
+      source = sns.fetch_status_source(params[:id], {headers:})
+      status = sns.fetch_status(params[:id], {headers:})
       return {
         status: source['text'],
         spoiler_text: source['spoiler_text'].to_s,
@@ -190,6 +191,22 @@ module Mulukhiya
         media_ids: Array(status['media_attachments']).map {|v| v['id']},
         media_attributes: params[:media_attributes],
       }
+    end
+
+    # モロヘイヤ自身が上流 Mastodon を叩くときのヘッダ (#4621)。
+    #
+    # ⚠ **クライアントの `X-Mulukhiya-Purpose` を引き継がない。** これは
+    # 「この要求はモロヘイヤへ通してよい」と nginx へ名乗るためのヘッダで、
+    # 上流へ出ていく要求には意味が無い。
+    #
+    # 引き継ぐと、vhost に #4474 以前の `if ($http_x_mulukhiya_purpose != '')`
+    # が残っている環境で **モロヘイヤ自身の内部 fetch が :3008 へ送り返されて
+    # ループし、GET が 404 になる**（ステージングで実際に起きた）。
+    # ⚠ `/source` は location の正規表現に一致せず素通りして 200 だったため、
+    # **`/source` は通るのに `fetch_status` だけ落ちる**という非対称になり
+    # 気づきにくい。正しい nginx なら無害だが、名乗る理由が無いものは出さない。
+    def upstream_headers
+      return @headers.except('X-Mulukhiya-Purpose')
     end
 
     def token

--- a/test/unit/controller/alt_edit_body.rb
+++ b/test/unit/controller/alt_edit_body.rb
@@ -14,28 +14,37 @@ module Mulukhiya
   class AltEditBodyTest < TestCase
     # `fetch_status_source` / `fetch_status` だけ返す SNS のダブル。
     class SnsDouble
+      # 内部 fetch に渡されたヘッダ。#4621 の検証に使う。
+      attr_reader :source_headers, :status_headers
+
       def initialize(source, status)
         @source = source
         @status = status
       end
 
-      def fetch_status_source(_id, _params = {})
+      def fetch_status_source(_id, params = {})
+        @source_headers = params[:headers]
         return @source
       end
 
-      def fetch_status(_id, _params = {})
+      def fetch_status(_id, params = {})
+        @status_headers = params[:headers]
         return @status
       end
     end
 
-    def build_body(source: nil, status: nil, params: nil)
+    def create_controller(source: nil, status: nil, headers: nil)
       controller = MastodonController.new!
-      controller.instance_variable_set(:@headers, {})
+      controller.instance_variable_set(:@headers, headers || {})
       controller.instance_variable_set(:@sns, SnsDouble.new(
         source || {'text' => '本文', 'spoiler_text' => ''},
         status || {'sensitive' => false, 'media_attachments' => [{'id' => '111'}]},
       ))
-      return controller.create_media_update_body(
+      return controller
+    end
+
+    def build_body(source: nil, status: nil, params: nil, headers: nil)
+      return create_controller(source:, status:, headers:).create_media_update_body(
         params || {id: '1', media_attributes: [{id: '111', description: 'ゴメちゃん'}]},
       )
     end
@@ -100,6 +109,46 @@ module Mulukhiya
 
       # ⚠ refute だけだと nil でも通ってしまうので、型で false を名指しする。
       assert_instance_of(FalseClass, body[:sensitive])
+    end
+
+    # ⚠ **内部 fetch にクライアントの `X-Mulukhiya-Purpose` を持ち込まない (#4621)。**
+    # Purpose は nginx への名乗りであって上流に意味は無く、#4474 以前の
+    # `if ($http_x_mulukhiya_purpose != '')` が残った vhost では内部 fetch が
+    # モロヘイヤへ送り返されてループする（ステージングで実際に起きた）。
+    def test_purpose_is_not_carried_into_internal_fetch
+      controller = create_controller(headers: {
+        'Authorization' => 'Bearer ゴメちゃん',
+        'X-Mulukhiya-Purpose' => 'media_update',
+      })
+      controller.create_media_update_body({id: '1', media_attributes: [{id: '111'}]})
+      sns = controller.instance_variable_get(:@sns)
+
+      refute(sns.source_headers.key?('X-Mulukhiya-Purpose'))
+      refute(sns.status_headers.key?('X-Mulukhiya-Purpose'))
+    end
+
+    # ⚠ **Authorization まで落とさない。** 内部 fetch は利用者のトークンで
+    # 読みに行くので、これが欠けると自分の投稿すら 404 になる。
+    def test_authorization_survives_in_internal_fetch
+      controller = create_controller(headers: {
+        'Authorization' => 'Bearer ゴメちゃん',
+        'X-Mulukhiya-Purpose' => 'media_update',
+      })
+      controller.create_media_update_body({id: '1', media_attributes: [{id: '111'}]})
+      sns = controller.instance_variable_get(:@sns)
+
+      assert_equal('Bearer ゴメちゃん', sns.source_headers['Authorization'])
+      assert_equal('Bearer ゴメちゃん', sns.status_headers['Authorization'])
+    end
+
+    # ⚠ **呼び元の @headers を壊さない。**`token` が同じハッシュを読むので、
+    # 破壊的に消すと以後の照合が変わる。
+    def test_original_headers_are_not_mutated
+      headers = {'X-Mulukhiya-Purpose' => 'media_update'}
+      controller = create_controller(headers:)
+      controller.create_media_update_body({id: '1', media_attributes: [{id: '111'}]})
+
+      assert_equal('media_update', headers['X-Mulukhiya-Purpose'])
     end
   end
 end

--- a/test/unit/service/mastodon_status_update_boundary.rb
+++ b/test/unit/service/mastodon_status_update_boundary.rb
@@ -1,0 +1,98 @@
+module Mulukhiya
+  # gem 境界のテスト (#4621)。
+  #
+  # ALT 編集の `PUT /api/v1/statuses/:id` で、**`media_attributes` が Hash の
+  # 配列のまま上流へ届くか**は gem 側の組み立てに握られている。かつて
+  # ginseng-fediverse は `media_attributes[0][id]=...` と**数字の添字**で
+  # form-urlencode しており、この形は Rack / Rails 側で `fields_for` 形式の
+  # Hash `{"0" => {...}}` に解釈され**配列にならなかった**。Mastodon の
+  # `UpdateStatusService` は `(@options[:media_attributes] || []).each` と回すので
+  # `["0", {...}]`（Array）を掴み、`attributes[:id]` で
+  # `TypeError: no implicit conversion of Symbol into Integer` ＝ **500** になった
+  # (pooza/ginseng-fediverse#253)。
+  #
+  # ⚠ `alt_edit_body` は**モロヘイヤが組んだ Hash** しか見ないので、この退行を
+  # 捕まえられない。**gem が組んだリクエスト**を押さえるのがこのファイルの役目。
+  # `bundle update` で黙って戻る類なので、境界の契約として残す。
+  class MastodonStatusUpdateBoundaryTest < TestCase
+    # PUT の引数を捕まえるだけの http スタブ。
+    class CapturingHTTP
+      attr_reader :options
+
+      def put(_uri, options = {})
+        @options = options
+        return nil
+      end
+    end
+
+    def update(body)
+      http = CapturingHTTP.new
+      service = Ginseng::Fediverse::MastodonService.new(Ginseng::URI.parse('https://precure.ml/'))
+      service.instance_variable_set(:@http, http)
+      service.update_status('111', body)
+      return http.options
+    end
+
+    # ⚠ ginseng-core の `create_body` は Content-Type が JSON のときだけ
+    # `to_json` する。無指定だと HTTParty が Hash を form-urlencode し、
+    # そこでも数字の添字（HashConversions#to_params）になって同じ 500 に戻る。
+    def sent_body(options)
+      return JSON.parse(options[:body].to_json)
+    end
+
+    def test_content_type_is_json
+      options = update({media_attributes: [{id: '111', description: 'ゴメちゃん'}]})
+
+      assert_equal('application/json', options[:headers]['Content-Type'])
+    end
+
+    # 眼目。Hash の配列でないと Mastodon が 500 を返す。
+    def test_media_attributes_reach_upstream_as_array_of_hashes
+      options = update({
+        media_attributes: [
+          {id: '111', description: 'ゴメちゃん'},
+          {id: '222', description: 'ダイの大冒険'},
+        ],
+      })
+
+      assert_equal(
+        [
+          {'id' => '111', 'description' => 'ゴメちゃん'},
+          {'id' => '222', 'description' => 'ダイの大冒険'},
+        ],
+        sent_body(options)['media_attributes'],
+      )
+    end
+
+    # ⚠ 平坦化の痕跡が残っていないこと。キーとしては通っても配列にならない。
+    # ⚠ **percent-encode を解いてから見る。**form-urlencoded の body は
+    # `media_attributes%5B0%5D%5Bid%5D` になるので、生のまま探すと素通りする。
+    def test_flattened_keys_are_gone
+      options = update({media_attributes: [{id: '111'}]})
+
+      refute_includes(
+        ::URI.decode_www_form_component(options[:body].to_json),
+        'media_attributes[0]',
+      )
+    end
+
+    # #4589 の不変条件。落とすと投稿から添付が全部外れ、CW と閲覧注意が消える。
+    def test_restored_fields_reach_upstream
+      options = update({
+        status: '本文',
+        spoiler_text: 'ネタバレ',
+        sensitive: false,
+        media_ids: ['111', '222'],
+        media_attributes: [{id: '111'}],
+      })
+      body = sent_body(options)
+
+      assert_equal('本文', body['status'])
+      assert_equal('ネタバレ', body['spoiler_text'])
+      assert_equal(['111', '222'], body['media_ids'])
+      # ⚠ refute だけだと nil でも通る。キーの存在と対で見る。
+      refute(body['sensitive'])
+      assert(body.key?('sensitive'))
+    end
+  end
+end


### PR DESCRIPTION
#4621。ALT 編集の `PUT /api/v1/statuses/:id` が上流 Mastodon で 500 になる件。**pooza/ginseng-fediverse#253 が着地したので、この PR で完結します。**

## 原因

`ginseng-fediverse` の `flatten_media_attributes` が `media_attributes[0][id]=...` と **数字の添字**で form-urlencode していた。この形は Rack / Rails 側で `fields_for` 形式の **Hash** に解釈され、**配列にならない**。

```
旧   media_attributes[0][id]=111&media_attributes[0][description]=x
  → {"media_attributes" => {"0" => {"id"=>"111", "description"=>"x"}}}   ← Hash
新（JSON）
  → {"media_attributes" => [{"id"=>"111", "description"=>"x"}]}          ← Hash の配列
```

Mastodon の `UpdateStatusService#update_media_attachments!` は `(@options[:media_attributes] || []).each do |attributes|` と回すので、Hash を each した `["0", {...}]`（**Array**）が渡り、`attributes[:id]` で `TypeError: no implicit conversion of Symbol into Integer` ＝ 500。issue のバックトレースが `Array#find`（`next_media_attachments.find` のブロック内）を指しているのと一致する。

⚠ **ginseng-fediverse#245 は入っていた。**「gem 側の修正が着地した」は「正しく直っている」ではなく、**#245 の平坦化そのものが誤り**だった。

## 入っているもの

1. **`bundle update ginseng-fediverse`（1.8.28 → 1.8.29 / `0129fa5e`）** — pooza/ginseng-fediverse#253。form-urlencoded をやめて JSON で送る。⚠ Content-Type の明示が要る（ginseng-core の `create_body` は JSON のときだけ `to_json` するので、無指定だと HTTParty が form-urlencode して**同じ数字の添字に戻る**）
2. **gem 境界の契約テスト** `test/unit/service/mastodon_status_update_boundary.rb` — ⚠ `alt_edit_body` は**モロヘイヤが組んだ Hash** しか見ないので、gem 側が形を崩しても捕まえられない。#4589 / #4594 と同じく `bundle update` で黙って戻る類なので、**gem が組んだリクエスト**を押さえる側を別に置いた
3. **内部 fetch と上流への PUT に `X-Mulukhiya-Purpose` を出さない** — #4621 が併記していた潜在的な危うさ。#4474 以前の `if ($http_x_mulukhiya_purpose != '')` が残った vhost では **内部 fetch が :3008 へ送り返されてループし GET が 404** になる（ステージングで実際に起きた）。⚠ `/source` は location の正規表現に一致せず素通りして 200 だったため、**`/source` は通るのに `fetch_status` だけ落ちる**という非対称で気づきにくい
   - `Authorization` は落とさない（内部 fetch は利用者のトークンで読む）／`@headers` は破壊せず `except` で複製する（`token` が同じハッシュを読む）

4. **`bundle update ginseng-core`（1.19.0 / `4a029e9c`）** — #4616 の続き。5.34.0 へ入れる判断（2026-08-22）。🔴 **#527 リダイレクト追従で `Authorization` / `Cookie` が別オリジンへそのまま送られていた**。⚠ **`host_validator` では塞げない**（リダイレクト先が公開ホストなら通る）。併せて #554 / #556（cert）、#532 / #561（run_stop の pid）、#553 が乗る
   - ⚠ **cert タスクの受け取り（#4617）は含めていない**（`Ginseng.load_tasks` と `cert/cacert.pem` をコミットするかの判断が要るため）
   - ⚠ **モロヘイヤでの実害は小さい**（資格情報を付けて叩く先は自前の Mastodon / Misskey）。急ぐ理由としては使わない

## 検証

- `rake test` **1097 tests / 1520 assertions / 0 failures / 0 errors / 321 omissions**
- `rake lint` 481 files no offenses / bundler-audit 脆弱性なし
- **旧 revision（`8031dd9c`）へ戻すと境界テスト 4 件が落ちる**ことを確認済み（`bundle update` の退行を実際に捕まえる）
- `test_purpose_is_not_carried_into_internal_fetch` も、修正を戻すと落ちることを確認済み
- ⚠ **ステージング（dev24）での実地確認は未了。**capsicum と同じ PUT を投げて 200 と ALT 反映を見るところまでがクローズ条件
