### PR TITLE
obs: プールの観測を SELECT 1 より先に取る (#4618 の P2)

### DIFF
--- a/app/lib/mulukhiya/dbms/postgres.rb
+++ b/app/lib/mulukhiya/dbms/postgres.rb
@@ -42,12 +42,20 @@ module Mulukhiya
       return Ginseng::Postgres::DSN.parse(config['/postgres/dsn']) rescue nil
     end
 
+    # ⚠⚠ **プールの観測は `SELECT 1` より先に取る (#4618)。**
+    # `SELECT 1` 自身がプールから接続を借りるので、詰まっているときは
+    # **health のリクエストが待ち行列に並ぶ**。並び終えてから読むと
+    # **自分の前の待ちが捌けた後の値**になり、有限のスパイクを丸ごと取りこぼす。
+    # 「詰まりに近づいている」を見るための指標なのに、**近づいている瞬間だけ見えない**
+    # という逆立ちが起きていた。
     def self.health
       return {status: 'OK', skipped: true} unless config?
+
+      snapshot = pool
       instance.connection.fetch('SELECT 1 AS ok').first
-      return {status: 'OK'}.merge(pool)
+      return {status: 'OK'}.merge(snapshot)
     rescue Sequel::PoolTimeout => e
-      return {error: e.message, status: 'WARN', reason: 'pool_exhausted'}.merge(pool)
+      return {error: e.message, status: 'WARN', reason: 'pool_exhausted'}.merge(snapshot || pool)
     rescue => e
       return {error: e.message, status: 'NG'}
     end

--- a/test/unit/dbms/postgres.rb
+++ b/test/unit/dbms/postgres.rb
@@ -15,6 +15,25 @@ module Mulukhiya
       undef_method :num_waiting
     end
 
+    # `SELECT 1` を待っている間に待ち行列が捌けるプールを模す (#4618)。
+    # ⚠ **これが起きると、観測を後から取る実装は「詰まっていない」と報告する。**
+    class DrainingPool < FakePool
+      def initialize(...)
+        super
+        @drained = false
+      end
+
+      def drain
+        @drained = true
+      end
+
+      def num_waiting
+        return 0 if @drained
+
+        return super
+      end
+    end
+
     class FakeConnection
       attr_reader :disconnected
       attr_writer :pool
@@ -33,6 +52,7 @@ module Mulukhiya
       end
 
       def fetch(_sql)
+        @pool.drain if @pool.respond_to?(:drain)
         return [{ok: 1}]
       end
     end
@@ -107,6 +127,18 @@ module Mulukhiya
       stub_instance(nil)
 
       assert_empty(Postgres.pool)
+    end
+
+    # ⚠ **回帰テスト (#4618)。**観測を `SELECT 1` の後に取る実装だと、
+    # health 自身が待ち行列に並んでいる間に前の待ちが捌けて `waiting: 0` に化ける。
+    # **有限のスパイクだけが見えない**ので、Gate 2 の rollback 信号として使えない。
+    def test_health_reports_pool_state_before_the_probe_query
+      config['/postgres/dsn'] = 'postgres://example.invalid/dummy'
+      stub_instance(DrainingPool.new(max: 10, size: 10, waiting: 5))
+      health = Postgres.health
+
+      assert_equal('OK', health[:status])
+      assert_equal(5, health[:pool][:waiting])
     end
 
     def test_health_includes_pool


### PR DESCRIPTION
#4618 の **P2 のみ**。⚠ P1（pgbouncer と Sidekiq 側の逼迫が見えない）は独立した別作業として Issue に残す。

## 何が起きていたか

`Postgres.health` は `SELECT 1` を投げてから `pool` を読んでいた。
⚠ **`SELECT 1` 自身がプールから接続を借りる**ので、詰まっているときは
**health のリクエストが待ち行列に並ぶ**。並び終えてから `num_waiting` を読むと
**自分の前の待ちが捌けた後**の値になり、**有限のスパイクを丸ごと取りこぼす**。

「詰まりに近づいている」を見るための指標なのに、**近づいている瞬間だけ見えない**という逆立ち。

## なぜいま直すか

**#4639（Gate 2 の overlay flip）の rollback 信号がこの `waiting`。**
flip する前に、信号のほうを信用できる状態にしておく。

## 変更

`SELECT 1` の前にスナップショットを取り、成功時も `Sequel::PoolTimeout` 時もそれを返す。

## 回帰テスト

「`SELECT 1` を待っている間に待ち行列が捌けるプール」を模した `DrainingPool` を足した。

- **修正前の実装では落ちる**ことを確認済み（`<5> expected but was <0>`）
- 修正後は `test/unit/dbms/postgres.rb` の 11 件すべて緑
- `rubocop` 緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)