### PR TITLE
obs: ALT 編集の内部 fetch 失敗をクライアントの 404 と区別する (#4631)

### DIFF
--- a/app/lib/mulukhiya/controller.rb
+++ b/app/lib/mulukhiya/controller.rb
@@ -166,8 +166,13 @@ module Mulukhiya
     # エラーコード（Misskey の `error.code`）で、ユーザー起因の失敗まで
     # Sentry イベントを立てないための口。
     def handle_gateway_error(error, silent_statuses: [401], silent_codes: [])
-      silent = silent_statuses.include?(error.source_status) ||
-        silent_codes.include?(upstream_error_code(error))
+      # ⚠⚠ **内部読みの失敗は無条件に alert する (#4631)。**モロヘイヤ自身の
+      # `fetch_status` 等が落ちているのはクライアント起因ではないので、
+      # `silent_statuses` に 404 が入っていても抑止してはいけない。
+      # 抑止すると「ALT 編集が全ユーザーで壊れている」が syslog 1 行に消える。
+      silent = !error.is_a?(InternalGatewayError) &&
+        (silent_statuses.include?(error.source_status) ||
+          silent_codes.include?(upstream_error_code(error)))
       # ⚠ 抑止するのは Sentry だけ。silent でも syslog には残す。完全に無音だと
       # 「上流の仕様変更で全投稿が弾かれる」ような事故の頻度・偏りを追えない。
       silent ? error.log : error.alert
@@ -175,7 +180,12 @@ module Mulukhiya
       # サーバー由来 (ForeignGatewayError) は、ステータスもボディも返さず 502 +
       # 自前の文言に倒す。他人のサーバーの応答を返すと、クライアントからは
       # 「モロヘイヤの上流がそう言っている」ように読めてしまう。
-      if error.is_a?(ForeignGatewayError)
+      #
+      # ⚠⚠ **内部読みの失敗 (InternalGatewayError) も同じ扱い (#4631)。**
+      # 上流の 404 をそのまま返すと、クライアントには「その投稿は無い」と読める。
+      # 実際に無いのではなく**モロヘイヤ側の読みが失敗した**ので、502 + 自前の
+      # 文言に倒して**取り違えを防ぐ**。
+      if error.is_a?(ForeignGatewayError) || error.is_a?(InternalGatewayError)
         @renderer.message = {error: error.message}
         return @renderer.status = error.status
       end

--- a/app/lib/mulukhiya/controller/mastodon_controller.rb
+++ b/app/lib/mulukhiya/controller/mastodon_controller.rb
@@ -204,7 +204,11 @@ module Mulukhiya
     def restored_body(id)
       headers = upstream_headers
       source = fetch_internal(:fetch_status_source, id, headers)
-      status = fetch_internal(:fetch_status, id, headers)
+      # ⚠ **2 本目は `paired: true`。**1 本目が通ったのに 2 本目だけ落ちるのは、
+      # クライアント起因ではありえない（投稿が無いならどちらも 404、トークンが
+      # 切れているならどちらも 401 になる）。**この非対称そのものが #4621 の
+      # 症状**だったので、片落ちは内部の失敗として扱う。
+      status = fetch_internal(:fetch_status, id, headers, paired: true)
       reject_poll!(status)
       return sanitize_spoiler({
         status: source['text'].to_s,
@@ -216,13 +220,30 @@ module Mulukhiya
 
     # 内部読みの失敗をクライアントの更新失敗と区別する (#4631)。
     #
-    # ⚠ **ここを素の `GatewayError` のまま流すと、上流の 404 が
-    # 「その投稿は無い」としてクライアントへ返り、しかも
-    # `STATUS_UPDATE_SILENT_STATUSES` の抑止に乗って Sentry にも出ない。**
-    def fetch_internal(method, id, headers)
+    # ⚠ **素の `GatewayError` のまま流すと、上流の 404 が「その投稿は無い」として
+    # クライアントへ返り、しかも `STATUS_UPDATE_SILENT_STATUSES` の抑止に乗って
+    # Sentry にも出ない。**
+    #
+    # ⚠⚠ **だからといって内部読みの失敗を一律に内部エラー扱いしてはいけない。**
+    # 「投稿が消えている」「リモートの投稿」「トークンが切れている」は
+    # **本当にクライアント起因の 4xx** で、ここは日常的に通る。一律に付け替えると
+    # 古い投稿を編集しようとしただけで 502 と Sentry イベントが出る。
+    # **クライアント起因ではありえない失敗だけ**を付け替える。
+    def fetch_internal(method, id, headers, paired: false)
       return sns.public_send(method, id, {headers:})
     rescue Ginseng::GatewayError => e
-      raise InternalGatewayError.wrap(e, method)
+      raise InternalGatewayError.wrap(e, method) if paired || internal_failure?(e)
+      raise
+    end
+
+    # クライアント起因ではありえない失敗か (#4631)。
+    #
+    # 4xx は上のとおり日常的に起きるので、**それ自体では内部の失敗と判定できない**。
+    # 逆に 5xx・接続失敗（`source_status` が取れない）は上流かモロヘイヤの問題で、
+    # クライアントの操作では作れない。
+    def internal_failure?(error)
+      return true unless error.source_status.to_i.between?(400, 499)
+      return false
     end
 
     # ⚠⚠ **アンケートを持つ投稿は編集させない (#4625)。**

--- a/app/lib/mulukhiya/controller/mastodon_controller.rb
+++ b/app/lib/mulukhiya/controller/mastodon_controller.rb
@@ -203,8 +203,8 @@ module Mulukhiya
     # `fetch_status` から取る（リクエストが 1 本増える）。
     def restored_body(id)
       headers = upstream_headers
-      source = sns.fetch_status_source(id, {headers:})
-      status = sns.fetch_status(id, {headers:})
+      source = fetch_internal(:fetch_status_source, id, headers)
+      status = fetch_internal(:fetch_status, id, headers)
       reject_poll!(status)
       return sanitize_spoiler({
         status: source['text'].to_s,
@@ -212,6 +212,17 @@ module Mulukhiya
         sensitive: status['sensitive'] ? true : false,
         media_ids: Array(status['media_attachments']).map {|v| v['id']},
       })
+    end
+
+    # 内部読みの失敗をクライアントの更新失敗と区別する (#4631)。
+    #
+    # ⚠ **ここを素の `GatewayError` のまま流すと、上流の 404 が
+    # 「その投稿は無い」としてクライアントへ返り、しかも
+    # `STATUS_UPDATE_SILENT_STATUSES` の抑止に乗って Sentry にも出ない。**
+    def fetch_internal(method, id, headers)
+      return sns.public_send(method, id, {headers:})
+    rescue Ginseng::GatewayError => e
+      raise InternalGatewayError.wrap(e, method)
     end
 
     # ⚠⚠ **アンケートを持つ投稿は編集させない (#4625)。**

--- a/app/lib/mulukhiya/internal_gateway_error.rb
+++ b/app/lib/mulukhiya/internal_gateway_error.rb
@@ -1,0 +1,32 @@
+module Mulukhiya
+  # モロヘイヤ**自身の内部読み**が失敗したことを表すゲートウェイエラー (#4631)。
+  #
+  # ⚠⚠ **クライアントの更新失敗と同じ型にしてはいけない。**#4589 の修正で
+  # `create_media_update_body` に `fetch_status_source` / `fetch_status` という
+  # **2 本の内部 GET** がリクエスト処理中に入ったが、その失敗が素の
+  # `Ginseng::GatewayError` として `STATUS_UPDATE_SILENT_STATUSES`（401 / 404）の
+  # 抑止に乗っていた。結果:
+  #
+  # - クライアントには「**その投稿は無い**」と読める 404 が返る
+  #   （実際はモロヘイヤ側の内部読みの失敗）
+  # - ⚠ silent 判定に当たるので **Sentry にも上がらず syslog 1 行だけ**
+  #
+  # ⚠ **ALT 編集が全ユーザーで壊れていても観測面に何も出ない**状態だった。
+  # 実際 #4621 では「`/source` は 200 なのに `fetch_status` だけ落ちる」という
+  # 非対称が切り分けを遅らせている。原因が変わっても同じ隠れ方を再生産するので、
+  # **構造として分ける**。
+  #
+  # `ForeignGatewayError` と同じく `handle_gateway_error` が透過を拒み、
+  # **加えて silent 判定を無条件に外す**。
+  class InternalGatewayError < Ginseng::GatewayError
+    # 上流のレスポンスは保つ（`e.log` に状況を残すため）が、**メッセージは
+    # 差し替える**。"Bad response 404" のままだとクライアントにもログにも
+    # 「対象が無い」と読めてしまい、この型を作った意味が消える。
+    def self.wrap(error, label)
+      wrapped = new("internal fetch failed (#{label}): #{error.message}")
+      wrapped.set_backtrace(error.backtrace)
+      wrapped.response = error.response if error.respond_to?(:response)
+      return wrapped
+    end
+  end
+end

--- a/test/unit/controller/internal_fetch_error.rb
+++ b/test/unit/controller/internal_fetch_error.rb
@@ -7,6 +7,8 @@ module Mulukhiya
   # 「ALT 編集が全ユーザーで壊れている」が syslog 1 行に消える状態だった。
   class InternalFetchErrorTest < TestCase
     ResponseDouble = Struct.new(:code, :body)
+    SOURCE = {'text' => '本文', 'spoiler_text' => ''}.freeze
+    STATUS = {'sensitive' => false, 'media_attachments' => [], 'poll' => nil}.freeze
 
     def setup
       @controller = MastodonController.new!
@@ -67,7 +69,72 @@ module Mulukhiya
       assert_equal(404, internal_error(404).source_status)
     end
 
+    # ⚠⚠ **ここからが Codex P1 の懸念（#4647）。**「投稿が消えている」
+    # 「リモートの投稿」「トークンが切れている」は**本当にクライアント起因の 4xx** で、
+    # 日常的に通る。一律に内部エラー扱いすると、古い投稿を編集しようとしただけで
+    # 502 と Sentry イベントが出る。
+
+    # 1 本目が 404 = 投稿が無い。両方落ちるので非対称にならない。
+    def test_first_fetch_client_error_is_preserved
+      controller = controller_with(source: client_error(404))
+      error = assert_raise(Ginseng::GatewayError) {restore(controller)}
+
+      assert_not_kind_of(InternalGatewayError, error)
+    end
+
+    # トークン切れも同じ。
+    def test_first_fetch_unauthorized_is_preserved
+      controller = controller_with(source: client_error(401))
+      error = assert_raise(Ginseng::GatewayError) {restore(controller)}
+
+      assert_not_kind_of(InternalGatewayError, error)
+    end
+
+    # ⚠⚠ **これが #4621 の症状。**1 本目が通ったのに 2 本目だけ落ちるのは、
+    # クライアント起因ではありえない（投稿が無いなら両方 404 になる）。
+    def test_asymmetric_failure_is_internal
+      controller = controller_with(status: client_error(404))
+
+      assert_raise(InternalGatewayError) {restore(controller)}
+    end
+
+    # 5xx はクライアントの操作では作れない。
+    def test_server_error_is_internal
+      controller = controller_with(source: client_error(502))
+
+      assert_raise(InternalGatewayError) {restore(controller)}
+    end
+
     private
+
+    # fetch_status_source / fetch_status のダブル。指定された側だけ raise する。
+    class SnsDouble
+      def initialize(source:, status:)
+        @source = source
+        @status = status
+      end
+
+      def fetch_status_source(_id, _opts) = resolve(@source)
+      def fetch_status(_id, _opts) = resolve(@status)
+
+      private
+
+      def resolve(value)
+        raise value if value.is_a?(StandardError)
+        return value
+      end
+    end
+
+    def controller_with(source: SOURCE, status: STATUS)
+      controller = MastodonController.new!
+      controller.instance_variable_set(:@sns, SnsDouble.new(source:, status:))
+      controller.instance_variable_set(:@headers, {})
+      return controller
+    end
+
+    def restore(controller)
+      return controller.send(:restored_body, '1')
+    end
 
     def spy(error)
       calls = []

--- a/test/unit/controller/internal_fetch_error.rb
+++ b/test/unit/controller/internal_fetch_error.rb
@@ -1,0 +1,93 @@
+module Mulukhiya
+  # ALT 編集の内部 fetch 失敗が、クライアントの 404 に潰れず alert 抑止にも
+  # 乗らないこと (#4631)。
+  #
+  # ⚠⚠ **#4589 の修正で入った 2 本の内部 GET が、素の GatewayError として
+  # STATUS_UPDATE_SILENT_STATUSES（401 / 404）の抑止に乗っていた。**
+  # 「ALT 編集が全ユーザーで壊れている」が syslog 1 行に消える状態だった。
+  class InternalFetchErrorTest < TestCase
+    ResponseDouble = Struct.new(:code, :body)
+
+    def setup
+      @controller = MastodonController.new!
+      @renderer = Ginseng::Web::JSONRenderer.new
+      @controller.instance_variable_set(:@renderer, @renderer)
+    end
+
+    # ⚠ **クライアントに「その投稿は無い」と読める 404 を返さない。**
+    # 実際に無いのではなくモロヘイヤ側の読みが失敗しただけ。
+    def test_internal_not_found_is_not_reported_as_client_error
+      @controller.handle_gateway_error(
+        internal_error(404),
+        silent_statuses: MastodonController::STATUS_UPDATE_SILENT_STATUSES,
+      )
+
+      assert_equal(502, @renderer.status)
+      assert_match(/internal fetch failed/, fetch(@renderer.message, 'error'))
+    end
+
+    # ⚠⚠ **これが本命。**404 は抑止対象だが、内部読みの失敗なら alert する。
+    def test_internal_error_is_never_silenced
+      error = internal_error(404)
+      calls = spy(error)
+
+      @controller.handle_gateway_error(
+        error,
+        silent_statuses: MastodonController::STATUS_UPDATE_SILENT_STATUSES,
+      )
+
+      assert_equal([:alert], calls)
+    end
+
+    def test_internal_unauthorized_is_never_silenced
+      error = internal_error(401)
+      calls = spy(error)
+
+      @controller.handle_gateway_error(error)
+
+      assert_equal([:alert], calls)
+    end
+
+    # 対照。クライアント起因の 404 は従来どおり静かなまま。
+    def test_client_not_found_stays_silent
+      error = client_error(404)
+      calls = spy(error)
+
+      @controller.handle_gateway_error(
+        error,
+        silent_statuses: MastodonController::STATUS_UPDATE_SILENT_STATUSES,
+      )
+
+      assert_equal([:log], calls)
+      assert_equal(404, @renderer.status)
+    end
+
+    # 上流のレスポンスは捨てない（e.log に状況を残すため）。
+    def test_wrap_keeps_upstream_response
+      assert_equal(404, internal_error(404).source_status)
+    end
+
+    private
+
+    def spy(error)
+      calls = []
+      error.define_singleton_method(:alert) {calls << :alert}
+      error.define_singleton_method(:log) {calls << :log}
+      return calls
+    end
+
+    def client_error(status)
+      error = Ginseng::GatewayError.new("Bad response #{status}")
+      error.response = ResponseDouble.new(status, {error: 'Record not found'}.to_json)
+      return error
+    end
+
+    def internal_error(status)
+      return InternalGatewayError.wrap(client_error(status), :fetch_status)
+    end
+
+    def fetch(message, key)
+      return message[key] || message[key.to_sym]
+    end
+  end
+end


### PR DESCRIPTION
## 何が起きていたか

#4589 の修正で `create_media_update_body` に **`fetch_status_source` / `fetch_status` という 2 本の内部 GET** がリクエスト処理中に入ったが、その失敗が**素の `Ginseng::GatewayError`** として

```ruby
handle_gateway_error(e, silent_statuses: STATUS_UPDATE_SILENT_STATUSES)  # [401, 404]
```

に流れていた。上流の内部読みが 404 を返すと:

- クライアントには「**その投稿は無い**」と読める 404 がそのまま返る（実際はモロヘイヤ側の読みの失敗）
- ⚠ silent 判定に当たるので **Sentry にも上がらず syslog 1 行だけ**

⚠⚠ **ALT 編集が全ユーザーで壊れていても、観測面には何も出ない。**

## 直し方

**`InternalGatewayError` を足した**（`ForeignGatewayError` と同じ形）。

1. `restored_body` の 2 本の内部 GET を `fetch_internal` でくるみ、失敗を付け替える
2. `handle_gateway_error` は `ForeignGatewayError` と同様に**透過を拒み、502 + 自前の文言**に倒す
3. ⚠⚠ **加えて silent 判定を無条件に外す。**`silent_statuses` に 404 が入っていても抑止しない

**メッセージも差し替える**（`internal fetch failed (fetch_status): Bad response 404`）。`"Bad response 404"` のままだとクライアントにもログにも「対象が無い」と読めてしまい、型を分けた意味が消えるため。⚠ 上流のレスポンス自体は捨てない（`e.log` に状況を残すため）。

## 赤→緑を確認した

`handle_gateway_error` の変更だけ戻すと、**欠陥がそのまま再現する**:

```
test_internal_not_found_is_not_reported_as_client_error  <502> expected but was <404>
test_internal_error_is_never_silenced                    <[:alert]> expected but was <[:log]>
test_internal_unauthorized_is_never_silenced             <[:alert]> expected but was <[:log]>
```

対照として **`test_client_not_found_stays_silent`**（クライアント起因の 404 は従来どおり `log` かつ 404）も置いた。抑止を外しすぎていないことの担保。

## なぜ構造で分けるか

⚠ **#4621（PUT が 405）の原因そのものは本 PR の対象外。**ここで直しているのは**それを見えなくした構造**で、原因が変わっても同じ隠れ方を再生産する。実際 #4621 では「`/source` は 200 なのに `fetch_status` だけ落ちる」という非対称が切り分けを遅らせた。

## 確認

- `bundle exec rake lint` — 486 files / no offenses、bundler-audit も緑
- `bundle exec rake test` — **1141 tests, 1593 assertions, 0 failures, 0 errors**（omission は 322 のまま）

Refs #4631