### PR TITLE
security: 壊れたバイト列でパスの秘匿が落ちないようにする (#4655 の続き)

### DIFF
--- a/app/lib/mulukhiya/log_scrubber.rb
+++ b/app/lib/mulukhiya/log_scrubber.rb
@@ -67,9 +67,18 @@ module Mulukhiya
     #
     # ⚠ **パスの構造は仮定しない。**セグメントに割って、digest の形をしたものだけを
     # 丸める。前後にどんなセグメントが付いていても効く。
+    #
+    # ⚠⚠ **区切りはバイト単位で見る (PR #4666 の Codex P2)。**`request.path` は
+    # `PATH_INFO` そのもので、**不正な UTF-8 バイト列を含みうる**。`String#split` は
+    # それだけで `ArgumentError` を上げるので、**壊れたバイトが 1 つあるだけで
+    # request ログが消え、`before` の rescue に落ちて経路が壊れる**。
+    # `/` は ASCII なのでバイト単位で割っても壊れない。
     def scrub_log_path(path)
       return path unless path.is_a?(String)
-      return path.split('/', -1).map {|segment| scrub_log_digest(segment)}.join('/')
+      segments = path.b.split('/', -1).map do |segment|
+        scrub_log_digest(segment.force_encoding(path.encoding))
+      end
+      return segments.join('/').force_encoding(path.encoding)
     end
 
     # digest 単体を丸める。⚠ **digest でない値は 1 バイトも変えない**
@@ -85,6 +94,18 @@ module Mulukhiya
     # となり、**可逆な形の完全な鍵がそのまま syslog に残っていた**（実測で確認）。
     def scrub_log_digest(value)
       return value unless value.is_a?(String)
+      # ⚠⚠ **壊れたバイト列で例外を上げない (#4655・PR #4666 の Codex P2)。**
+      # `String#match?` は不正な UTF-8 で `ArgumentError` を上げる。ここは
+      # `Controller#before` のログ行を組む途中なので、**上げると request ログが
+      # 丸ごと消えるうえ、`before` の rescue に落ちて `@sns` が未設定のまま
+      # 経路が進む**（malformed な URL 1 本で 500 にできた）。
+      # ⚠ **これは [[project_log-credential-exposure]] と同型**（gem 側でも
+      # `mask_urls_in` が同じ理由でマスクごと外れていた。pooza/ginseng-core#587）。
+      #
+      # ⚠ 素通ししても鍵は漏れない。**64 桁の 16 進はすべて ASCII** なので、
+      # 不正なバイト列を含むセグメントは digest ではありえず、
+      # `Webhook.create!` も引き当てられない。
+      return value unless value.valid_encoding?
       return "#{value[0, LOG_DIGEST_PREFIX_LENGTH]}..." if value.match?(WEBHOOK_DIGEST_PATTERN)
       decoded = unescape_log_segment(value)
       return value unless decoded.match?(WEBHOOK_DIGEST_PATTERN)
@@ -96,8 +117,12 @@ module Mulukhiya
     # ⚠ **デコードできなくても落とさない。**ここで例外を上げるとログ行そのものが
     # 消える。⚠ 解けない値は Sinatra 側でも解けない＝ `Webhook.create!` が
     # 引き当てられないので、**その形で有効な鍵が漏れることはない**。
+    #
+    # ⚠⚠ **`%FF` のようなバイトは `unescape_path` が「例外なしで不正な UTF-8」を
+    # 返す。**rescue では捕まらないので、**戻す前に妥当性を見る**こと。
     def unescape_log_segment(value)
-      return Rack::Utils.unescape_path(value)
+      decoded = Rack::Utils.unescape_path(value)
+      return decoded.valid_encoding? ? decoded : value
     rescue StandardError
       return value
     end

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -2591,6 +2591,13 @@ Controller 層での注意:
   🔴 **`request.path` は生のまま（`PATH_INFO` そのもの）で、Sinatra の `params[:digest]` だけが
   デコード済み。**`%61` を 1 文字混ぜるだけで**引き当ては成功するのにログには丸ごと残る**
   という抜け道が開いていた（実測で確認）。**「パスから来る値」を扱うときは常にこの非対称を疑う**
+- ⚠⚠ **不正なバイト列で例外を上げない**（PR #4666 の Codex P2）。`String#match?` も
+  `String#split` も不正な UTF-8 で `ArgumentError` を上げる。🔴 **`Controller#before` の
+  ログ行を組む途中なので、上げると request ログが丸ごと消え、`before` の rescue に落ちて
+  `@sns` 未設定のまま経路が進む**（malformed な URL 1 本で 500 にできた）。
+  ⚠ **[[project_log-credential-exposure]] と同型**（gem 側でも `mask_urls_in` が同じ理由で
+  マスクごと外れていた。pooza/ginseng-core#587）。区切りは `path.b.split('/')` と
+  **バイト単位で見る**（`/` は ASCII なので壊れない）
 
 ### Webhook digest の安定性
 

--- a/test/unit/controller/log_scrub_path.rb
+++ b/test/unit/controller/log_scrub_path.rb
@@ -10,6 +10,8 @@ module Mulukhiya
     # `Webhook.create_digest` は `String#sha256` ＝ 64 桁の 16 進。
     DIGEST = ('a1b2c3d4' * 8).freeze
     DIGEST_PATTERN = /#{DIGEST}/o
+    # ⚠ 3 バイト文字の途中で切れたバイト列（`logger_mask_boundary.rb` と同じ形）。
+    BROKEN = "\xFF".dup.force_encoding(Encoding::UTF_8).freeze
 
     def setup
       @controller = MisskeyController.new!
@@ -73,6 +75,30 @@ module Mulukhiya
     # ⚠ **解けない値でも落とさない。**ログ行そのものが消えるほうが困る。
     def test_tolerates_broken_escape
       assert_equal('/x/%zz', scrub('/x/%zz'))
+    end
+
+    # ⚠⚠ **不正なバイト列で例外を上げない（PR #4666 の Codex P2）。**
+    # `String#match?` も `String#split` も不正な UTF-8 で `ArgumentError` を上げる。
+    # ⚠ ここは `Controller#before` のログ行を組む途中なので、上げると
+    # **request ログが丸ごと消え、`before` の rescue に落ちて `@sns` 未設定のまま
+    # 経路が進む**（malformed な URL 1 本で 500 にできた）。
+    # ⚠ **[[project_log-credential-exposure]] と同型**（gem 側でも `mask_urls_in` が
+    # 同じ理由でマスクごと外れていた。pooza/ginseng-core#587）。
+    def test_tolerates_invalid_byte_sequence
+      # `%FF` は `unescape_path` が **例外なしで不正な UTF-8 を返す**（rescue では捕まらない）。
+      assert_equal('/x/%FF', scrub('/x/%FF'))
+      assert_equal("/x/#{BROKEN}", scrub("/x/#{BROKEN}"))
+    end
+
+    # ⚠ **壊れたバイトが混ざっても、digest の秘匿は効き続けること。**
+    # 素通しに倒すと「1 バイト混ぜればマスクを外せる」に戻る。
+    def test_scrubs_digest_next_to_invalid_byte_sequence
+      # ⚠ 検査する側も不正なバイト列で `ArgumentError` を上げるので、
+      #   **アサーションの直前だけ** `String#scrub` を通す（本体の戻り値は生のまま）。
+      scrubbed = scrub("/mulukhiya/webhook/#{BROKEN}/#{DIGEST}").scrub
+
+      assert_not_match(DIGEST_PATTERN, scrubbed)
+      assert_match(/a1b2c3d4a1b2\.\.\./, scrubbed)
     end
 
     # digest でないパスは 1 バイトも変えない（ログが役に立たなくなる）。


### PR DESCRIPTION
PR #4666 の Codex P2 への対応。#4655 の続き。

## ⚠ 実機で再現しました

```
$ scrub_log_path("/x/%FF")
ArgumentError: invalid byte sequence in UTF-8
```

🔴 `String#match?` も `String#split` も**不正な UTF-8 で `ArgumentError` を上げます**。`scrub_log_path` は `Controller#before` のログ行を組む途中で走るので、上げると:

- request ログが**丸ごと消える**
- `before` の rescue に落ちて **`@sns` 未設定のまま経路が進む**（500 になる）

⚠⚠ **malformed な URL 1 本で 500 にできました。**

⚠ **これは [[project_log-credential-exposure]] と同型**です。gem 側でも `mask_urls_in` が同じ理由で `ArgumentError` を上げ、**マスクごと外れていました**（pooza/ginseng-core#587 / #4616）。**壊れたバイト列 1 つでガードが素通りする**という同じ形が、今度はパスの側で出た形です。

## 変更

| # | 直したもの |
|---|-----------|
| 1 | **区切りをバイト単位で見る** — `path.b.split('/', -1)`。`/` は ASCII なので壊れない |
| 2 | **`match?` の前に `valid_encoding?` で降りる** |
| 3 | ⚠⚠ **`%FF` は `unescape_path` が「例外なしで不正な UTF-8」を返す** — rescue では捕まらないので、戻す前に妥当性を見る |

⚠ **2 で素通ししても鍵は漏れません。**64 桁の 16 進は**すべて ASCII** なので、不正なバイト列を含むセグメントは digest ではありえず、`Webhook.create!` も引き当てられません。

⚠ **壊れたバイトが混ざっても digest の秘匿は効き続ける**ことを 1 に固定しました。素通しに倒すと「**1 バイト混ぜればマスクを外せる**」に戻ります。

```
"/mulukhiya/webhook/\xFF/<digest>" -> "/mulukhiya/webhook/\xFF/a1b2c3d4a1b2..."
```

## 回帰テスト

| テスト | 見るもの |
|--------|---------|
| `test_tolerates_invalid_byte_sequence` | `%FF` と生の不正バイトで落ちないこと |
| `test_scrubs_digest_next_to_invalid_byte_sequence` | 壊れたバイトの隣の digest も消えること |

⚠ **修正前の実装で 2 件とも `ArgumentError` になることを確認済み**です。

- `rake lint` 緑
- `rake test` 1180 tests, 0 failures, 0 errors, 322 omissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)