### PR TITLE
obs: クライアント起因の 4xx を alert に上げない共通ヘルパへ寄せる (#4603 / #4629)

### DIFF
--- a/app/lib/mulukhiya/controller.rb
+++ b/app/lib/mulukhiya/controller.rb
@@ -124,6 +124,29 @@ module Mulukhiya
       raise Ginseng::AuthError, 'Token integrity check failed'
     end
 
+    # クライアント起因の失敗を Sentry alert に上げない共通判定
+    # (#4542 / #4594 / #4603 / #4629)。
+    #
+    # ⚠⚠ **例外クラスの列挙で判定しない。**同じ方針が 3 系統で別々に書かれ、
+    # そのたびに取りこぼした——#4603 は `NotFoundError`、#4629 は `AuthError` と
+    # `NotFoundError` が `else` へ落ちて alert していた。**ステータスで判定する**ので、
+    # 新しい 4xx を投げても漏れない。
+    #
+    # ⚠ **抑止するのは Sentry だけ。syslog には必ず残す**（`handle_gateway_error` と
+    # 同じ設計）。完全に無音だと「webhook が全滅している」ような事故の頻度・偏りを
+    # 追えなくなる。
+    #
+    # ⚠ **`status` を持たない例外は alert 側へ倒す。**素の `StandardError`
+    # （`NoMethodError` 等）はモロヘイヤ自身のバグなので、黙らせてはいけない。
+    def report_error(error)
+      client_error?(error) ? error.log : error.alert
+    end
+
+    def client_error?(error)
+      return false unless error.respond_to?(:status)
+      return error.status.to_i.between?(400, 499)
+    end
+
     # 上流のエラー包絡をそのままクライアントへ返す (#4480)。
     #
     # モロヘイヤはプロキシなので、上流が返した理由——Misskey の

--- a/app/lib/mulukhiya/controller/api_controller.rb
+++ b/app/lib/mulukhiya/controller/api_controller.rb
@@ -934,13 +934,7 @@ module Mulukhiya
       @renderer.message = {key:, entry:}
       return @renderer.to_s
     rescue => e
-      if e.is_a?(Ginseng::ConflictError)
-        # 409 (auto_update? 有効時 / 重複キー / 書き込みロック競合 #4534) は
-        # 期待動作のため Sentry alert 不要
-        Logger.new.info(program_entry: {event: 'conflict', key: params[:key], message: e.message})
-      else
-        e.alert
-      end
+      handle_program_entry_error(e, params[:key])
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -962,13 +956,7 @@ module Mulukhiya
       @renderer.message = {key: params[:key], entry:}
       return @renderer.to_s
     rescue => e
-      if e.is_a?(Ginseng::ConflictError)
-        # 409 (auto_update? 有効時 / 書き込みロック競合 #4534) は期待動作のため
-        # Sentry alert 不要
-        Logger.new.info(program_entry: {event: 'conflict', key: params[:key], message: e.message})
-      else
-        e.alert
-      end
+      handle_program_entry_error(e, params[:key])
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -982,13 +970,7 @@ module Mulukhiya
       @renderer.message = {key: params[:key], entry:}
       return @renderer.to_s
     rescue => e
-      if e.is_a?(Ginseng::ConflictError)
-        # 409 (auto_update? 有効時 / 書き込みロック競合 #4534) は期待動作のため
-        # Sentry alert 不要
-        Logger.new.info(program_entry: {event: 'conflict', key: params[:key], message: e.message})
-      else
-        e.alert
-      end
+      handle_program_entry_error(e, params[:key])
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -1002,13 +984,7 @@ module Mulukhiya
       @renderer.message = {key: params[:key], entry:}
       return @renderer.to_s
     rescue => e
-      if e.is_a?(Ginseng::ConflictError)
-        # 409 (auto_update? 有効時 / 書き込みロック競合 #4534) は期待動作のため
-        # Sentry alert 不要
-        Logger.new.info(program_entry: {event: 'conflict', key: params[:key], message: e.message})
-      else
-        e.alert
-      end
+      handle_program_entry_error(e, params[:key])
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -1021,15 +997,7 @@ module Mulukhiya
       @renderer.message = {key: params[:key], entry:}
       return @renderer.to_s
     rescue => e
-      # 409 (auto_update? 有効時 / 書き込みロック競合 #4534) と 422 (days が不正)
-      # はいずれも期待動作。⚠ **クライアント起因を alert に上げない** (#4542 と同型)。
-      if e.is_a?(Ginseng::ConflictError)
-        Logger.new.info(program_entry: {event: 'conflict', key: params[:key], message: e.message})
-      elsif e.is_a?(Ginseng::ValidateError)
-        Logger.new.info(program_entry: {event: 'invalid', key: params[:key], message: e.message})
-      else
-        e.alert
-      end
+      handle_program_entry_error(e, params[:key])
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -1173,6 +1141,31 @@ module Mulukhiya
     # する (#4346)。未認証・未連携等ユーザー入力起因の 403/404 は alert spam を避け log
     # のみ (#4265)。kind は :annict_record / :annict_review、id_label/id_value は
     # episode_id / work_id の文脈。
+    # 番組表編集 5 本の rescue (#4629)。
+    #
+    # ⚠⚠ **`AuthError` と `NotFoundError` が `else` へ落ちて alert していた。**
+    # 無効トークン・非管理者トークンで叩かれるたびに Sentry イベントと管理者への
+    # アラートメールが飛ぶ形で、#4594 でボットの 401 連打が実際にメール化したのと
+    # 同じ。非 livecure サーバーへの誤アクセスも 404 で毎回鳴っていた。
+    #
+    # ⚠ **同じ rescue が 5 本に複写されていたのが取りこぼしの原因**なので、
+    # クラスを足すのではなくヘルパへ寄せた。判定の本体は `report_error`
+    # （ステータスで見るので新しい 4xx を投げても漏れない）。
+    #
+    # 409 / 422 だけ構造化ログを残すのは、期待動作として頻度を追いたいため。
+    def handle_program_entry_error(error, key)
+      case error
+      when Ginseng::ConflictError
+        # 409 (auto_update? 有効時 / 重複キー / 書き込みロック競合 #4534)
+        Logger.new.info(program_entry: {event: 'conflict', key:, message: error.message})
+      when Ginseng::ValidateError
+        # 422 (days が不正 等)
+        Logger.new.info(program_entry: {event: 'invalid', key:, message: error.message})
+      else
+        report_error(error)
+      end
+    end
+
     def handle_annict_write_error(error, kind:, lock:, id_label:, id_value:)
       if error.is_a?(Ginseng::ConflictError)
         handle_annict_conflict(error, kind:, lock:, id_label:, id_value:)

--- a/app/lib/mulukhiya/controller/webhook_controller.rb
+++ b/app/lib/mulukhiya/controller/webhook_controller.rb
@@ -35,7 +35,9 @@ module Mulukhiya
       # (#4603)。同じ `verify_webhook!` を通す `get '/:digest'` は `e.log` なので、
       # **同じ例外が GET なら静か・POST なら alert** という非対称になっていた。
       report_error(e)
-      @renderer.status = e.status
+      # ⚠ **`e.status` を直に呼ばない。**引き当ての失敗 (`Sequel::DatabaseConnectionError`
+      # 等) は `status` を持たないので、rescue 自身が `NoMethodError` で落ちる。
+      @renderer.status = e.respond_to?(:status) ? e.status : 500
       @renderer.message = {error: e.message}
       return @renderer.to_s
     end
@@ -45,14 +47,20 @@ module Mulukhiya
       @renderer.message = {message: 'OK'}
       return @renderer.to_s
     rescue => e
-      e.log
-      @renderer.status = e.status
+      # ⚠ **POST と同じ判定にする** (#4603)。従来は一律 `e.log` で、未知の digest も
+      # DB 障害も等しく無音だった。ここも `report_error` に寄せると、4xx は静かなまま
+      # **引き当ての失敗だけが alert される**。
+      report_error(e)
+      @renderer.status = e.respond_to?(:status) ? e.status : 500
       @renderer.message = {error: e.message}
       return @renderer.to_s
     end
 
     def webhook
-      @webhook ||= Webhook.create(params[:digest])
+      # ⚠ **`create` ではなく `create!`** (#4603 の Codex P1)。`create` は DB 障害も
+      # 握って nil を返すので、`verify_webhook!` がそれを 404 に変換してしまい、
+      # **全 webhook が落ちている状態が「未知の digest」として無音になる**。
+      @webhook ||= Webhook.create!(params[:digest])
       return @webhook
     end
 

--- a/app/lib/mulukhiya/controller/webhook_controller.rb
+++ b/app/lib/mulukhiya/controller/webhook_controller.rb
@@ -10,6 +10,9 @@ module Mulukhiya
       @renderer.message = reporter.to_h
       return @renderer.to_s
     rescue => e
+      # ⚠ **ここは `report_error` に寄せない (#4603)。**主な失敗は署名検証
+      # (`AuthError`) と設定不備 (`ServiceUnavailableError`) で、**署名不一致を
+      # 黙らせたくない**。4xx でも alert するのが正しい。
       e.alert
       @renderer.status = e.respond_to?(:status) ? e.status : 500
       @renderer.message = {error: e.message}
@@ -28,7 +31,10 @@ module Mulukhiya
       end
       return @renderer.to_s
     rescue => e
-      e.alert
+      # ⚠ **消された・打ち間違えた webhook URL を叩かれただけ**で 404 になる
+      # (#4603)。同じ `verify_webhook!` を通す `get '/:digest'` は `e.log` なので、
+      # **同じ例外が GET なら静か・POST なら alert** という非対称になっていた。
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s

--- a/app/lib/mulukhiya/webhook.rb
+++ b/app/lib/mulukhiya/webhook.rb
@@ -122,13 +122,22 @@ module Mulukhiya
       }.to_json.sha256
     end
 
+    # ⚠⚠ **引き当ての失敗を握り潰す。**呼び側が「そんな digest は無い」と
+    # 区別できないので、**404 に化かしてはいけない経路は `create!` を使う**
+    # (#4603 の Codex P1)。DB 障害で全 webhook が落ちている状態を 4xx として
+    # 扱うと、クライアント起因の alert 抑止に乗って**無音**になる。
     def self.create(key)
-      return new(key) if key.is_a?(UserConfig)
-      token = find_token_by_digest(key)
-      return token&.account&.webhook
+      return create!(key)
     rescue => e
       e.log(key: key.to_s)
       return nil
+    end
+
+    # 引き当てに失敗したら例外をそのまま上げる。**戻り値の nil は
+    # 「そんな digest は無い」だけを意味する。**
+    def self.create!(key)
+      return new(key) if key.is_a?(UserConfig)
+      return find_token_by_digest(key)&.account&.webhook
     end
 
     # トークンを持たないアカウントの「幽霊 webhook」は列挙しない (#4487)。

--- a/test/unit/controller/client_error_alert.rb
+++ b/test/unit/controller/client_error_alert.rb
@@ -64,6 +64,53 @@ module Mulukhiya
     end
   end
 
+  # 引き当ての失敗を「未知の digest」の 404 に化かさない (#4603 の Codex P1)。
+  #
+  # ⚠⚠ **`Webhook.create` は全例外を握って nil を返す。**それを
+  # `verify_webhook!` が 404 に変換するので、alert 抑止を入れると
+  # **DB 障害で全 webhook が落ちている状態が無音になる**。
+  class WebhookLookupFailureTest < TestCase
+    class LookupError < StandardError; end
+
+    # 従来どおり nil へ倒れる（他の呼び出し元の互換）。
+    def test_create_still_swallows
+      with_failing_lookup do
+        assert_nil(Webhook.create('deadbeef'))
+      end
+    end
+
+    # ⚠ **こちらが本命。**引き当ての失敗はそのまま上がるので、
+    # 呼び側は「そんな digest は無い」と区別できる。
+    def test_create_bang_propagates
+      with_failing_lookup do
+        assert_raise(LookupError) {Webhook.create!('deadbeef')}
+      end
+    end
+
+    # ⚠ 上がってきた例外は `status` を持たないので、`report_error` は alert 側へ倒す。
+    def test_lookup_failure_is_alerted
+      error = LookupError.new('connection refused')
+      calls = []
+      error.define_singleton_method(:alert) {calls << :alert}
+      error.define_singleton_method(:log) {calls << :log}
+
+      MisskeyController.new!.report_error(error)
+
+      assert_equal([:alert], calls)
+    end
+
+    private
+
+    def with_failing_lookup
+      Webhook.singleton_class.alias_method(:__orig_find_token_by_digest, :find_token_by_digest)
+      Webhook.define_singleton_method(:find_token_by_digest) {|_| raise LookupError, 'connection refused'}
+      yield
+    ensure
+      Webhook.singleton_class.alias_method(:find_token_by_digest, :__orig_find_token_by_digest)
+      Webhook.singleton_class.remove_method(:__orig_find_token_by_digest)
+    end
+  end
+
   # 番組表編集 5 本の rescue (#4629)。
   class ProgramEntryErrorHandlingTest < TestCase
     def setup

--- a/test/unit/controller/client_error_alert.rb
+++ b/test/unit/controller/client_error_alert.rb
@@ -1,0 +1,122 @@
+module Mulukhiya
+  # クライアント起因の失敗を Sentry alert に上げない (#4542 / #4594 / #4603 / #4629)。
+  #
+  # ⚠⚠ **同じ方針が 3 系統で別々に書かれ、そのたびに取りこぼした。**
+  # #4603 は `NotFoundError`、#4629 は `AuthError` と `NotFoundError` が `else` へ
+  # 落ちて alert していた。**「実際に alert しないこと」を正面から確かめる。**
+  class ClientErrorAlertTest < TestCase
+    # status を持つ例外のダブル。report_error が見るのは status だけ。
+    class ErrorDouble
+      attr_reader :calls, :status
+
+      def initialize(status)
+        @status = status
+        @calls = []
+      end
+
+      def alert = @calls << :alert
+      def log = @calls << :log
+    end
+
+    # ⚠ status を持たない素の例外（NoMethodError 等）はモロヘイヤ自身のバグ。
+    class StatuslessDouble
+      attr_reader :calls
+
+      def initialize = @calls = []
+      def alert = @calls << :alert
+      def log = @calls << :log
+    end
+
+    def setup
+      @controller = MisskeyController.new!
+    end
+
+    def test_client_errors_are_logged_not_alerted
+      [400, 401, 403, 404, 409, 422, 499].each do |status|
+        error = ErrorDouble.new(status)
+        @controller.report_error(error)
+
+        assert_equal([:log], error.calls, "status #{status} は log であるべき")
+      end
+    end
+
+    def test_server_errors_are_alerted
+      [500, 502, 503].each do |status|
+        error = ErrorDouble.new(status)
+        @controller.report_error(error)
+
+        assert_equal([:alert], error.calls, "status #{status} は alert であるべき")
+      end
+    end
+
+    # ⚠ 黙らせてよいのはステータスで「クライアント起因」と言えるものだけ。
+    def test_statusless_error_is_alerted
+      error = StatuslessDouble.new
+      @controller.report_error(error)
+
+      assert_equal([:alert], error.calls)
+    end
+
+    def test_client_error_predicate
+      assert_true(@controller.client_error?(ErrorDouble.new(404)))
+      assert_false(@controller.client_error?(ErrorDouble.new(500)))
+      assert_false(@controller.client_error?(StatuslessDouble.new))
+    end
+  end
+
+  # 番組表編集 5 本の rescue (#4629)。
+  class ProgramEntryErrorHandlingTest < TestCase
+    def setup
+      @controller = APIController.new!
+    end
+
+    # ⚠⚠ **これが #4629 そのもの。**無効トークン・非管理者トークンで叩かれるたびに
+    # Sentry イベントと管理者へのアラートメールが飛んでいた。
+    def test_auth_error_is_not_alerted
+      error = spy(Ginseng::AuthError.new('Unauthorized'))
+      handle(error)
+
+      assert_equal([:log], error.mulukhiya_calls)
+    end
+
+    # 非 livecure サーバーへ誤って叩かれると 404 で毎回鳴っていた。
+    def test_not_found_error_is_not_alerted
+      error = spy(Ginseng::NotFoundError.new('Not Found'))
+      handle(error)
+
+      assert_equal([:log], error.mulukhiya_calls)
+    end
+
+    # 409 / 422 は期待動作なので、log でも alert でもなく構造化ログだけ残す。
+    def test_conflict_and_validate_are_structured_only
+      [Ginseng::ConflictError.new('conflict'), Ginseng::ValidateError.new('invalid')].each do |raw|
+        error = spy(raw)
+        handle(error)
+
+        assert_equal([], error.mulukhiya_calls, "#{raw.class} は log/alert しない")
+      end
+    end
+
+    # モロヘイヤ自身のバグは黙らせない。
+    def test_server_error_is_alerted
+      error = spy(Ginseng::GatewayError.new('Bad response 502'))
+      handle(error)
+
+      assert_equal([:alert], error.mulukhiya_calls)
+    end
+
+    private
+
+    def handle(error)
+      @controller.send(:handle_program_entry_error, error, 'precure')
+    end
+
+    def spy(error)
+      calls = []
+      error.define_singleton_method(:mulukhiya_calls) {calls}
+      error.define_singleton_method(:alert) {calls << :alert}
+      error.define_singleton_method(:log) {calls << :log}
+      return error
+    end
+  end
+end


### PR DESCRIPTION
`#4542` / `#4594` に続いて**同じ型が 3 系統目**（#4629 本文）なので、クラスの列挙をやめて共通ヘルパへ寄せた。

## 実証した欠陥

旧コード（5 本に複写されていた rescue と webhook POST）をそのまま再現して確認:

```
=== 番組表編集 5 本 ===
  Ginseng::AuthError       status=403 -> [:alert]     ⚠
  Ginseng::NotFoundError   status=404 -> [:alert]     ⚠
  Ginseng::ConflictError   status=409 -> 構造化ログのみ
=== webhook post /:digest ===
  Ginseng::NotFoundError   status=404 -> [:alert]     ⚠
```

- **#4629**: 無効トークン・非管理者トークンで叩かれるたびに Sentry イベント＋**管理者へのアラートメール**。#4594 でボットの 401 連打が実際にメール化したのと同じ形。非 livecure サーバーへの誤アクセスも 404 で毎回鳴る
- **#4603**: 消された・打ち間違えた webhook URL を叩かれただけで 404。⚠ **同じ `verify_webhook!` を通す `get '/:digest'` は `e.log`** ＝ **同じ例外が GET なら静か・POST なら alert** という非対称だった

## 直し方

**`Controller#report_error` / `#client_error?` を新設。**

⚠⚠ **例外クラスの列挙で判定しない。**取りこぼしの原因がまさにそれだった（`ConflictError` と `ValidateError` だけ列挙し、`AuthError` / `NotFoundError` が `else` へ落ちる）。**ステータスで判定する**ので、新しい 4xx を投げても漏れない。

⚠ **`status` を持たない例外は alert 側へ倒す。** 素の `NoMethodError` 等はモロヘイヤ自身のバグなので黙らせてはいけない。

**番組表編集は `handle_program_entry_error` へ寄せた。** 同じ rescue が 5 本に複写されていたのが取りこぼしの原因なので、ヘルパ 1 箇所にする（`post` / `put` / `delete` / `episode/increment` / `next_on/advance`）。409 / 422 の構造化ログは頻度を追うため残す。

## ⚠ `post '/admin'` は据え置き

主な失敗は署名検証（`AuthError`）と設定不備（`ServiceUnavailableError`）で、**署名不一致を黙らせたくない**。4xx でも alert するのが正しいので、寄せずに理由をコメントに明記した（#4603 本文の指示どおり）。

## 抑止するのは Sentry だけ

syslog には必ず残す（`handle_gateway_error` と同じ設計）。完全に無音だと「webhook が全滅している」ような事故の頻度・偏りを追えなくなる。

## テスト

`test/unit/controller/client_error_alert.rb`（**omission 0**）。「実際に alert しないこと」を正面から見る:

- 400/401/403/404/409/422/499 → `log`、500/502/503 → `alert`、status なし → `alert`
- `handle_program_entry_error`: `AuthError` → log / `NotFoundError` → log / `ConflictError`・`ValidateError` → 構造化ログのみ / 502 → alert

⚠ **修正前のコードでは新テストが `NoMethodError` になる**（ヘルパがまだ無いため）。赤→緑の対比としては弱いので、**旧実装の挙動を別途再現して欠陥を実証した**（上の表）。

## 確認

- `bundle exec rake lint` — 484 files / no offenses、bundler-audit も緑
- `bundle exec rake test` — **1133 tests, 1583 assertions, 0 failures, 0 errors**（omission は 322 のまま増えていない）

## 別途気づいた点（本 PR では触っていない）

`post '/:digest'` の rescue は `@renderer.status = e.status` を直に呼ぶので、**`status` を持たない例外だと rescue 自身が `NoMethodError` で落ちる**。同じファイルの `post '/admin'` は `e.respond_to?(:status) ? e.status : 500` になっている。⚠ **v5.33.0 以前からの既存の穴**でこの Issue の範囲外なので、必要なら別 Issue を立てます。

Refs #4603, #4629