### PR TITLE
security: ログの秘匿の穴 2 件を塞ぐ（例外メッセージ内の URL / blocks・attachments）(#4630)

### DIFF
--- a/app/lib/mulukhiya/controller.rb
+++ b/app/lib/mulukhiya/controller.rb
@@ -12,6 +12,10 @@ module Mulukhiya
     SCRUBBED_LOG_PARAMS = [
       'status', 'text', 'body', 'comment', 'spoiler_text', 'cw',
       'q', 'title', 'artist', 'album', # word/suggest・nowplaying のユーザー入力 (#4394)
+      # ⚠ Slack legacy attachments の本文系 (#4630)。`SlackWebhookPayload#format_attachment`
+      #   が **すべて投稿本文へ組み立てる**ので、`text` だけ伏せても残りが平文で残る。
+      #   `title` は上の行で既に対象。`fields[].value` はキー名が `value`。
+      'pretext', 'author_name', 'value', 'footer',
       'code', # OAuth 認可コード (spotify/auth・annict/auth)。短命だが資格情報なので伏せる
       # ⚠ アクセストークン本体。`i` は Misskey がボディで渡す（MisskeyController#token
       #   のフォールバック）。/logger/mask_query_params は URL のクエリにしか効かない

--- a/app/lib/mulukhiya/controller.rb
+++ b/app/lib/mulukhiya/controller.rb
@@ -19,6 +19,11 @@ module Mulukhiya
       'i', 'access_token'
     ].freeze
 
+    # `scrub_log_params` が潜る深さの上限 (#4630)。Block Kit の
+    # `blocks[].text.text` で 4、`attachments[].blocks[].text.text` で 6 なので、
+    # 実用形には十分な余裕がある。
+    MAX_LOG_SCRUB_DEPTH = 12
+
     # 上流へそのまま中継してよい受信ヘッダ (#4598)。
     #
     # ⚠ **`@headers` の丸投げはしない。**`Host` / `Content-Length` / `Cookie` /
@@ -225,12 +230,39 @@ module Mulukhiya
 
     private
 
+    # ⚠⚠ **入れ子まで走査する (#4630)。**従来は `scrubbed.key?(key)` の
+    # **トップレベル走査だけ**だったが、Slack 互換 webhook が実際に使う
+    # Block Kit の本文は `blocks` / `attachments` の入れ子の中にある。
+    #
+    #   {"blocks":[{"type":"section","text":{"text":"（本文）"}}]}
+    #
+    # ⚠ **同じ本文を `text` で送れば `[FILTERED]` になるのに、`blocks` で送ると
+    # 平文で syslog に残る**＝送り方で秘匿の効き方が変わっていた。#4394 が
+    # 「投稿本文系フィールドを平文で残さない」ために入れた対策の抜け。
+    # gem 側の `Logger#mask` はキー名で落とすが、`/logger/mask_fields` は
+    # 資格情報の名前だけなので本文系はそちらでも落ちない。
     def scrub_log_params(params)
-      scrubbed = params.deep_dup
-      SCRUBBED_LOG_PARAMS.each do |key|
-        scrubbed[key] = '[FILTERED]' if scrubbed.key?(key)
+      return scrub_log_value(params.deep_dup, 0)
+    end
+
+    # ⚠ **深さで打ち切る。**外部から渡る JSON なので、際限なく潜ると
+    # スタックを掘り尽くせる。打ち切りは**残す側ではなく落とす側**へ倒す
+    # （読めない深さのものを平文で通すより、伏せて出すほうが安全）。
+    def scrub_log_value(value, depth)
+      return '[FILTERED]' if depth > MAX_LOG_SCRUB_DEPTH
+      case value
+      when Hash
+        value.each_key do |key|
+          value[key] = if SCRUBBED_LOG_PARAMS.include?(key.to_s)
+            '[FILTERED]'
+          else
+            scrub_log_value(value[key], depth + 1)
+          end
+        end
+      when Array
+        value.map! {|v| scrub_log_value(v, depth + 1)}
       end
-      return scrubbed
+      return value
     end
 
     def default_renderer_class

--- a/app/lib/mulukhiya/media_file.rb
+++ b/app/lib/mulukhiya/media_file.rb
@@ -183,13 +183,21 @@ module Mulukhiya
         'tmp/media',
         "#{uri.to_s.sha256}#{File.extname(uri.path)}",
       )
-      raise Ginseng::GatewayError, "Too large content '#{uri}'" unless
+      raise_too_large(uri, :content_length) unless
         valid_content_length?(uri, request_options(params))
       body = HTTP.new.get(uri, request_options(params)).body.to_s
-      raise Ginseng::GatewayError, "Too large content '#{uri}'" if
-        body.bytesize > download_max_bytes
+      raise_too_large(uri, :body) if body.bytesize > download_max_bytes
       write_atomic(path, body)
       return new(path).file
+    end
+
+    # ⚠⚠ **URI を例外メッセージへ埋めない (#4630)。**`Ginseng::Logger#mask_url` は
+    # `\A` アンカーで「値そのものが URL」のときしかマスクしないので、文中へ埋めると
+    # webhook から第三者が渡した `image_url`（署名付き URL のことがある）が
+    # 平文で syslog に残る。**URI はマスクの効くフィールドで別に残す。**
+    def self.raise_too_large(uri, phase)
+      Logger.new.error(error: 'too large content', phase:, url: uri.to_s)
+      raise Ginseng::GatewayError, 'Too large content'
     end
 
     # ⚠ **宛先へ直接書かない (#4626)。**`path` は URL の sha256 由来の**固定名**なので、

--- a/app/lib/mulukhiya/remote_dictionary.rb
+++ b/app/lib/mulukhiya/remote_dictionary.rb
@@ -24,11 +24,17 @@ module Mulukhiya
     def fetch
       response = @http.get(uri)
       parsed = response.parsed_response
-      raise Ginseng::GatewayError, "empty response (#{uri})" unless parsed.present?
+      # ⚠⚠ **URI を例外メッセージへ埋めない (#4630)。**`Ginseng::Logger#mask_url` は
+      # `URL_PATTERN` を `\A` アンカーで見るので、マスクが効くのは
+      # **値そのものが URL である文字列**だけ。文中に埋めると
+      # `?access_token=` 付きの辞書 URL がそのまま syslog に残る。
+      # ⚠ 同じ URL を `log_invalid_schema` の `url:` では `[FILTERED]` にしているのに
+      # 例外メッセージ側だけ平文、という非対称になっていた。
+      # URI はサブクラスの `e.log(dic: uri.to_s)`（マスクが効く）側に任せる。
+      raise Ginseng::GatewayError, 'empty response' unless parsed.present?
       return parsed if valid_schema?(parsed)
       log_invalid_schema(response, parsed)
-      raise Ginseng::GatewayError,
-        "unexpected response type '#{parsed.class.name}' (#{uri})"
+      raise Ginseng::GatewayError, "unexpected response type '#{parsed.class.name}'"
     end
 
     # サブクラスが `parse` で前提にしている型。

--- a/test/unit/controller/log_scrub.rb
+++ b/test/unit/controller/log_scrub.rb
@@ -35,6 +35,58 @@ module Mulukhiya
       assert_equal('abc', scrub('i' => 'SECRET', 'noteId' => 'abc')['noteId'])
     end
 
+    # ⚠⚠ **ここからが #4630。**Slack 互換 webhook が実際に使う Block Kit の本文は
+    # `blocks` の入れ子の中にあり、トップレベル走査では素通りしていた。
+    # **同じ本文を `text` で送れば伏せられるのに、`blocks` で送ると平文**という
+    # 送り方依存の穴だった。
+    def test_scrubs_nested_block_kit_text
+      scrubbed = scrub(
+        'blocks' => [{'type' => 'section', 'text' => {'type' => 'mrkdwn', 'text' => '（本文）'}}],
+      )
+
+      assert_equal('[FILTERED]', scrubbed['blocks'][0]['text'])
+    end
+
+    def test_scrubs_nested_attachments
+      scrubbed = scrub(
+        'attachments' => [{'text' => '（本文）', 'image_url' => 'https://example.com/a.png'}],
+      )
+
+      assert_equal('[FILTERED]', scrubbed['attachments'][0]['text'])
+      assert_equal('https://example.com/a.png', scrubbed['attachments'][0]['image_url'])
+    end
+
+    # 入れ子の資格情報も落とす。
+    def test_scrubs_nested_token
+      scrubbed = scrub('payload' => {'inner' => {'access_token' => 'SECRET'}})
+
+      assert_equal('[FILTERED]', scrubbed['payload']['inner']['access_token'])
+    end
+
+    # ⚠ **際限なく潜らない。**外部から渡る JSON なのでスタックを掘り尽くせる。
+    # 打ち切りは落とす側へ倒す（読めない深さを平文で通すより伏せる）。
+    def test_truncates_deep_nesting
+      deep = value = {}
+      30.times do
+        value['nested'] = {}
+        value = value['nested']
+      end
+      value['text'] = '（本文）'
+
+      dumped = scrub(deep).to_json
+
+      # 本命は「本文がログに出ないこと」。打ち切り位置の off-by-one に依存しない形で見る。
+      assert_not_match(/（本文）/, dumped)
+      assert_match(/\[FILTERED\]/, dumped)
+    end
+
+    # 入れ子を壊さない（マスク対象外はそのまま残る）。
+    def test_keeps_nested_other_params
+      scrubbed = scrub('blocks' => [{'type' => 'section'}])
+
+      assert_equal('section', scrubbed['blocks'][0]['type'])
+    end
+
     # 処理に使う @params を壊さない (ログ用の複製だけを書き換える)。
     def test_does_not_mutate_source
       params = Sinatra::IndifferentHash['i' => 'SECRET']

--- a/test/unit/controller/log_scrub.rb
+++ b/test/unit/controller/log_scrub.rb
@@ -56,6 +56,28 @@ module Mulukhiya
       assert_equal('https://example.com/a.png', scrubbed['attachments'][0]['image_url'])
     end
 
+    # ⚠⚠ **legacy attachments は `text` 以外も投稿本文になる (#4630・Codex P1)。**
+    # `SlackWebhookPayload#format_attachment` が pretext / author_name / title /
+    # text / fields[].value / footer を**すべて本文へ組み立てる**ので、`text` だけ
+    # 伏せても残りが平文で残る。
+    def test_scrubs_legacy_attachment_body_fields
+      scrubbed = scrub('attachments' => [{
+        'pretext' => '前置き',
+        'author_name' => '著者',
+        'title' => '見出し',
+        'text' => '本文',
+        'fields' => [{'title' => '項目', 'value' => '値'}],
+        'footer' => '脚注',
+      }])
+      attachment = scrubbed['attachments'][0]
+
+      %w[pretext author_name title text footer].each do |key|
+        assert_equal('[FILTERED]', attachment[key], "#{key} が伏せられていない")
+      end
+      assert_equal('[FILTERED]', attachment['fields'][0]['value'])
+      assert_equal('[FILTERED]', attachment['fields'][0]['title'])
+    end
+
     # 入れ子の資格情報も落とす。
     def test_scrubs_nested_token
       scrubbed = scrub('payload' => {'inner' => {'access_token' => 'SECRET'}})

--- a/test/unit/controller/log_scrub.rb
+++ b/test/unit/controller/log_scrub.rb
@@ -71,7 +71,7 @@ module Mulukhiya
       }])
       attachment = scrubbed['attachments'][0]
 
-      %w[pretext author_name title text footer].each do |key|
+      ['pretext', 'author_name', 'title', 'text', 'footer'].each do |key|
         assert_equal('[FILTERED]', attachment[key], "#{key} が伏せられていない")
       end
       assert_equal('[FILTERED]', attachment['fields'][0]['value'])


### PR DESCRIPTION
どちらも**ログの秘匿の穴**なので 1 本にまとめた。

## 1. 例外メッセージへ URL を埋めると `mask_url` が効かない

`Ginseng::Logger#mask_url` は `URL_PATTERN` を ⚠ **`\A` アンカー**で見るので、マスクが効くのは「**値そのものが URL である文字列**」だけ。実測:

```
値そのもの : https://example.com/d.json?access_token=[FILTERED]
文中に埋込 : empty response (https://example.com/d.json?access_token=SECRET123)   ⚠
```

⚠ **同じ URL を `log_invalid_schema` の `url:` フィールドでは `[FILTERED]` にしているのに、例外メッセージ側では平文**という非対称だった。⚠ v5.33.0 では URI を含んでいなかった（旧コードは `raise 'empty'`）ので、**5.34.0 の差分で 3 箇所とも新設された穴**。

- `remote_dictionary.rb` 2 箇所 — 辞書 URL のクエリに `access_token=` が付いていれば平文で残る
- `media_file.rb` 2 箇所 — webhook から**第三者が渡す** `image_url`（署名付き URL のことがある）が同じ形で残る

**直し方**: `remote_dictionary` は URI をメッセージから落とす（サブクラスが `e.log(dic: uri.to_s)` で残しており、そちらはマスクが効く）。`media_file` は `raise_too_large` を足し、**URI をマスクの効くフィールドへ寄せる**（`phase:` でどちらの検査で落ちたかは残る）。

```
{"error":"too large content","url":"https://e.com/x?access_token=[FILTERED]"}
```

## 2. リクエストログのスクラブが `blocks` / `attachments` を素通しする

`scrub_log_params` は `scrubbed.key?(key)` の**トップレベル走査だけ**。Slack 互換 webhook が実際に使う Block Kit の本文は入れ子の中にある。

⚠ **同じ本文を `text` で送れば `[FILTERED]` になるのに、`blocks` で送ると平文**＝**送り方で秘匿の効き方が変わっていた**。gem 側の `Logger#mask` は入れ子も辿るが `/logger/mask_fields` は**資格情報の名前だけ**（`auth` / `token` / `secret` 等）なので、本文系はそちらでも落ちない。#4394 の対策の抜け。

**直し方**: `scrub_log_params` を再帰にした。

⚠ **深さで打ち切る。**外部から渡る JSON なので際限なく潜るとスタックを掘り尽くせる。⚠ **打ち切りは残す側ではなく落とす側へ倒した**（読めない深さのものを平文で通すより、伏せて出すほうが安全）。上限 12 は `attachments[].blocks[].text.text` で 6 なので実用形に十分な余裕がある。

## 赤→緑を確認した

`scrub_log_params` を修正前に戻すと、**本文とトークンが実際に漏れる**:

```
test_scrubs_nested_block_kit_text  <"[FILTERED]"> expected but was <{"text"=>"（本文）", ...}>
test_scrubs_nested_attachments     <"[FILTERED]"> expected but was <"（本文）">
test_scrubs_nested_token           <"[FILTERED]"> expected but was <"SECRET">
test_truncates_deep_nesting        /（本文）/ was expected to not match ...
```

⚠ 深さの試験は**打ち切り位置の off-by-one に依存しない形**にした（「本文がログに出ないこと」を JSON 全体で見る）。マスク対象外が素通しされること（`type` / `image_url`）も対照として置いた。

## 確認

- `bundle exec rake lint` — 486 files / no offenses、bundler-audit も緑
- `bundle exec rake test` — **1150 tests, 1606 assertions, 0 failures, 0 errors**（omission は 322 のまま）

⚠ `MediaFile` が `Metrics/ClassLength` 上限ちょうど（201/200）になったので、2 つ目の呼び出しを 1 行に詰めて 200 に収めた。**#4570（`Program` が上限ちょうど）と同じ兆候**が出ているので、別途 size:M で分割を検討する余地があります。

Refs #4630