### PR TITLE
fix: /media のページ送りが境界で 1 件飛ばすのを止める (#4632)

### DIFF
--- a/app/lib/mulukhiya/model/mastodon/attachment.rb
+++ b/app/lib/mulukhiya/model/mastodon/attachment.rb
@@ -62,13 +62,27 @@ module Mulukhiya
         return true
       end
 
+      # ⚠ **OFFSET は「ページ幅」で計算する (#4632)。**`has_next` を見るために
+      # 取得件数へ +1 しているので、その `limit` を OFFSET の基準にも使うと
+      # **ページごとに 1 件抜ける**（既定の 100 件なら page=2 が 101 件目から
+      # 始まり、100 件目がどのページにも出ない）。取得件数とページ幅は
+      # 別のキーで渡す。
+      def self.catalog_offset(params)
+        return 0 if params[:cursor]
+        return 0 unless params[:page]
+        return (params[:page] - 1) * params[:limit]
+      end
+
       def self.catalog(params = {})
         params[:limit] ||= config['/webui/media/catalog/limit']
         unless params[:rule] || params[:skip_cache]
           cached = catalog_from_cache(params)
           return cached if cached
         end
-        rows = Postgres.exec(:media_catalog, params.merge(limit: params[:limit] + 1))
+        rows = Postgres.exec(:media_catalog, params.merge(
+          limit: params[:limit] + 1,
+          offset: catalog_offset(params),
+        ))
         has_next = rows.size > params[:limit]
         page_rows = rows.first(params[:limit])
         items = build_catalog_items(page_rows)

--- a/app/lib/mulukhiya/model/misskey/attachment.rb
+++ b/app/lib/mulukhiya/model/misskey/attachment.rb
@@ -44,13 +44,27 @@ module Mulukhiya
         return false
       end
 
+      # ⚠ **OFFSET は「ページ幅」で計算する (#4632)。**`has_next` を見るために
+      # 取得件数へ +1 しているので、その `limit` を OFFSET の基準にも使うと
+      # **ページごとに 1 件抜ける**（既定の 100 件なら page=2 が 101 件目から
+      # 始まり、100 件目がどのページにも出ない）。取得件数とページ幅は
+      # 別のキーで渡す。
+      def self.catalog_offset(params)
+        return 0 if params[:cursor]
+        return 0 unless params[:page]
+        return (params[:page] - 1) * params[:limit]
+      end
+
       def self.catalog(params = {})
         params[:limit] ||= config['/webui/media/catalog/limit']
         unless params[:rule] || params[:skip_cache]
           cached = catalog_from_cache(params)
           return cached if cached
         end
-        rows = Postgres.exec(:media_catalog, params.merge(limit: params[:limit] + 1))
+        rows = Postgres.exec(:media_catalog, params.merge(
+          limit: params[:limit] + 1,
+          offset: catalog_offset(params),
+        ))
         has_next = rows.size > params[:limit]
         page_rows = rows.first(params[:limit])
         items = build_catalog_items(page_rows)

--- a/app/query/mastodon/media_catalog.sql.erb
+++ b/app/query/mastodon/media_catalog.sql.erb
@@ -27,7 +27,9 @@
     only_person 25,998ms → 6.5ms / rule つき 8,900ms → 837ms /
     rule ヒット無し 2,244ms → 14.0ms（いずれも照合の差分 0 行）
 -%>
-<% offset = params[:cursor] ? 0 : (params[:page] ? ((params[:page] - 1) * params[:limit]) : 0) %>
+<%# offset は呼び出し側が「ページ幅」で計算して渡す。ここで params[:limit] から
+    導出すると has_next 用の +1 が混ざり、ページごとに 1 件抜ける (#4632)。 -%>
+<% offset = params[:offset].to_i %>
 SELECT
   picked.id,
   picked.name,

--- a/app/query/misskey/media_catalog.sql.erb
+++ b/app/query/misskey/media_catalog.sql.erb
@@ -53,5 +53,6 @@ ORDER BY
   note_file.note_id DESC
 LIMIT <%= params[:limit] %>
 <% unless params[:cursor] %>
-  OFFSET <%= params[:page] ? ((params[:page] - 1) * params[:limit]) : 0 %>
+  <%# ページ幅は呼び出し側が計算して渡す。has_next 用の +1 を混ぜない (#4632) -%>
+  OFFSET <%= params[:offset].to_i %>
 <% end %>


### PR DESCRIPTION
## 概要

5.34.0 リリース前 5 観点レビュー（API 契約）由来の受け皿。**既存事象**（v5.33.0 でも同じ）。

`has_next` を見るために取得件数へ +1 して SQL へ渡しているのに、**OFFSET もその `limit`（= ページ幅 + 1）を基準に計算していた**。

- 既定の `/webui/media/catalog/limit` は 100
- `?page=2` → `offset = (2 - 1) * 101 = 101`
- ⚠ **100 件目（0 起点）がどのページにも出ない。**`views/media.slim` の無限スクロールは `page` 方式なので **WebUI でそのまま欠落する**

## 変更

取得件数とページ幅を**別のキーで渡す**形にした。

- `catalog_offset` が**ページ幅**で OFFSET を計算し、SQL は `params[:offset]` を使うだけにした
- ⚠ **Mastodon / Misskey の両系とも同じ誤り**だったので両方直した
- `feed`（`page: 1` 固定・`offset` を渡さない）は `to_i` で 0 になるので従来どおり

## 検証（fedi-test-harness / Mastodon）

⚠ **既定の seed では media が 1 件しか無く、ページ送り系は omission になる**（`omit('ページ送りを検証できるだけの media が未 seed（chubo2#64）')`）。**そのままでは修正前でも緑**なので、検証用に media を仕込んだ。

| コード | `test_catalog_page_offset_matches_cursor` |
| --- | --- |
| 修正前（develop） | **落ちる**（cursor 経由と `page=2` の結果が食い違う） |
| 修正後 | 21 tests / 45 assertions / **0 failures** |

- 仕込んだ行は削除して元の状態に戻してある
- ローカル全件 `1120 tests / 0 failures / 0 errors`、`rubocop` no offenses

## 関連

- #4393（この SQL を全面書き換えした回）/ pooza/chubo2#64（ハーネスの seed 拡充）
