### PR TITLE
fix: 5.35.0 リリース前レビューの赤 2 件と自己起因の退行を是正する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'sidekiq-scheduler', '~>6.0.1'
 group :development do
   gem 'bundler-audit'
   # RuboCop 設定の正本。本体と minitest/performance/rake プラグインもこの gem が抱える。
-  gem 'ginseng-style', github: 'pooza/ginseng-style', tag: 'v1.1.0', require: false
+  gem 'ginseng-style', github: 'pooza/ginseng-style', tag: 'v1.1.4', require: false
   gem 'ostruct' # https://github.com/pooza/mulukhiya-toot-proxy/issues/4229
   gem 'rack-test'
   gem 'rails-erb-lint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,10 +73,10 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-style.git
-  revision: fd65197dbb08ef209e2c54734b4a80b72481da58
-  tag: v1.1.0
+  revision: 0c9ddb19d902d675504fc2d6ed258e590901073f
+  tag: v1.1.4
   specs:
-    ginseng-style (1.1.0)
+    ginseng-style (1.1.4)
       rubocop
       rubocop-minitest
       rubocop-performance

--- a/app/lib/mulukhiya/controller.rb
+++ b/app/lib/mulukhiya/controller.rb
@@ -7,26 +7,7 @@ module Mulukhiya
 
     attr_reader :sns, :reporter
 
-    # 投稿本文系フィールドを info ログに平文で残さない (#4394)。処理には素の
-    # @params を使うため、ログ用の複製だけ top-level の該当キーをマスクする。
-    SCRUBBED_LOG_PARAMS = [
-      'status', 'text', 'body', 'comment', 'spoiler_text', 'cw',
-      'q', 'title', 'artist', 'album', # word/suggest・nowplaying のユーザー入力 (#4394)
-      # ⚠ Slack legacy attachments の本文系 (#4630)。`SlackWebhookPayload#format_attachment`
-      #   が **すべて投稿本文へ組み立てる**ので、`text` だけ伏せても残りが平文で残る。
-      #   `title` は上の行で既に対象。`fields[].value` はキー名が `value`。
-      'pretext', 'author_name', 'value', 'footer',
-      'code', # OAuth 認可コード (spotify/auth・annict/auth)。短命だが資格情報なので伏せる
-      # ⚠ アクセストークン本体。`i` は Misskey がボディで渡す（MisskeyController#token
-      #   のフォールバック）。/logger/mask_query_params は URL のクエリにしか効かない
-      #   ので、ボディ側はここで落とす。両方揃って #4511 の掃討が完成する。
-      'i', 'access_token'
-    ].freeze
-
-    # `scrub_log_params` が潜る深さの上限 (#4630)。Block Kit の
-    # `blocks[].text.text` で 4、`attachments[].blocks[].text.text` で 6 なので、
-    # 実用形には十分な余裕がある。
-    MAX_LOG_SCRUB_DEPTH = 12
+    include LogScrubber
 
     # 上流へそのまま中継してよい受信ヘッダ (#4598)。
     #
@@ -145,8 +126,11 @@ module Mulukhiya
     # 同じ設計）。完全に無音だと「webhook が全滅している」ような事故の頻度・偏りを
     # 追えなくなる。
     #
-    # ⚠ **`status` を持たない例外は alert 側へ倒す。**素の `StandardError`
-    # （`NoMethodError` 等）はモロヘイヤ自身のバグなので、黙らせてはいけない。
+    # ⚠ **素の `StandardError` は alert 側へ倒れる。**ginseng-core の refine が
+    # `StandardError#status` に **500** を定義しているので、`NoMethodError` や
+    # `Sequel::DatabaseConnectionError` は 4xx に当たらず alert される。
+    # モロヘイヤ自身のバグを黙らせてはいけないので、これが正しい既定。
+    # `respond_to?` のガードは refine が外れたときの保険で、通常は到達しない。
     def report_error(error)
       client_error?(error) ? error.log : error.alert
     end
@@ -233,41 +217,6 @@ module Mulukhiya
     end
 
     private
-
-    # ⚠⚠ **入れ子まで走査する (#4630)。**従来は `scrubbed.key?(key)` の
-    # **トップレベル走査だけ**だったが、Slack 互換 webhook が実際に使う
-    # Block Kit の本文は `blocks` / `attachments` の入れ子の中にある。
-    #
-    #   {"blocks":[{"type":"section","text":{"text":"（本文）"}}]}
-    #
-    # ⚠ **同じ本文を `text` で送れば `[FILTERED]` になるのに、`blocks` で送ると
-    # 平文で syslog に残る**＝送り方で秘匿の効き方が変わっていた。#4394 が
-    # 「投稿本文系フィールドを平文で残さない」ために入れた対策の抜け。
-    # gem 側の `Logger#mask` はキー名で落とすが、`/logger/mask_fields` は
-    # 資格情報の名前だけなので本文系はそちらでも落ちない。
-    def scrub_log_params(params)
-      return scrub_log_value(params.deep_dup, 0)
-    end
-
-    # ⚠ **深さで打ち切る。**外部から渡る JSON なので、際限なく潜ると
-    # スタックを掘り尽くせる。打ち切りは**残す側ではなく落とす側**へ倒す
-    # （読めない深さのものを平文で通すより、伏せて出すほうが安全）。
-    def scrub_log_value(value, depth)
-      return '[FILTERED]' if depth > MAX_LOG_SCRUB_DEPTH
-      case value
-      when Hash
-        value.each_key do |key|
-          value[key] = if SCRUBBED_LOG_PARAMS.include?(key.to_s)
-            '[FILTERED]'
-          else
-            scrub_log_value(value[key], depth + 1)
-          end
-        end
-      when Array
-        value.map! {|v| scrub_log_value(v, depth + 1)}
-      end
-      return value
-    end
 
     def default_renderer_class
       return Ginseng::Web::JSONRenderer

--- a/app/lib/mulukhiya/controller/api_controller.rb
+++ b/app/lib/mulukhiya/controller/api_controller.rb
@@ -1141,31 +1141,6 @@ module Mulukhiya
     # する (#4346)。未認証・未連携等ユーザー入力起因の 403/404 は alert spam を避け log
     # のみ (#4265)。kind は :annict_record / :annict_review、id_label/id_value は
     # episode_id / work_id の文脈。
-    # 番組表編集 5 本の rescue (#4629)。
-    #
-    # ⚠⚠ **`AuthError` と `NotFoundError` が `else` へ落ちて alert していた。**
-    # 無効トークン・非管理者トークンで叩かれるたびに Sentry イベントと管理者への
-    # アラートメールが飛ぶ形で、#4594 でボットの 401 連打が実際にメール化したのと
-    # 同じ。非 livecure サーバーへの誤アクセスも 404 で毎回鳴っていた。
-    #
-    # ⚠ **同じ rescue が 5 本に複写されていたのが取りこぼしの原因**なので、
-    # クラスを足すのではなくヘルパへ寄せた。判定の本体は `report_error`
-    # （ステータスで見るので新しい 4xx を投げても漏れない）。
-    #
-    # 409 / 422 だけ構造化ログを残すのは、期待動作として頻度を追いたいため。
-    def handle_program_entry_error(error, key)
-      case error
-      when Ginseng::ConflictError
-        # 409 (auto_update? 有効時 / 重複キー / 書き込みロック競合 #4534)
-        Logger.new.info(program_entry: {event: 'conflict', key:, message: error.message})
-      when Ginseng::ValidateError
-        # 422 (days が不正 等)
-        Logger.new.info(program_entry: {event: 'invalid', key:, message: error.message})
-      else
-        report_error(error)
-      end
-    end
-
     def handle_annict_write_error(error, kind:, lock:, id_label:, id_value:)
       if error.is_a?(Ginseng::ConflictError)
         handle_annict_conflict(error, kind:, lock:, id_label:, id_value:)
@@ -1224,6 +1199,31 @@ module Mulukhiya
     rescue => e
       e.log(acct: acct.to_s)
       return nil
+    end
+
+    # 番組表編集 5 本の rescue (#4629)。
+    #
+    # ⚠⚠ **`AuthError` と `NotFoundError` が `else` へ落ちて alert していた。**
+    # 無効トークン・非管理者トークンで叩かれるたびに Sentry イベントと管理者への
+    # アラートメールが飛ぶ形で、#4594 でボットの 401 連打が実際にメール化したのと
+    # 同じ。非 livecure サーバーへの誤アクセスも 404 で毎回鳴っていた。
+    #
+    # ⚠ **同じ rescue が 5 本に複写されていたのが取りこぼしの原因**なので、
+    # クラスを足すのではなくヘルパへ寄せた。判定の本体は `report_error`
+    # （ステータスで見るので新しい 4xx を投げても漏れない）。
+    #
+    # 409 / 422 だけ構造化ログを残すのは、期待動作として頻度を追いたいため。
+    def handle_program_entry_error(error, key)
+      case error
+      when Ginseng::ConflictError
+        # 409 (auto_update? 有効時 / 重複キー / 書き込みロック競合 #4534)
+        Logger.new.info(program_entry: {event: 'conflict', key:, message: error.message})
+      when Ginseng::ValidateError
+        # 422 (days が不正 等)
+        Logger.new.info(program_entry: {event: 'invalid', key:, message: error.message})
+      else
+        report_error(error)
+      end
     end
 
     def fetch_json(http, url, accept)

--- a/app/lib/mulukhiya/controller/webhook_controller.rb
+++ b/app/lib/mulukhiya/controller/webhook_controller.rb
@@ -1,7 +1,7 @@
 module Mulukhiya
   class WebhookController < Controller
     post '/admin' do
-      raise Ginseng::ServiceUnavailableError, 'Info agent not configured' unless info_agent_service
+      raise ServiceUnavailableError, 'Info agent not configured' unless info_agent_service
       verify_admin_webhook!(@body)
       admin_payload = JSON.parse(@body)
       event = detect_admin_event(admin_payload)
@@ -11,7 +11,7 @@ module Mulukhiya
       return @renderer.to_s
     rescue => e
       # ⚠ **ここは `report_error` に寄せない (#4603)。**主な失敗は署名検証
-      # (`AuthError`) と設定不備 (`ServiceUnavailableError`) で、**署名不一致を
+      # (`AuthError`) と設定不備 (`ServiceUnavailableError`・503) で、**署名不一致を
       # 黙らせたくない**。4xx でも alert するのが正しい。
       e.alert
       @renderer.status = e.respond_to?(:status) ? e.status : 500
@@ -35,8 +35,10 @@ module Mulukhiya
       # (#4603)。同じ `verify_webhook!` を通す `get '/:digest'` は `e.log` なので、
       # **同じ例外が GET なら静か・POST なら alert** という非対称になっていた。
       report_error(e)
-      # ⚠ **`e.status` を直に呼ばない。**引き当ての失敗 (`Sequel::DatabaseConnectionError`
-      # 等) は `status` を持たないので、rescue 自身が `NoMethodError` で落ちる。
+      # ⚠ **`status` を持たない例外はここには来ない。**ginseng-core の refine が
+      # `StandardError#status` に 500 を定義しているため、引き当ての失敗
+      # (`Sequel::DatabaseConnectionError` 等) も 500 を返す＝ `report_error` の
+      # alert 側へ倒れる。`respond_to?` は refine が外れたときの保険。
       @renderer.status = e.respond_to?(:status) ? e.status : 500
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -72,9 +74,7 @@ module Mulukhiya
     private
 
     def verify_webhook!
-      unless controller_class.webhook?
-        raise Ginseng::ServiceUnavailableError, 'Webhook is not enabled'
-      end
+      raise ServiceUnavailableError, 'Webhook is not enabled' unless controller_class.webhook?
       return if webhook
       raise Ginseng::NotFoundError,
         "Webhook not found (digest: #{params[:digest][0, 12]}...)"

--- a/app/lib/mulukhiya/handler/webhook_image_handler.rb
+++ b/app/lib/mulukhiya/handler/webhook_image_handler.rb
@@ -1,5 +1,7 @@
 module Mulukhiya
   class WebhookImageHandler < Handler
+    include LogScrubber
+
     def disable?
       return true unless controller_class.webhook?
       return true unless sns.account&.webhook
@@ -20,30 +22,64 @@ module Mulukhiya
       queue = Queue.new
       (payload['attachments'] || []).each {|v| queue.push(v)}
       slots = create_slots(payload)
-      workers = [Parallel.processor_count, queue.size].min
-      Array.new(workers) {Thread.new {consume(queue, payload, slots)}}.each(&:join)
+      run_workers(queue, payload, slots)
+      drain(queue)
     end
 
     private
 
-    # ⚠⚠ **候補を「配る」のではなく「取りに行く」形にする (#4633・Codex P2)。**
-    # `Parallel.each` で候補を配ると、**枠切れで skip した候補は二度と戻らない**。
-    # 先に枠を取る実装と組み合わせると、先頭の候補が枠を全部押さえ→そのうち 1 本が
-    # 失敗して枠を返しても、**skip 済みの後続を拾う者がいない**＝空いた枠が
-    # 使われないまま、有効な添付が黙って落ちる（候補 5・枠 4・先頭で 1 失敗なら 3 枚）。
+    # ⚠⚠ **`Parallel.each` をやめた代償を自分で払う。**あちらが面倒を見ていた
+    # 2 つが、素の `Thread.new` では落ちる:
     #
-    # 取りに行く形なら、**失敗して枠を返したワーカーがそのまま次の候補に使う**。
+    # 1. **HTTP 計装**（`HandlerProfile`）はスレッドローカルで、`ParallelProbe` が
+    #    `Parallel` にしか prepend されていない。引き継がないと webhook 添付の
+    #    ダウンロード + アップロードが丸ごと `http_count: 0` になる
+    # 2. **ワーカーの後始末**。`Parallel.each(in_threads:)` は `ensure` で
+    #    `threads.each(&:kill)` していた。無いと、join が例外で打ち切られたときに
+    #    走り続けたスレッドが**応答を組み立てた後**に `push` して孤児メディアを作る
+    def run_workers(queue, payload, slots)
+      counter = Thread.current[HandlerProfile::HTTP_KEY]
+      workers = [Parallel.processor_count, queue.size].min
+      threads = Array.new(workers) do
+        Thread.new do
+          Thread.current[HandlerProfile::HTTP_KEY] = counter if counter
+          consume(queue, payload, slots)
+        end
+      end
+      threads.each(&:join)
+    ensure
+      threads&.each(&:kill)
+    end
+
+    # ⚠⚠ **枠を取ってから候補を取り出す。**逆順（取り出してから枠を取る）だと、
+    # 候補を握ったまま枠が取れずに降りる窓ができ、その間に別のワーカーが失敗して
+    # 枠を返し終了すると、**その候補は誰にも拾われず黙って消える**。
+    # 枠を先に取れば、失敗したワーカーは**自分が返した枠を自分で取り直す**ので
+    # 候補の受け渡し自体が無くなる。
+    #
+    # ⚠ 候補を「配る」形（`Parallel.each`）に戻さないこと。枠切れで skip した候補が
+    # 二度と戻らず、空いた枠が使われないまま有効な添付が落ちる (#4633・Codex P2)。
     def consume(queue, payload, slots)
       loop do
-        break unless attachment = pop_attachment(queue)
-        next unless uri = parse_image_uri(attachment)
-        unless reserve_slot(slots)
-          # ⚠ **取り出したまま降りない。**別のワーカーが失敗して枠を返したときに
-          # 拾える候補が消える。戻してから降りる。
-          queue.push(attachment)
+        break unless reserve_slot(slots)
+        unless attachment = pop_attachment(queue)
+          slots.increment
           break
         end
+        unless uri = parse_image_uri(attachment)
+          slots.increment
+          next
+        end
         upload_attachment(payload, uri, slots, attachment)
+      end
+    end
+
+    # ⚠ **枠切れで残った候補も「落ちた」として残す (#4633)。**従来は完全に無音で、
+    # 6 枚送って 4 枚しか付かなくても送信側にも運用者にも何も出なかった。
+    # 取得失敗と上限超過だけ記録して枠切れを黙らせるのは、この Issue の趣旨に反する。
+    def drain(queue)
+      while attachment = pop_attachment(queue)
+        record_drop('SlotExhausted', 'max media attachments exceeded', attachment)
       end
     end
 
@@ -54,7 +90,7 @@ module Mulukhiya
     end
 
     # ⚠ **`image_url` を持たない添付は正常。**Slack legacy attachments は
-    # 本文だけのものが普通にあるので、落ちた扱いにしない（枠も取らない）。
+    # 本文だけのものが普通にあるので、落ちた扱いにしない。
     def parse_image_uri(attachment)
       return Ginseng::URI.parse(attachment['image_url'])
     rescue => e
@@ -65,11 +101,21 @@ module Mulukhiya
     # ⚠⚠ **握り潰しても黙って消さない (#4633)。**「1 枚落ちても投稿は通す」設計
     # 自体は正しいが、上限超過 (`/media/download/max_bytes`) も取得失敗も
     # **200 と作成済み投稿 ID が返るだけ**で、送信側は成功と区別できなかった。
-    # ⚠ `attachment` ごと渡すのは、`image_url` が値そのものとして
-    # `Logger#mask_url` に当たり `[FILTERED]` になるため (#4630)。
     def drop_attachment(error, attachment)
-      logger.error(error: 'webhook attachment dropped', reason: error.class.to_s, attachment:)
-      errors.push(class: error.class.to_s, message: error.message, attachment:)
+      record_drop(error.class.to_s, error.message, attachment)
+    end
+
+    # ⚠⚠ **添付を丸ごと出さない (#4630)。**Slack legacy attachments の
+    # `title` / `text` / `pretext` / `footer` / `author_name` / `fields[].value` は
+    # **すべて投稿本文になる**ので、素で渡すと同じリリースで塞いだ穴を開け直す。
+    # ⚠ **gem 側の `mask_url` は当てにならない。**あれは URL のクエリパラメータの
+    # 値しか伏せないので、`image_url` 全体も本文も素通しする。
+    # ⚠ `errors` 側も同じものを通す。`Reporter` が `summary` 経由で `logger.info`
+    # へ流すため、片方だけ伏せても意味がない。
+    def record_drop(reason, message, attachment)
+      scrubbed = scrub_log_params(attachment)
+      logger.error(error: 'webhook attachment dropped', reason:, attachment: scrubbed)
+      errors.push(class: reason, message:, attachment: scrubbed)
     end
 
     def create_slots(payload)

--- a/app/lib/mulukhiya/log_scrubber.rb
+++ b/app/lib/mulukhiya/log_scrubber.rb
@@ -1,0 +1,66 @@
+module Mulukhiya
+  # 投稿本文系フィールドと資格情報をログに平文で残さない (#4394 / #4630)。
+  #
+  # ⚠⚠ **Controller だけの関心事ではない。**5.35.0 のリリース前レビューで、
+  # `WebhookImageHandler#drop_attachment` が落とした添付を丸ごと `logger.error`
+  # へ渡し、**同じリリースで塞いだはずの Slack legacy attachments の本文
+  # （`title` / `text` / `pretext` / `footer` / `author_name` / `fields[].value`）を
+  # 平文で出し直していた**ことが判明したため、Controller から切り出して
+  # 共有できるようにした。
+  #
+  # ⚠ **gem 側の `Ginseng::Logger#mask` では落ちない。**あちらが見るのは
+  # `/logger/mask_fields`（`auth` / `endpoint` / `password` / `publickey` /
+  # `secret` / `token`）だけで、本文系は 1 つも入っていない。`mask_url` も
+  # **URL のクエリパラメータの値**しか伏せないので、URL 全体や本文には効かない。
+  module LogScrubber
+    SCRUBBED_LOG_PARAMS = [
+      'status', 'text', 'body', 'comment', 'spoiler_text', 'cw',
+      'q', 'title', 'artist', 'album', # word/suggest・nowplaying のユーザー入力 (#4394)
+      # ⚠ Slack legacy attachments の本文系 (#4630)。`SlackWebhookPayload#format_attachment`
+      #   が **すべて投稿本文へ組み立てる**ので、`text` だけ伏せても残りが平文で残る。
+      #   `title` は上の行で既に対象。`fields[].value` はキー名が `value`。
+      'pretext', 'author_name', 'value', 'footer',
+      'code', # OAuth 認可コード (spotify/auth・annict/auth)。短命だが資格情報なので伏せる
+      # ⚠ アクセストークン本体。`i` は Misskey がボディで渡す（MisskeyController#token
+      #   のフォールバック）。/logger/mask_query_params は URL のクエリにしか効かない
+      #   ので、ボディ側はここで落とす。両方揃って #4511 の掃討が完成する。
+      'i', 'access_token'
+    ].freeze
+
+    # `scrub_log_params` が潜る深さの上限 (#4630)。Block Kit の
+    # `blocks[].text.text` で 4、`attachments[].blocks[].text.text` で 6 なので、
+    # 実用形には十分な余裕がある。
+    MAX_LOG_SCRUB_DEPTH = 12
+
+    # ⚠⚠ **入れ子まで走査する (#4630)。**Slack 互換 webhook が実際に使う
+    # Block Kit の本文は `blocks` / `attachments` の入れ子の中にある。
+    #
+    #   {"blocks":[{"type":"section","text":{"text":"（本文）"}}]}
+    #
+    # ⚠ **同じ本文を `text` で送れば `[FILTERED]` になるのに、`blocks` で送ると
+    # 平文で syslog に残る**＝送り方で秘匿の効き方が変わっていた。
+    def scrub_log_params(params)
+      return scrub_log_value(params.deep_dup, 0)
+    end
+
+    # ⚠ **深さで打ち切る。**外部から渡る JSON なので、際限なく潜ると
+    # スタックを掘り尽くせる。打ち切りは**残す側ではなく落とす側**へ倒す
+    # （読めない深さのものを平文で通すより、伏せて出すほうが安全）。
+    def scrub_log_value(value, depth)
+      return '[FILTERED]' if depth > MAX_LOG_SCRUB_DEPTH
+      case value
+      when Hash
+        value.each_key do |key|
+          value[key] = if SCRUBBED_LOG_PARAMS.include?(key.to_s)
+            '[FILTERED]'
+          else
+            scrub_log_value(value[key], depth + 1)
+          end
+        end
+      when Array
+        value.map! {|v| scrub_log_value(v, depth + 1)}
+      end
+      return value
+    end
+  end
+end

--- a/app/lib/mulukhiya/service_unavailable_error.rb
+++ b/app/lib/mulukhiya/service_unavailable_error.rb
@@ -1,0 +1,28 @@
+module Mulukhiya
+  # 機能が無効・未設定で要求に応えられないことを表すエラー (503)。
+  #
+  # ⚠⚠ **`Ginseng::ServiceUnavailableError` は存在しない。**v5.34.0 以前から
+  # `WebhookController` が 2 箇所でその名前を `raise` しており、**到達すると
+  # `NameError` になっていた**（5.35.0 のリリース前レビューで検出）。
+  #
+  # `StandardError#status` は ginseng-core の refine で 500 を返すため、
+  # `NameError` は **500 ＋「uninitialized constant」をクライアントへ返し、
+  # かつ alert 側へ倒れる**。つまり:
+  #
+  # - `POST /mulukhiya/webhook/admin` は**署名検証より前**に此処を通るので、
+  #   `agent.info.token` 未設定のサーバーでは**誰でも管理者アラートを撃てた**
+  # - `features.webhook: false` のサーバーでは、`verify_webhook!` が同じ形になる
+  #
+  # ⚠ **`broadcastable?` を false にする。**設定が無いのは運用者が知っていれば
+  # 足りる話で、外部から叩かれるたびに管理者へメール／Slack を飛ばす種類の
+  # 事象ではない（#4594 と同じ判断）。
+  class ServiceUnavailableError < Ginseng::Error
+    def status
+      return 503
+    end
+
+    def broadcastable?
+      return false
+    end
+  end
+end

--- a/test/unit/controller/webhook_service_unavailable.rb
+++ b/test/unit/controller/webhook_service_unavailable.rb
@@ -1,0 +1,37 @@
+module Mulukhiya
+  # 機能が無効・未設定のときに 503 を返すこと (5.35.0 リリース前レビューの赤)。
+  #
+  # ⚠⚠ **`Ginseng::ServiceUnavailableError` は存在しない定数だった。**
+  # `WebhookController` が 2 箇所でそれを `raise` しており、到達すると
+  # `NameError` になる。`StandardError#status` は refine で 500 を返すので、
+  # クライアントには **500 +「uninitialized constant」**が返り、さらに
+  # alert 側へ倒れて**未認証の第三者が管理者アラートを撃てる**状態だった。
+  class WebhookServiceUnavailableTest < TestCase
+    def test_constant_exists
+      assert_kind_of(Class, ServiceUnavailableError)
+      assert_operator(ServiceUnavailableError, :<, Ginseng::Error)
+    end
+
+    def test_status_is_service_unavailable
+      assert_equal(503, ServiceUnavailableError.new('x').status)
+    end
+
+    # ⚠ 設定が無いのは運用者が知っていれば足りる話で、外部から叩かれるたびに
+    # 管理者へメール / Slack を飛ばす種類の事象ではない（#4594 と同じ判断）。
+    def test_is_not_broadcastable
+      assert_false(ServiceUnavailableError.new('x').broadcastable?)
+    end
+
+    # ⚠ **旧コードは NameError になっていた。**同じ名前で raise していないことを見る。
+    def test_ginseng_namespace_is_not_used
+      source = File.read(File.join(Environment.dir, 'app/lib/mulukhiya/controller/webhook_controller.rb'))
+
+      assert_not_match(/raise Ginseng::ServiceUnavailableError/, source)
+    end
+
+    # 4xx ではないので alert 抑止には乗らない（運用者には見える）。
+    def test_is_not_treated_as_client_error
+      assert_false(MisskeyController.new!.client_error?(ServiceUnavailableError.new('x')))
+    end
+  end
+end

--- a/test/unit/handler/webhook_attachment_slots.rb
+++ b/test/unit/handler/webhook_attachment_slots.rb
@@ -96,6 +96,42 @@ module Mulukhiya
       assert_equal(0, handler.dropped.count)
     end
 
+    # ⚠⚠ **枠切れで落ちた添付も記録する (#4630 / #4633)。**従来は完全に無音で、
+    # 6 枚送って 4 枚しか付かなくても送信側にも運用者にも何も出なかった。
+    def test_slot_exhausted_candidates_are_recorded
+      handler = build_handler
+      payload = {'media' => Concurrent::Array.new}
+      queue = Queue.new
+      6.times {|i| queue.push({'image_url' => "https://example.com/#{i}.png"})}
+
+      handler.send(:run_workers, queue, payload, Concurrent::AtomicFixnum.new(4))
+      handler.send(:drain, queue)
+
+      assert_equal(4, payload['media'].count)
+      assert_equal(2, handler.dropped.count)
+      assert_equal(['SlotExhausted'], handler.dropped.map {|v| v[:reason]}.uniq)
+    end
+
+    # ⚠⚠ **落とした添付の本文をログに平文で残さない (#4630)。**
+    # `title` / `text` / `pretext` / `footer` / `author_name` / `fields[].value` は
+    # すべて投稿本文になる。⚠ gem 側の `mask_url` では落ちない。
+    def test_dropped_attachment_body_is_scrubbed
+      handler = build_handler
+      queue = Queue.new
+      queue.push({
+        'image_url' => 'https://example.com/x.png',
+        'title' => '見出し', 'text' => '本文', 'pretext' => '前置き',
+        'footer' => '脚注', 'author_name' => '著者',
+        'fields' => [{'title' => '項目', 'value' => '値'}]
+      })
+
+      handler.send(:drain, queue)
+      dumped = handler.dropped.first[:attachment].to_json
+
+      assert_not_match(/見出し|本文|前置き|脚注|著者|項目|値/, dumped)
+      assert_match(%r{https://example\.com/x\.png}, dumped)
+    end
+
     private
 
     # `consume` を実インスタンスで動かすためのダブル。
@@ -124,8 +160,8 @@ module Mulukhiya
         return uri.to_s
       end
 
-      def drop_attachment(_error, attachment)
-        @dropped.push(attachment)
+      def record_drop(reason, _message, attachment)
+        @dropped.push(reason:, attachment: scrub_log_params(attachment))
       end
     end
 


### PR DESCRIPTION
5 観点並列レビュー（セキュリティ / API 契約 / 並行性 / 観測性 / スタイル）の結果。**赤は 2 件**で、いずれも実機で再現を確認した。

## 赤 1: `Ginseng::ServiceUnavailableError` は存在しない定数

```
$ ruby -r mulukhiya -e 'p Ginseng::ServiceUnavailableError'
NameError: uninitialized constant Ginseng::ServiceUnavailableError
```

`WebhookController` が 2 箇所でそれを `raise` していた。⚠ `StandardError#status` は ginseng-core の refine で **500** を返すので、クライアントには **500 +「uninitialized constant」**が返り、さらに alert 側へ倒れる。

- ⚠⚠ **`POST /mulukhiya/webhook/admin` は署名検証より前**に此処を通る。`agent.info.token` 未設定のサーバーでは**誰でも管理者アラート（Sentry ＋ mail ＋ Slack ＋ LINE）を撃てた**
- `features.webhook: false` のサーバーでは `verify_webhook!` が同じ形。⚠ **GET は本リリースで `e.log` → `report_error` になったため、ここで初めて alert 化していた**（自己起因の退行）

`Mulukhiya::ServiceUnavailableError`（503 / `broadcastable?` = false）を新設。⚠ 設定が無いのは運用者が知っていれば足りる話で、外部から叩かれるたびに管理者へメールを飛ばす事象ではない（#4594 と同じ判断）。

## 赤 2: `drop_attachment` が #4630 で塞いだ穴を同じリリースで開け直していた

落とした添付を丸ごと `logger.error` へ渡していた。実測:

```json
{"error":"webhook attachment dropped","attachment":{
  "title":"見出し","text":"本文","pretext":"前置き","footer":"脚注",
  "author_name":"著者","fields":[{"title":"項目","value":"値"}],
  "image_url":"https://ex.com/a.png?access_token=[FILTERED]"}}
```

⚠ **`SCRUBBED_LOG_PARAMS` へ足したフィールドそのものが平文。**⚠ **`mask_url` は当てにならない** — あれは URL のクエリパラメータの**値**しか伏せないので、URL 全体も本文も素通しする（「`image_url` が値そのものとして `[FILTERED]` になる」という私のコメントは**誤り**だったので訂正した）。

スクラブを **`LogScrubber`** として切り出し、`Controller` と `WebhookImageHandler` の両方から使う。⚠ **`errors` 側も同じものを通す** — `Reporter` が `summary` 経由で `logger.info` へ流すので、片方だけ伏せても意味がない（こちらは v5.34.0 からの既存漏れ）。

## 自己起因の退行 4 件（このリリースで私が入れたもの）

| 退行 | 内容 |
| --- | --- |
| **HTTP 計装が切れた** | `ParallelProbe` は `Parallel` にしか prepend されていないので、素の `Thread.new` ではスレッドローカルの計装が引き継がれず、webhook 添付の HTTP が丸ごと `http_count: 0` になっていた |
| **ワーカーの後始末が消えた** | `Parallel.each(in_threads:)` は `ensure threads.each(&:kill)` を持っていた。無いと join が例外で打ち切られたとき、走り続けたスレッドが**応答を組み立てた後**に push して孤児メディアを作る |
| **候補の受け渡し窓** | pop→reserve の順だと、候補を握ったまま枠が取れずに降りる窓ができ、その間に別ワーカーが枠を返して終了すると候補が消える。**reserve→pop に入れ替え**て受け渡し自体を無くした |
| **枠切れが無音** | 6 枚送って 4 枚しか付かなくても `errors` にも syslog にも何も出なかった。`SlotExhausted` として記録する |

## 誤ったコメントの訂正

⚠ **「`status` を持たない例外は rescue 自身が `NoMethodError` で落ちる」は誤り。** ginseng-core の refine が `StandardError#status` に 500 を定義している（実測: `Sequel::DatabaseConnectionError#status` → 500、owner は `StandardError`）。3 つのレビュー観点がこれを根拠に「5 箇所を直せ」と指摘してきたが、**指摘のほうが誤り**なので直していない。代わりにコメントを事実に合わせた。

## 確認

- `bundle exec rake lint` — 490 files / no offenses、bundler-audit も緑
- `bundle exec rake test` — **1165 tests / 0 failures / 0 errors**
- **harness 実走（リリースゲート・省略不可）**:

| 系 | controller | 結果 |
| --- | --- | --- |
| Mastodon v4.7.0 | `mastodon` / `:3000` | 1237 tests / **0 failures / 0 errors** / 159 omissions |
| Misskey 2026.7.0 | `misskey` / `:3001` | 1240 tests / **0 failures / 0 errors** / 146 omissions |

黄・緑の指摘は別途 Issue に起票します。