### PR TITLE
fix: ginseng-fediverse 1.8.30 を取り込む（ALT 編集の PUT が X-Mulukhiya を名乗る・#4621）

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,10 +42,10 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-fediverse.git
-  revision: 0129fa5ec6e129ba7bdd89c10ba4b706d680c313
+  revision: c283c52195497fbc27c4274ded2359430c3f0c08
   branch: main
   specs:
-    ginseng-fediverse (1.8.29)
+    ginseng-fediverse (1.8.30)
 
 GIT
   remote: https://github.com/pooza/ginseng-piefed.git

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1235,7 +1235,14 @@ shallu / gomander / sweep は 5.32.0 のままで、**本番のバージョン�
     表に出ていなかっただけ。**ステージング固有の話ではない**
   - ⚠ **2026-08-23（2 回目の同期）で pooza/ginseng-fediverse#254 のマージを確認した。**
     `main` は **1.8.30**＝`MEDIA_UPDATE_FEDIVERSE_VERSION` と同値。**残るのはこちら側の取り込みと実機確認だけ**
-  - **残作業**: ~~#254 マージ~~ → `bundle update ginseng-fediverse`（1.8.30）→ dev24 再デプロイ →
+  - **`bundle update ginseng-fediverse`（1.8.29 → 1.8.30）は 2026-08-23 に取り込み済み**（PR #4643）。
+    `rake lint` / `rake test`（1121 tests・0 failures・0 errors）とも緑。
+    ⚠ **取り込んだだけでは `/about` の `media_update` は false のまま**（capability の既定が
+    fail-closed なので、サーバーごとの opt-in が要る）。**「gem を上げた＝動く」ではない**
+  - ⚠ **既存のゲートのテストは 8 件とも `Gem.loaded_specs` を差し替えて見ており、
+    「実際のピンが要件を満たしているか」を 1 件も見ていなかった。**差し替えないケースを 1 件足した
+    （`test_pinned_fediverse_satisfies_gate`）。ゲート定数を 99.0.0 にすると落ちることを確認済み
+  - **残作業**: ~~#254 マージ~~ → ~~`bundle update ginseng-fediverse`（1.8.30）~~ → dev24 再デプロイ →
     capsicum と同じ PUT で **200 と ALT 反映**を確認 → クローズ
   - ⚠ **検証用の投稿は dev24 に残してある**（`117137204800272266`・visibility=direct・
     CW ＋閲覧注意＋添付 1・ALT は「変更前の説明」のまま）。

--- a/test/unit/model/controller_media_update.rb
+++ b/test/unit/model/controller_media_update.rb
@@ -64,6 +64,20 @@ module Mulukhiya
       assert_false(config[CAPABILITY_PATH])
     end
 
+    # ⚠ 上のケースはどれも `Gem.loaded_specs` を差し替えて見ているので、
+    # **実際のピンが要件を満たしているかは 1 件も見ていない**。ここだけは
+    # 差し替えずに実物を見る。ピンが 1.8.30 未満へ戻ると (#4621 の取り込みが
+    # 巻き戻ると) ALT 編集は本番で 405 に戻るので、退行として落とす。
+    def test_pinned_fediverse_satisfies_gate
+      spec = Gem.loaded_specs['ginseng-fediverse']
+
+      assert_not_nil(spec)
+      assert_true(
+        spec.version >= ControllerMethods::MEDIA_UPDATE_FEDIVERSE_VERSION,
+        "ginseng-fediverse #{spec.version} < #{ControllerMethods::MEDIA_UPDATE_FEDIVERSE_VERSION}",
+      )
+    end
+
     private
 
     def with_capability(value)


### PR DESCRIPTION
## 何をしたか

pooza/ginseng-fediverse#254（`update_status` も `create_headers` を通す）が着地したので、ピンを **1.8.29 → 1.8.30** へ上げた。#4621 の**欠陥 2**の解消にあたる。

これで**モロヘイヤ自身の PUT が `X-Mulukhiya` を名乗る**ようになり、nginx の map のキーが `PUT::media_update`（:3008 へループ）でも `PUT::`（reject → 405）でもなくなる。

同じ版に、モロヘイヤが触る面の修正が 3 件入っている:

| gem 側 | こちらへの意味 |
| --- | --- |
| #256 / #258 `create_headers` が渡された hash を複製し、設定のトークンを呼び側に残さない | 秘匿まわり（#4630 と隣接） |
| #248 / #261 `TagContainer` の入口で UTF-8 を保証 | #4642 の前提。⚠ **こちらが `self.scan` を上書きしているので、この取り込みだけでは届かない** |
| #251 / #262 数字だけの username を numeric AP ID と取り違えない | `publicize` の no-op 解消 |

## テストを 1 件足した

⚠ **`media_update?` のゲートのテストは 8 件とも `Gem.loaded_specs` を差し替えて見ており、「実際のピンが要件を満たしているか」を 1 件も見ていなかった。** 差し替えないケース（`test_pinned_fediverse_satisfies_gate`）を足した。ゲート定数を `99.0.0` に置くと落ちることを確認済み。

## ⚠ これだけでは `/about` は false のまま

capability の既定は fail-closed なので、`media_update` を true にするには**各サーバーの `local.yaml` へ `/mastodon/capabilities/media_update: true`** が要る（nginx の map を確認したサーバーだけ。本番 3 台は 2026-08-05 に是正済み・ステージング 3 台は pooza/chubo2#188 で未是正）。**「gem を上げた＝動く」ではない。**

## 確認

- `bundle exec rake lint` — rubocop 482 files / erb-lint / slim-lint / bundler-audit すべて緑
- `bundle exec rake test` — **1121 tests, 1559 assertions, 0 failures, 0 errors**

## 残る #4621 の作業

dev24 再デプロイ → capsicum と同じ PUT で **200 と ALT 反映**を確認 → クローズ。
⚠ 検証用の投稿は dev24 に残してあるが、**トークンは revoke 済み**なので作り直しが要る。

Refs #4621