### PR TITLE
security: webhook の digest をログへ平文で残さない (#4655)

### DIFF
--- a/app/lib/mulukhiya/controller.rb
+++ b/app/lib/mulukhiya/controller.rb
@@ -31,7 +31,9 @@ module Mulukhiya
       end
       logger.info(request: {
         method: request.request_method,
-        path: request.path,
+        # ⚠ **パスも秘匿の対象 (#4655)。**webhook の digest はそれ 1 つで
+        # 投稿権限が通るので、パスをそのまま出すと使うたびに鍵がログに残る。
+        path: scrub_log_path(request.path),
         params: scrub_log_params(@params),
         remote: request.ip,
       })
@@ -51,6 +53,9 @@ module Mulukhiya
     not_found do
       @renderer = default_renderer_class.new
       @renderer.status = 404
+      # ⚠ **ここは `scrub_log_path` を通さない (#4655)。**これはログではなく
+      # **要求した本人へ返すボディ**で、パスは相手が送ってきた値そのもの。
+      # 丸めても秘匿にはならず、404 のボディ（api.md の契約）が変わるだけ。
       @renderer.message = Ginseng::NotFoundError.new("Resource #{request.path} not found.").to_h
       return @renderer.to_s
     end
@@ -64,7 +69,7 @@ module Mulukhiya
       else
         @renderer.status = 500
         @renderer.message = {error: 'Internal Server Error'}
-        e.log(path: request.path)
+        e.log(path: scrub_log_path(request.path))
         Sentry.capture_exception(e) rescue nil if Sentry.initialized?
       end
       return @renderer.to_s
@@ -109,7 +114,7 @@ module Mulukhiya
         event: 'token_mismatch',
         expected: expected.first(8),
         actual: sns.token&.first(8),
-        path: request.path,
+        path: scrub_log_path(request.path),
       )
       raise Ginseng::AuthError, 'Token integrity check failed'
     end
@@ -212,7 +217,7 @@ module Mulukhiya
         event: 'account_mismatch_detected',
         expected_account: sns.account&.id,
         posted_as: posted_id,
-        path: request.path,
+        path: scrub_log_path(request.path),
       )
     end
 

--- a/app/lib/mulukhiya/log_scrubber.rb
+++ b/app/lib/mulukhiya/log_scrubber.rb
@@ -27,6 +27,26 @@ module Mulukhiya
       'i', 'access_token'
     ].freeze
 
+    # ⚠⚠ **webhook の digest は資格情報そのもの (#4655)。**
+    # `POST /mulukhiya/webhook/<digest>` は **digest だけで投稿権限が通る**
+    # （`verify_webhook!` 以外に認証が無い）。⚠ **既存の掃討はどれも当たらない** —
+    # `Ginseng::Logger#mask_url` は `\A<scheme>://` に一致する**値**にしか効かず、
+    # `SCRUBBED_LOG_PARAMS` は**パラメータのキー**しか見ず、nginx 側のパターン
+    # （#4511 の `access_token=` / `"i":"` / `[?&]i=`）にも当たらない。
+    # **webhook を 1 回使うたびに完全な鍵が syslog に残っていた。**
+    #
+    # ⚠⚠ **マウント位置ではなく digest の形で判定する。**webhook のパスは
+    # `config/route.yaml` で変えられるし、テストでは各 Controller が root に載る。
+    # **接頭辞で切ると、設定を変えた瞬間に黙って秘匿が外れる**（fail-open）。
+    # `Webhook.create_digest` は `String#sha256`＝ **64 桁の 16 進**なので、
+    # 経路上でこの形を持つのは digest だけ。
+    WEBHOOK_DIGEST_PATTERN = /\A[0-9a-f]{64}\z/i
+
+    # digest として残す先頭の文字数。⚠ `verify_webhook!` のエラーメッセージ
+    # （`"Webhook not found (digest: #{params[:digest][0, 12]}...)"`）と揃える。
+    # **同じ digest がログとエラーで別の形に見えると突き合わせられない。**
+    LOG_DIGEST_PREFIX_LENGTH = 12
+
     # `scrub_log_params` が潜る深さの上限 (#4630)。Block Kit の
     # `blocks[].text.text` で 4、`attachments[].blocks[].text.text` で 6 なので、
     # 実用形には十分な余裕がある。
@@ -41,6 +61,23 @@ module Mulukhiya
     # 平文で syslog に残る**＝送り方で秘匿の効き方が変わっていた。
     def scrub_log_params(params)
       return scrub_log_value(params.deep_dup, 0)
+    end
+
+    # パスに埋まった webhook の digest を丸める (#4655)。
+    #
+    # ⚠ **パスの構造は仮定しない。**セグメントに割って、digest の形をしたものだけを
+    # 丸める。前後にどんなセグメントが付いていても効く。
+    def scrub_log_path(path)
+      return path unless path.is_a?(String)
+      return path.split('/', -1).map {|segment| scrub_log_digest(segment)}.join('/')
+    end
+
+    # digest 単体を丸める。⚠ **digest でない値は 1 バイトも変えない**
+    # （ログが役に立たなくなる）。
+    def scrub_log_digest(value)
+      return value unless value.is_a?(String)
+      return value unless value.match?(WEBHOOK_DIGEST_PATTERN)
+      return "#{value[0, LOG_DIGEST_PREFIX_LENGTH]}..."
     end
 
     # ⚠ **深さで打ち切る。**外部から渡る JSON なので、際限なく潜ると

--- a/app/lib/mulukhiya/webhook.rb
+++ b/app/lib/mulukhiya/webhook.rb
@@ -2,6 +2,8 @@ module Mulukhiya
   class Webhook
     include Package
     include SNSMethods
+    # ⚠ クラスメソッド (`self.create`) から digest を丸めるので `extend` (#4655)。
+    extend LogScrubber
 
     attr_reader :sns, :reporter
 
@@ -129,7 +131,9 @@ module Mulukhiya
     def self.create(key)
       return create!(key)
     rescue => e
-      e.log(key: key.to_s)
+      # ⚠ **key は digest（＝資格情報）で来うる (#4655)。**そのまま出すと
+      # 引き当てが失敗するたびに完全な鍵が syslog に残る。
+      e.log(key: scrub_log_digest(key.to_s))
       return nil
     end
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -2575,6 +2575,19 @@ Controller 層での注意:
 
 **Ruby 構文の落とし穴**: `return X rescue Y` を `def ... rescue ... end` のメソッド末尾 rescue と併用すると、`return` が発火せず次行にフォールスルーする（`return X; rescue Y` と解釈される）。必ず `plain = X rescue Y; return plain` か `return (X rescue Y)` と書くこと。5.19.1 の初版修正で実際に踏んだ罠で、[LineAlertHandler#token](app/lib/mulukhiya/handler/line_alert_handler.rb#L17-L19) のように外側 rescue がない関数では同じ書き方が動くため気づきにくい。
 
+### Webhook digest は資格情報（#4655）
+
+`POST /mulukhiya/webhook/<digest>` は **digest だけで投稿権限が通る**（`verify_webhook!` 以外に認証が無い）。
+⚠⚠ **したがってパスをログへ出すと、webhook を 1 回使うたびに完全な鍵が syslog に残る。**
+
+- 既存の掃討はどれも当たらない — `Ginseng::Logger#mask_url` は `\A<scheme>://` に一致する**値**にしか
+  効かず、`SCRUBBED_LOG_PARAMS` は**パラメータのキー**しか見ず、nginx 側のパターン（#4511 の
+  `access_token=` / `"i":"` / `[?&]i=`）にも当たらない
+- 対策は `LogScrubber#scrub_log_path`。⚠ **マウント位置ではなく digest の形（64 桁の 16 進）で判定する。**
+  webhook のパスは `config/route.yaml` で変えられるので、**接頭辞で切ると設定変更で黙って秘匿が外れる**
+- ⚠ **`not_found` のボディだけは丸めない。**あれはログではなく**要求した本人へ返す値**で、
+  丸めても秘匿にならず 404 のボディ（api.md の契約）が変わるだけ
+
 ### Webhook digest の安定性
 
 `Webhook.create_digest` は Webhook URL の一部となる digest を生成する。入力は SNS の URI、OAuth トークン、`/crypt/salt`（フォールバック: `/crypt/password`）の3要素。

--- a/test/unit/controller/log_scrub_path.rb
+++ b/test/unit/controller/log_scrub_path.rb
@@ -1,0 +1,88 @@
+module Mulukhiya
+  # webhook の digest をログへ平文で残さないこと (#4655)。
+  #
+  # ⚠⚠ **digest は資格情報そのもの。**`POST /mulukhiya/webhook/<digest>` は
+  # digest だけで投稿権限が通る（`verify_webhook!` 以外に認証が無い）。
+  # ⚠ **既存の掃討はどれも当たらない** — `mask_url` は `\A<scheme>://` に一致する
+  # 値にしか効かず、`SCRUBBED_LOG_PARAMS` はパラメータのキーしか見ず、
+  # nginx 側のパターン（#4511）にも当たらない。
+  class LogScrubPathTest < TestCase
+    # `Webhook.create_digest` は `String#sha256` ＝ 64 桁の 16 進。
+    DIGEST = ('a1b2c3d4' * 8).freeze
+    DIGEST_PATTERN = /#{DIGEST}/o
+
+    def setup
+      @controller = MisskeyController.new!
+    end
+
+    def scrub(path)
+      return @controller.send(:scrub_log_path, path)
+    end
+
+    # 眼目。webhook のパスから digest が消えること。
+    def test_scrubs_webhook_digest
+      scrubbed = scrub("/mulukhiya/webhook/#{DIGEST}")
+
+      assert_not_match(DIGEST_PATTERN, scrubbed)
+      assert_equal('/mulukhiya/webhook/a1b2c3d4a1b2...', scrubbed)
+    end
+
+    # ⚠ **突き合わせられる長さは残す。**`verify_webhook!` のエラーメッセージが
+    # 先頭 12 文字なので、ログとエラーで同じ形に見えること。
+    def test_prefix_length_matches_verify_webhook_message
+      assert_equal(12, LogScrubber::LOG_DIGEST_PREFIX_LENGTH)
+      assert_match(
+        /params\[:digest\]\[0, 12\]/,
+        File.read(File.join(Environment.dir, 'app/lib/mulukhiya/controller/webhook_controller.rb')),
+      )
+    end
+
+    # ⚠⚠ **マウント位置を仮定しない。**`config/route.yaml` で変えられるし、
+    # 前後にセグメントが付いても効くこと。
+    def test_scrubs_regardless_of_mount_point
+      assert_not_match(DIGEST_PATTERN, scrub("/#{DIGEST}"))
+      assert_not_match(DIGEST_PATTERN, scrub("/some/where/#{DIGEST}/extra"))
+    end
+
+    # digest でないパスは 1 バイトも変えない（ログが役に立たなくなる）。
+    def test_keeps_other_paths
+      ['/mulukhiya/api/v1/statuses/123', '/nodeinfo/2.0', '/', ''].each do |path|
+        assert_equal(path, scrub(path), "#{path} が書き換えられている")
+      end
+    end
+
+    # 64 桁ちょうどでなければ digest ではない。
+    def test_keeps_near_miss_segments
+      ['a' * 63, 'a' * 65, "#{'a' * 63}z"].each do |segment|
+        assert_equal("/x/#{segment}", scrub("/x/#{segment}"), "#{segment} が丸められている")
+      end
+    end
+
+    def test_tolerates_non_string
+      assert_nil(scrub(nil))
+    end
+
+    # ⚠ **クラスメソッドからも使う。**`Webhook.create` の rescue は key（＝digest）を
+    # ログへ出す。
+    def test_webhook_class_scrubs_digest
+      assert_equal('a1b2c3d4a1b2...', Webhook.scrub_log_digest(DIGEST))
+    end
+
+    # ⚠⚠ **回帰の本体はここ。**`Controller` がログへ渡すパスは必ず
+    # `scrub_log_path` を通す。素の `request.path` を書き戻したら落ちる。
+    #
+    # ⚠ **素の `request.path` が許されるのは 1 箇所だけ** — `not_found` が
+    # **要求した本人へ返すボディ**（ログではない。丸めても秘匿にならず、
+    # 404 のボディという api.md の契約が変わるだけ）。
+    def test_controller_never_logs_raw_path
+      source = File.read(File.join(Environment.dir, 'app/lib/mulukhiya/controller.rb'))
+      # ⚠ コメント行は数えない（この注記自体が `request.path` を含む）。
+      code = source.lines.reject {|line| line.strip.start_with?('#')}.join
+      bare = code.scan(/(?<!scrub_log_path\()request\.path/)
+
+      assert_not_match(/path: request\.path/, code)
+      assert_equal(1, bare.size, "素の request.path が #{bare.size} 箇所ある")
+      assert_match(/Resource .\{request\.path\} not found/, code)
+    end
+  end
+end


### PR DESCRIPTION
Closes #4655

## 何が起きていたか

`POST /mulukhiya/webhook/<digest>` は **digest だけで投稿権限が通る**（`verify_webhook!` 以外に認証が無い）。`Controller#before` が

```ruby
logger.info(request: {method:, path: request.path, params: scrub_log_params(@params), remote: request.ip})
```

と **URL パスをそのまま出す**ので、⚠ **webhook を 1 回使うたびに完全な鍵が syslog に残っていた。**

⚠ **既存の掃討はどれも当たらない**:

| 仕組み | 当たらない理由 |
| --- | --- |
| `Ginseng::Logger#mask_url` | `\A<scheme>://` に一致する**値**にしか効かない |
| `SCRUBBED_LOG_PARAMS` | **パラメータのキー**しか見ない |
| nginx 側の掃討（#4511） | `access_token=` / `"i":"` / `[?&]i=` のどれにも当たらない |

## 変更

`LogScrubber` に `scrub_log_path` / `scrub_log_digest` を足し、**Controller がログへ渡すパス 4 箇所**を通した。

- `before` のリクエストログ
- `error` ブロックの `e.log(path:)`
- `verify_token_integrity!` の `token_mismatch`
- `verify_account_integrity!` の `account_mismatch_detected`

`Webhook.create` の rescue（`e.log(key: key.to_s)`）も同様。⚠ 呼び出し元は `app/` に無いが、テストが契約として使っているので削らず丸めた。

## ⚠⚠ マウント位置ではなく digest の形で判定する

Issue の提案は「`/mulukhiya/webhook/` 配下だけ」でしたが、**接頭辞では切っていません。**

- **webhook のパスは `config/route.yaml` で変えられる**。テストでは各 Controller が root に載る
- 🔴 **接頭辞で切ると、設定を変えた瞬間に黙って秘匿が外れる**（fail-open）。この種の「ガードが静かに無効化される」形は [[feedback_fail-open-guard-footgun]] で繰り返し踏んでいる
- `Webhook.create_digest` は `String#sha256` ＝ **64 桁の 16 進**で、経路上でこの形を持つのは digest だけ

丸め方は**先頭 12 文字 + `...`** で、`verify_webhook!` のエラーメッセージ（`"Webhook not found (digest: #{params[:digest][0, 12]}...)"`）と揃えました。⚠ **同じ digest がログとエラーで別の形に見えると突き合わせられません。**

## 丸めなかったもの

`not_found` のボディ（`"Resource #{request.path} not found."`）。⚠ **あれはログではなく要求した本人へ返す値**で、パスは相手が送ってきた値そのものです。丸めても秘匿にならず、404 のボディ（api.md の契約）が変わるだけなので、**そう判断した理由をコード側にコメントで残しました**（将来「直し漏れ」に見えないように）。

## 回帰テスト

`test/unit/controller/log_scrub_path.rb`（8 ケース）。

⚠ **本体は `test_controller_never_logs_raw_path`** — ログ用のパスが `scrub_log_path` を通っていることをソースで見ます。**`path: request.path` を書き戻すと落ちる**ことを、修正前の実装で実際に確認済みです。素の `request.path` が許されるのは `not_found` の 1 箇所だけ、というところまで固定しています。

- `rake lint` 緑
- `rake test` 1174 tests, 0 failures, 0 errors, 322 omissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)