### PR TITLE
fix: webhook の添付が黙って落ちる 2 件を直す (#4633)

### DIFF
--- a/app/lib/mulukhiya/handler/webhook_image_handler.rb
+++ b/app/lib/mulukhiya/handler/webhook_image_handler.rb
@@ -17,15 +17,59 @@ module Mulukhiya
     def handle_pre_webhook(payload, params = {})
       payload.deep_stringify_keys!
       payload[attachment_field] = Concurrent::Array.new(payload[attachment_field] || [])
-      in_threads = Parallel.processor_count
-      Parallel.each(payload['attachments'] || [], in_threads:) do |attachment|
-        next unless uri = Ginseng::URI.parse(attachment['image_url'])
-        next if sns.max_media_attachments <= payload[attachment_field].count
-        payload[attachment_field].push(upload(uri))
-        result.push(source_url: uri.to_s)
+      slots = create_slots(payload)
+      Parallel.each(payload['attachments'] || [], in_threads: Parallel.processor_count) do |a|
+        next unless uri = Ginseng::URI.parse(a['image_url'])
+        next unless reserve_slot(slots)
+        upload_attachment(payload, uri, slots)
       rescue => e
-        errors.push(class: e.class.to_s, message: e.message, attachment:)
+        drop_attachment(e, a)
       end
+    end
+
+    private
+
+    # ⚠⚠ **握り潰しても黙って消さない (#4633)。**「1 枚落ちても投稿は通す」設計
+    # 自体は正しいが、上限超過 (`/media/download/max_bytes`) も取得失敗も
+    # **200 と作成済み投稿 ID が返るだけ**で、送信側は成功と区別できなかった。
+    # ⚠ `attachment` ごと渡すのは、`image_url` が値そのものとして
+    # `Logger#mask_url` に当たり `[FILTERED]` になるため (#4630)。
+    def drop_attachment(error, attachment)
+      logger.error(error: 'webhook attachment dropped', reason: error.class.to_s, attachment:)
+      errors.push(class: error.class.to_s, message: error.message, attachment:)
+    end
+
+    def create_slots(payload)
+      return Concurrent::AtomicFixnum.new(
+        [sns.max_media_attachments - payload[attachment_field].count, 0].max,
+      )
+    end
+
+    # ⚠⚠ **判定と確保を不可分にする (#4633)。**従来は
+    # `sns.max_media_attachments <= payload[attachment_field].count` を
+    # **ダウンロード + アップロードの前**に見ていた。`Concurrent::Array` は `push` を
+    # 原子化するが判定は守らないので、上限 4・現在 3 枚で残り 3 件を 3 スレッドが
+    # 同時に評価すると **3 本とも `3 < 4` を通過**し、それぞれ数百 ms〜秒かけて
+    # アップロードしてから揃って `push` する ＝ **6 枚**。上流が `media_ids` の
+    # 上限超過で **422 を返し webhook 投稿ごと落ちる**（かつアップロード済みの
+    # メディアが孤児として残る）。
+    def reserve_slot(slots)
+      reserved = false
+      slots.update do |remaining|
+        reserved = remaining.positive?
+        reserved ? remaining - 1 : remaining
+      end
+      return reserved
+    end
+
+    # ⚠ **失敗したら枠を返す。**返さないと、取得に失敗しただけで後続の添付が
+    # 枠切れで落ちる（従来は枠を先に取らないので起きなかった退行）。
+    def upload_attachment(payload, uri, slots)
+      payload[attachment_field].push(upload(uri))
+      result.push(source_url: uri.to_s)
+    rescue
+      slots.increment
+      raise
     end
   end
 end

--- a/app/lib/mulukhiya/handler/webhook_image_handler.rb
+++ b/app/lib/mulukhiya/handler/webhook_image_handler.rb
@@ -17,17 +17,50 @@ module Mulukhiya
     def handle_pre_webhook(payload, params = {})
       payload.deep_stringify_keys!
       payload[attachment_field] = Concurrent::Array.new(payload[attachment_field] || [])
+      queue = Queue.new
+      (payload['attachments'] || []).each {|v| queue.push(v)}
       slots = create_slots(payload)
-      Parallel.each(payload['attachments'] || [], in_threads: Parallel.processor_count) do |a|
-        next unless uri = Ginseng::URI.parse(a['image_url'])
-        next unless reserve_slot(slots)
-        upload_attachment(payload, uri, slots)
-      rescue => e
-        drop_attachment(e, a)
-      end
+      workers = [Parallel.processor_count, queue.size].min
+      Array.new(workers) {Thread.new {consume(queue, payload, slots)}}.each(&:join)
     end
 
     private
+
+    # ⚠⚠ **候補を「配る」のではなく「取りに行く」形にする (#4633・Codex P2)。**
+    # `Parallel.each` で候補を配ると、**枠切れで skip した候補は二度と戻らない**。
+    # 先に枠を取る実装と組み合わせると、先頭の候補が枠を全部押さえ→そのうち 1 本が
+    # 失敗して枠を返しても、**skip 済みの後続を拾う者がいない**＝空いた枠が
+    # 使われないまま、有効な添付が黙って落ちる（候補 5・枠 4・先頭で 1 失敗なら 3 枚）。
+    #
+    # 取りに行く形なら、**失敗して枠を返したワーカーがそのまま次の候補に使う**。
+    def consume(queue, payload, slots)
+      loop do
+        break unless attachment = pop_attachment(queue)
+        next unless uri = parse_image_uri(attachment)
+        unless reserve_slot(slots)
+          # ⚠ **取り出したまま降りない。**別のワーカーが失敗して枠を返したときに
+          # 拾える候補が消える。戻してから降りる。
+          queue.push(attachment)
+          break
+        end
+        upload_attachment(payload, uri, slots, attachment)
+      end
+    end
+
+    def pop_attachment(queue)
+      return queue.pop(true)
+    rescue ThreadError
+      return nil
+    end
+
+    # ⚠ **`image_url` を持たない添付は正常。**Slack legacy attachments は
+    # 本文だけのものが普通にあるので、落ちた扱いにしない（枠も取らない）。
+    def parse_image_uri(attachment)
+      return Ginseng::URI.parse(attachment['image_url'])
+    rescue => e
+      drop_attachment(e, attachment)
+      return nil
+    end
 
     # ⚠⚠ **握り潰しても黙って消さない (#4633)。**「1 枚落ちても投稿は通す」設計
     # 自体は正しいが、上限超過 (`/media/download/max_bytes`) も取得失敗も
@@ -64,12 +97,13 @@ module Mulukhiya
 
     # ⚠ **失敗したら枠を返す。**返さないと、取得に失敗しただけで後続の添付が
     # 枠切れで落ちる（従来は枠を先に取らないので起きなかった退行）。
-    def upload_attachment(payload, uri, slots)
+    # 返した枠は `consume` のループが次の候補に使う。
+    def upload_attachment(payload, uri, slots, attachment)
       payload[attachment_field].push(upload(uri))
       result.push(source_url: uri.to_s)
-    rescue
+    rescue => e
       slots.increment
-      raise
+      drop_attachment(e, attachment)
     end
   end
 end

--- a/test/unit/handler/webhook_attachment_slots.rb
+++ b/test/unit/handler/webhook_attachment_slots.rb
@@ -9,6 +9,7 @@ module Mulukhiya
   class WebhookAttachmentSlotsTest < TestCase
     MAX = 4
     UPLOAD_DELAY = 0.05
+    WORKERS = 16
 
     # 枠の確保だけを取り出して、旧実装と新実装を同じ並行条件で比べる。
     def test_reserve_slot_never_exceeds_capacity
@@ -57,7 +58,94 @@ module Mulukhiya
       assert_false(reserve_slot(slots))
     end
 
+    # ⚠⚠ **ここが Codex P2（#4650）。**候補を「配る」形だと、枠切れで skip した
+    # 候補は二度と戻らない。先頭が枠を全部押さえてそのうち 1 本が失敗すると、
+    # **空いた枠を拾う者がいない**まま有効な添付が黙って落ちる。
+    def test_released_slot_is_reused_by_later_candidate
+      handler = build_handler(fail: ['https://example.com/2.png'])
+      payload = {'media' => Concurrent::Array.new}
+
+      run_consume(handler, payload, slots: 4, candidates: 5)
+
+      # 5 候補・枠 4・1 本失敗 → 有効な 4 枚が積まれる。
+      assert_equal(4, payload['media'].count)
+      assert_equal(1, handler.dropped.count)
+    end
+
+    # 上限は決して超えない（枠を返す形にしても）。
+    def test_never_exceeds_capacity_with_failures
+      handler = build_handler(fail: ['https://example.com/1.png'])
+      payload = {'media' => Concurrent::Array.new}
+
+      run_consume(handler, payload, slots: 2, candidates: 6)
+
+      assert_equal(2, payload['media'].count)
+    end
+
+    # image_url を持たない添付は「落ちた」扱いにせず、枠も消費しない。
+    def test_attachment_without_image_url_costs_nothing
+      handler = build_handler
+      payload = {'media' => Concurrent::Array.new}
+      queue = Queue.new
+      queue.push({'text' => '本文だけ'})
+      2.times {|i| queue.push({'image_url' => "https://example.com/#{i}.png"})}
+
+      drive(handler, queue, payload, 2)
+
+      assert_equal(2, payload['media'].count)
+      assert_equal(0, handler.dropped.count)
+    end
+
     private
+
+    # `consume` を実インスタンスで動かすためのダブル。
+    # ⚠ `initialize` で `super` を呼ばない（Handler#initialize は DB を要求する）。
+    class HandlerDouble < WebhookImageHandler
+      attr_reader :dropped, :uploaded
+
+      # ⚠ `super` を呼ばない。`Handler#initialize` は SNS / DB を要求するので、
+      # ここで呼ぶとテストが環境依存になる。使うのは `consume` の周辺だけ。
+      def initialize(fail: []) # rubocop:disable Lint/MissingSuper
+        @fail = fail
+        @dropped = Concurrent::Array.new
+        @uploaded = Concurrent::Array.new
+      end
+
+      def attachment_field = 'media'
+
+      def result = @uploaded
+
+      # ⚠ **失敗する側も時間をかける。**上限超過は「受け取ってから」判るので、
+      # 実際に失敗が判明するのはダウンロードのあと。即座に raise すると、
+      # 枠が返るのが skip より早くなって**旧実装でも通ってしまう**。
+      def upload(uri)
+        sleep(UPLOAD_DELAY)
+        raise Ginseng::GatewayError, 'Too large content' if @fail.include?(uri.to_s)
+        return uri.to_s
+      end
+
+      def drop_attachment(_error, attachment)
+        @dropped.push(attachment)
+      end
+    end
+
+    def build_handler(fail: [])
+      return HandlerDouble.new(fail:)
+    end
+
+    def run_consume(handler, payload, slots:, candidates:)
+      queue = Queue.new
+      candidates.times {|i| queue.push({'image_url' => "https://example.com/#{i}.png"})}
+      drive(handler, queue, payload, slots)
+    end
+
+    # ⚠ **ワーカー数は枠より多くする。**本体は `Parallel.processor_count`
+    # （実機で 16）なので、枠 4 に対して常にワーカーのほうが多い。同数だと
+    # 「全ワーカーが枠を持っている間に skip が起きる」条件を作れない。
+    def drive(handler, queue, payload, slots)
+      atomic = Concurrent::AtomicFixnum.new(slots)
+      run_concurrently(WORKERS) {handler.send(:consume, queue, payload, atomic)}
+    end
 
     # 本体と同じ実装を呼ぶ (private なので send)。
     def reserve_slot(slots)

--- a/test/unit/handler/webhook_attachment_slots.rb
+++ b/test/unit/handler/webhook_attachment_slots.rb
@@ -1,0 +1,77 @@
+module Mulukhiya
+  # webhook の添付が上限を超えて積まれないこと (#4633)。
+  #
+  # ⚠⚠ **旧実装は `sns.max_media_attachments <= payload[...].count` を
+  # ダウンロード + アップロードの前に見ていた。**`Concurrent::Array` は `push` を
+  # 原子化するが判定は守らないので、複数スレッドが揃って判定を通過し、
+  # それぞれ時間をかけてアップロードしてから push する ＝ 上限超過。
+  # 上流が `media_ids` の上限超過で 422 を返し、**webhook 投稿ごと落ちる**。
+  class WebhookAttachmentSlotsTest < TestCase
+    MAX = 4
+    UPLOAD_DELAY = 0.05
+
+    # 枠の確保だけを取り出して、旧実装と新実装を同じ並行条件で比べる。
+    def test_reserve_slot_never_exceeds_capacity
+      slots = Concurrent::AtomicFixnum.new(MAX)
+      pushed = Concurrent::Array.new
+
+      run_concurrently(MAX * 3) do
+        next unless reserve_slot(slots)
+        sleep(UPLOAD_DELAY) # ダウンロード + アップロードの所要
+        pushed.push(:ok)
+      end
+
+      assert_equal(MAX, pushed.count)
+    end
+
+    # ⚠ **対照。**旧実装と同じ「判定 → 時間のかかる処理 → push」を並べると
+    # 実際に超過する。超過しないなら上のテストは何も守っていない。
+    def test_check_then_act_actually_overflows
+      pushed = Concurrent::Array.new
+
+      run_concurrently(MAX * 3) do
+        next if MAX <= pushed.count
+        sleep(UPLOAD_DELAY)
+        pushed.push(:ok)
+      end
+
+      assert_operator(pushed.count, :>, MAX, '旧実装は超過するはず')
+    end
+
+    # 失敗したら枠を返す。返さないと後続が枠切れで落ちる。
+    def test_failed_upload_returns_the_slot
+      slots = Concurrent::AtomicFixnum.new(1)
+
+      assert_true(reserve_slot(slots))
+      assert_equal(0, slots.value)
+
+      slots.increment
+
+      assert_true(reserve_slot(slots))
+    end
+
+    # 既に上限まで積まれていれば 1 枚も確保できない。
+    def test_no_slot_when_already_full
+      slots = Concurrent::AtomicFixnum.new(0)
+
+      assert_false(reserve_slot(slots))
+    end
+
+    private
+
+    # 本体と同じ実装を呼ぶ (private なので send)。
+    def reserve_slot(slots)
+      return handler.send(:reserve_slot, slots)
+    end
+
+    # ⚠ **メモ化しない。**`@handler` に入れると `TestCase#teardown` の
+    # `@handler&.clear` が、`allocate` した（ivar が nil の）インスタンスを掴んで落ちる。
+    def handler
+      return WebhookImageHandler.allocate
+    end
+
+    def run_concurrently(count, &)
+      Array.new(count) {Thread.new(&)}.each(&:join)
+    end
+  end
+end


### PR DESCRIPTION
## 1. 添付上限の check-then-act 競合（実バグ）

```ruby
next if sns.max_media_attachments <= payload[attachment_field].count   # ⚠ ここ
payload[attachment_field].push(upload(uri))                            # ⚠ 数百ms〜秒あと
```

`Concurrent::Array` は `push` を原子化するが**判定は守らない**。上限 4・現在 3 枚で残り 3 件を `Parallel.each` の 3 スレッドが同時に評価すると、**3 本とも `3 < 4` を通過**してそれぞれアップロードし、揃って `push` する ＝ **6 枚**。上流が `media_ids` の上限超過で **422 を返し webhook 投稿ごと落ちる**（かつアップロード済みメディアが孤児として残る）。

**`Concurrent::AtomicFixnum` で枠を先に確保**し、判定と確保を不可分にした。⚠ **失敗したら枠を返す**（返さないと、取得に失敗しただけで後続の添付が枠切れで落ちるという退行になる）。

### 競合を実際に再現した

⚠ **対照テストを置いた。**旧実装と同じ「判定 → 時間のかかる処理 → push」を並べると**実際に上限を超える**。超えないなら新実装のテストは何も守っていないので、この対照が要る。

```ruby
def test_check_then_act_actually_overflows
  run_concurrently(MAX * 3) do
    next if MAX <= pushed.count
    sleep(UPLOAD_DELAY)          # ダウンロード + アップロードの所要
    pushed.push(:ok)
  end
  assert_operator(pushed.count, :>, MAX, '旧実装は超過するはず')
end
```

新実装側は同じ並行条件で `assert_equal(MAX, pushed.count)`。枠を返す挙動と、既に満杯なら 1 枚も取れないことも見ている。

## 2. 上限超過が黙って落ちる

握り潰す設計自体は「1 枚落ちても投稿は通す」意図として正しいが、**記録がどこにも残らなかった**。`logger.error` に残すようにした。

⚠ `attachment` ごと渡しているのは、`image_url` が**値そのもの**として `Logger#mask_url` に当たり `[FILTERED]` になるため（#4630 で確認済みの挙動）。文中に埋めるとマスクが効かない。

## ⚠ 送信側へレスポンスで伝える半分は #4649 へ送った

元 Issue の「レスポンスに `errors` を載せる」は**やっていない**。理由:

`Handler#summary` が `entries: recursive_to_a(result.concat(errors))` と ⚠ **`result` と `errors` を 1 本に混ぜている**ため、`Reporter` からは「どれが失敗か」を取り出せない。⚠ **`summary` は全ハンドラ共通で投稿結果通知のレンダリングにも使われる**ので、ここを分けるのは size:S の枠を超え、通知の見た目を変えうる。

⚠ また capsicum / tomato-shrieker 双方に関わる**契約変更**なので、決める前に利用側の希望を聞くほうがよいと判断した。**#4649 として起票済み**（方向の候補 3 つを併記）。

⚠ 元 Issue の「方向」は「レスポンスに載せる／**少なくとも** `logger` に残す」なので、本 PR はその floor を満たしている。

## 確認

- `bundle exec rake lint` — 487 files / no offenses、bundler-audit も緑
- `bundle exec rake test` — **1149 tests, 1605 assertions, 0 failures, 0 errors**（omission は 322 のまま）

Refs #4633