### PR TITLE
test: only_person は「絞り込みが効いていること」を直接見る (#4619)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,9 @@ jobs:
         # 意図してテストを増やしたときは、この数値を実測に合わせて更新する。
         include:
           - controller: mastodon
-            omission_baseline: 321
+            omission_baseline: 322
           - controller: misskey
-            omission_baseline: 310
+            omission_baseline: 311
     services:
       redis:
         image: redis:7

--- a/test/unit/lib/attachment.rb
+++ b/test/unit/lib/attachment.rb
@@ -184,8 +184,13 @@ module Mulukhiya
     # Person だからにすぎない＝ #4583 と同じ「信用できない緑」）。
     #
     # baseline が覆う範囲（`min` 以上）に限れば「絞り込みは減らすだけ」は厳密に成り立つ。
+    #
+    # ⚠ **Mastodon 限定。**この下限比較は「返る `:id` が並び順のキーであること」に
+    # 依存する。Misskey は `note.id` で並べて `drive_file.id` を返すので、
+    # `min` が窓の境界を意味しない。
     def test_catalog_only_person_is_subset_within_baseline_range
       return unless @attachment
+      omit('Misskey は :id が並び順のキーではない') if Environment.misskey_type?
       all_ids = attachment_class.catalog(limit: 10, skip_cache: true)[:items].map {|v| v[:id]}
       omit('baseline が空（media 未 seed・chubo2#64）') if all_ids.empty?
       person_ids = attachment_class.catalog(limit: 10, only_person: 1, skip_cache: true)
@@ -197,12 +202,13 @@ module Mulukhiya
     private
 
     # 返ってきたアカウントが Person 扱いか。
-    # ⚠ **判定列は SNS で違う**（Mastodon は `accounts.actor_type`・
-    # Misskey は `user."isBot"`）。catalog はローカルアカウントしか返さないので、
-    # username は `domain` / `userHost` が null の側で一意に引ける。
+    # ⚠ **判定列も、ローカル判定の列も SNS で違う。**Mastodon は
+    # `accounts.actor_type` / `accounts.domain`、Misskey は `user."isBot"` /
+    # `user.host`（⚠ **`userHost` を持つのは `note` / `drive_file` 側だけ**）。
+    # catalog はローカルアカウントしか返さないので、username で一意に引ける。
     def person_account?(username)
       if Environment.misskey_type?
-        row = attachment_class.db[:user].where(username:, userHost: nil).first
+        row = attachment_class.db[:user].where(username:, host: nil).first
         return row.present? && row[:isBot] == false
       end
       row = attachment_class.db[:accounts].where(username:, domain: nil).first

--- a/test/unit/lib/attachment.rb
+++ b/test/unit/lib/attachment.rb
@@ -163,14 +163,50 @@ module Mulukhiya
       assert_equal(by_cursor[:items].map {|v| v[:id]}, by_offset[:items].map {|v| v[:id]})
     end
 
-    # only_person は絞り込みなので、結果は常に全体の部分集合。
-    def test_catalog_only_person_is_subset
+    # ⚠ **見たいのは「絞り込みが効いていること」。**返ってきたアカウントの種別を
+    # 直接見る (#4619)。subset 検証は代理でしかなく、母集合の取り方に依存する。
+    def test_catalog_only_person_returns_only_person
+      return unless @attachment
+      items = attachment_class.catalog(limit: 10, only_person: 1, skip_cache: true)[:items]
+      omit('only_person の結果が空（media 未 seed・chubo2#64）') if items.empty?
+
+      items.each do |item|
+        username = item.dig(:account, :username)
+
+        assert_true(person_account?(username), "#{username} is not a person")
+      end
+    end
+
+    # ⚠ **「最新 10 件」は母集合ではない (#4619)。**絞り込み無しの最新 10 件に
+    # bot / service が 1 件でも混ざると、only_person 側はその分だけ**より古い
+    # Person で 10 件を埋める**。埋めた分は baseline に無いので、**SQL が正しくても
+    # 素の subset は成り立たない**（緑なのは seed の最新 10 件がたまたま全部
+    # Person だからにすぎない＝ #4583 と同じ「信用できない緑」）。
+    #
+    # baseline が覆う範囲（`min` 以上）に限れば「絞り込みは減らすだけ」は厳密に成り立つ。
+    def test_catalog_only_person_is_subset_within_baseline_range
       return unless @attachment
       all_ids = attachment_class.catalog(limit: 10, skip_cache: true)[:items].map {|v| v[:id]}
+      omit('baseline が空（media 未 seed・chubo2#64）') if all_ids.empty?
       person_ids = attachment_class.catalog(limit: 10, only_person: 1, skip_cache: true)
         .fetch(:items).map {|v| v[:id]}
 
-      assert_empty(person_ids - all_ids)
+      assert_empty(person_ids.select {|id| id >= all_ids.min} - all_ids)
+    end
+
+    private
+
+    # 返ってきたアカウントが Person 扱いか。
+    # ⚠ **判定列は SNS で違う**（Mastodon は `accounts.actor_type`・
+    # Misskey は `user."isBot"`）。catalog はローカルアカウントしか返さないので、
+    # username は `domain` / `userHost` が null の側で一意に引ける。
+    def person_account?(username)
+      if Environment.misskey_type?
+        row = attachment_class.db[:user].where(username:, userHost: nil).first
+        return row.present? && row[:isBot] == false
+      end
+      row = attachment_class.db[:accounts].where(username:, domain: nil).first
+      return row.present? && [nil, 'Person'].include?(row[:actor_type])
     end
   end
 end


### PR DESCRIPTION
## 概要

PR #4613（#4393 の LATERAL merge）の Codex P2 の受け皿。**テストだけの問題で、本番のクエリは正しい。**

`test_catalog_only_person_is_subset` は「絞り込み無しの**最新 10 件**」を母集合として扱っていた。最新 10 件に bot / service の添付が 1 件でも混ざると、`only_person` 側はその分だけ**より古い Person の添付で 10 件を埋める**。埋めた分は baseline に無いので、**SQL が正しくてもテストが落ちる**。

⚠ **いま緑なのは seed の最新 10 件がたまたま全部 Person だからにすぎない**（#4583 と同じ「信用できない緑」）。

## 変更

- **主眼を「返ってきたアカウントが全部 Person か」の直接検証へ**（Issue の推奨案 2）。母集合の取り方に依存しない
  - ⚠ 判定列は SNS で違う（Mastodon `accounts.actor_type` / Misskey `user."isBot"`）
- subset は **baseline が覆う範囲（`min` 以上）に限れば厳密に成り立つ**ので、その形で残した（推奨案 3 の併用）

## 検証（fedi-test-harness / Mastodon）

⚠ **ローカル（DB 無し）ではクラスごと omission になるので、harness で実走した。**

1. **bot アカウントを仕込んで緑を確認** — `actor_type = 'Service'` のアカウント（`botty`）＋添付 1 件をハーネス DB に入れた状態で `21 tests / 0 failures`
2. **フィルタを壊すと落ちることを確認** — `media_catalog.sql.erb` の `only_person` 条件 2 箇所を無効化すると、新テストが **`botty is not a person`** で落ちる
3. ⚠ **このとき subset 側は落ちない。**旧テストは「フィルタが丸ごと効いていない」状態を取りこぼしていた（＝この PR の主眼）
4. 仕込んだ行と SQL は元に戻し、**harness フル実走で `1192 tests / 0 failures / 0 errors`**

## 関連

- #4613 / #4393 / #4583（同型の「信用できない緑」）