### PR TITLE
chore: ginseng-style を v1.1.4 に上げる

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'sidekiq-scheduler', '~>6.0.1'
 group :development do
   gem 'bundler-audit'
   # RuboCop 設定の正本。本体と minitest/performance/rake プラグインもこの gem が抱える。
-  gem 'ginseng-style', github: 'pooza/ginseng-style', tag: 'v1.1.0', require: false
+  gem 'ginseng-style', github: 'pooza/ginseng-style', tag: 'v1.1.4', require: false
   gem 'ostruct' # https://github.com/pooza/mulukhiya-toot-proxy/issues/4229
   gem 'rack-test'
   gem 'rails-erb-lint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,10 +73,10 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-style.git
-  revision: fd65197dbb08ef209e2c54734b4a80b72481da58
-  tag: v1.1.0
+  revision: 0c9ddb19d902d675504fc2d6ed258e590901073f
+  tag: v1.1.4
   specs:
-    ginseng-style (1.1.0)
+    ginseng-style (1.1.4)
       rubocop
       rubocop-minitest
       rubocop-performance


### PR DESCRIPTION
`ginseng-style` の参照を **`v1.1.4`** へ。

## v1.1.0 → v1.1.4 で変わったもの

| 版 | 中身 |
| --- | --- |
| `v1.1.1` | docs（cop 衝突・`assert_includes` の罠・利用側の上書きで gem の修正が届かない形） |
| `v1.1.2` | docs（バンプとタグを分ける。pooza/ginseng-style#59） |
| `v1.1.3` | ⚠ 配る既定の `TargetRubyVersion` が 3.3 → 3.4（pooza/ginseng-style#61） |
| `v1.1.4` | `required_ruby_version` を `>=3.3` に戻す（pooza/ginseng-style#63） |

⚠ **このリポジトリは `.rubocop.yml` で `TargetRubyVersion` を明示している**ので、配る既定が動いても実効は変わらない。

## ⚠ Gemfile.lock

**`bundle lock --update=ginseng-style --conservative`** で更新した。⚠⚠ **素で回すと rubocop 本体まで上がる**ので、差分が `ginseng-style` だけであることを確認済み。

## 確認したこと

- `rubocop` — **487 files, no offenses**