### PR TITLE
fix: TagContainer の上書きがエンコーディング検査を迂回するのを止める (#4642)

### DIFF
--- a/app/lib/mulukhiya/tag_container.rb
+++ b/app/lib/mulukhiya/tag_container.rb
@@ -2,11 +2,18 @@ module Mulukhiya
   class TagContainer < Ginseng::Fediverse::TagContainer
     include Package
 
+    # ⚠ **`sub` より先に UTF-8 を保証する (#4642)。** `sub` は不正なバイト列に対して
+    # `ArgumentError` を上げるので、ここを素通りさせると基底の `add` が持つ検査
+    # (pooza/ginseng-fediverse#248) へ届く前に落ちる。型も `ArgumentError` で
+    # 捕まえにくく、入口で 400 に落とせない (#4600)。
+    #
+    # ⚠ **`filter_map` の `.presence` は基底と挙動が違うので残す。**空白だけの語を
+    # 落とすのはこちら固有で、基底の `normalize` は空白を残す。
     def initialize(strings = [])
       strings = strings.to_a.filter_map do |v|
         case v
         in String
-          v.sub(/^#/, '').presence
+          self.class.to_utf8(v).sub(/^#/, '').presence
         else
           v
         end
@@ -21,9 +28,11 @@ module Mulukhiya
       return super
     end
 
-    def self.scan(text)
-      return new(text.scan(Ginseng::Fediverse::Parser.hashtag_pattern).map(&:first))
-    end
+    # ⚠⚠ **`self.scan` を上書きしない (#4642)。** 基底 (1.8.30) は入口で `to_utf8` を
+    # 通すようになったが、こちらの上書きはそれを呼ばずに `text.scan` していたため、
+    # **タグ抽出の主経路が丸ごとガードを迂回していた**。上書きは基底から
+    # `to_utf8` を抜いただけの同一実装で、消しても `new` は
+    # レシーバのクラス (= このクラス) を指すので挙動は変わらない。
 
     def self.default_tags
       return DefaultTagHandler.tags

--- a/test/unit/lib/tag_container_encoding.rb
+++ b/test/unit/lib/tag_container_encoding.rb
@@ -1,0 +1,36 @@
+module Mulukhiya
+  # タグ抽出の入口が UTF-8 を保証しているか (#4642)。
+  #
+  # ⚠⚠ **DB を要求しない位置に置くこと。** 隣の TagContainerTest は
+  # `Environment.dbms_class&.config?` で丸ごと omit されるので、そちらに書くと
+  # 「書いたのに一度も走っていない」状態になる (#4632 で踏んだカバレッジの穴)。
+  # 不正バイト列は `normalize` へ届く前に弾かれるため、DB 無しで検証できる。
+  class TagContainerEncodingTest < TestCase
+    # "\xE3\x81" は 3 バイト文字の途中で切れた列。
+    INVALID = "#\xE3\x81ほげ".dup.force_encoding(Encoding::UTF_8).freeze
+
+    def test_invalid_byte_sequence_is_rejected_by_scan
+      assert_false(INVALID.valid_encoding?)
+      assert_raise(Ginseng::ValidateError) {TagContainer.scan(INVALID)}
+    end
+
+    # `initialize` が `super` へ渡す前に `sub` を掛けており、`sub` は不正バイト列で
+    # `ArgumentError` を上げるため、基底の `add` の検査へ届く前に落ちていた。
+    def test_invalid_byte_sequence_is_rejected_by_new
+      assert_raise(Ginseng::ValidateError) {TagContainer.new([INVALID])}
+    end
+
+    # ⚠ **これが #4642 そのもの。** 基底 (ginseng-fediverse 1.8.30 以降) の
+    # `self.scan` は入口で `to_utf8` を通すが、こちらが上書きすると
+    # **タグ抽出の主経路が丸ごとガードを迂回する**。上書きが復活したら落とす。
+    def test_scan_is_not_overridden
+      assert_false(TagContainer.singleton_class.method_defined?(:scan, false))
+    end
+
+    # 寄せられるものは寄せる。scrub で黙って直すのとは別物で、
+    # 化けたタグが投稿されないことが要件。
+    def test_convertible_encoding_is_converted
+      assert_equal('#プリキュア', TagContainer.to_utf8('#プリキュア'.encode('Windows-31J')))
+    end
+  end
+end


### PR DESCRIPTION
## 何が起きていたか

`ginseng-fediverse` 1.8.30 が `TagContainer` の入口に UTF-8 の検査を入れた（pooza/ginseng-fediverse#248 / #261）が、⚠⚠ **モロヘイヤはその入口を上書きしていて基底を呼んでいなかった**ため、**タグ抽出の主経路が丸ごとガードを迂回していた**。

修正前の実測:

```
scan(不正バイト列)  -> ArgumentError: invalid byte sequence in UTF-8
new([不正バイト列]) -> ArgumentError: invalid byte sequence in UTF-8
scan(Shift_JIS)     -> Encoding::CompatibilityError
```

修正後:

```
scan(不正バイト列)  -> Ginseng::ValidateError: invalid byte sequence in UTF-8
new([不正バイト列]) -> Ginseng::ValidateError: invalid byte sequence in UTF-8
scan(Shift_JIS)     -> 変換されて通る
```

## 直し方

**① `self.scan` の上書きを消した。** 基底から `to_utf8` を抜いただけの同一実装だったので、消しても `new` はレシーバのクラス（＝このクラス）を指すため挙動は変わらない。

**② `initialize` が `super` へ渡す前に `sub` を掛けていた。** `sub` は不正なバイト列で `ArgumentError` を上げるので、基底の `add` が持つ検査へ届く前に落ちていた。先に `to_utf8` を通す。

⚠ `filter_map` の `.presence` は残した。**空白だけの語を落とすのはこちら固有**で、基底の `normalize` は空白を残すため、消すと挙動が変わる。

## ⚠ テストは DB を要求しない位置に置いた

隣の `TagContainerTest` は `Environment.dbms_class&.config?` で**丸ごと omit される**ので、そちらに書くと「書いたのに一度も走っていない」状態になる（#4632 で踏んだカバレッジの穴）。不正バイト列は `normalize` へ届く前に弾かれるため、DB 無しで検証できる。

`test_scan_is_not_overridden` は**上書きが復活したら落ちる**ことを実際に確かめてある（復活させると `true` を返す）。

## 確認

- 修正前のコードで新テストが**落ちる**ことを確認（`<Ginseng::ValidateError> expected but was <ArgumentError>`）
- `bundle exec rake lint` — 483 files / no offenses、bundler-audit も緑
- `bundle exec rake test` — **1125 tests, 1564 assertions, 0 failures, 0 errors**

## 関連

エラー型が `ArgumentError` から `Ginseng::ValidateError` になったので、**#4600（不正な UTF-8 が 500 + Sentry になる）の入口側が 400 に落としやすくなる**。ただし #4600 そのものはリクエスト入口の話なので、これでは閉じない。

Refs #4642