### PR TITLE
docs: Misskey の添付配列は createdNote.files (#4656)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1485,7 +1485,17 @@ Slack 互換のペイロードを投稿に変換する。`text` / `blocks` / `at
 
 数えるなら**送った画像 URL の本数**（`blocks[].type == "image"` ＋ 各 attachment の
 `image_url` / `thumb_url`）と、**応答の添付配列**を突き合わせること。
-⚠ **応答のキーは SNS で違う** — Mastodon は `media_attachments`、Misskey は `files`。
+
+⚠⚠ **応答は SNS 本体の投稿 API のものをそのまま返す**（モロヘイヤ独自のラップは無い）ので、
+**添付配列の場所が SNS 種別で違う。**
+
+| controller | 添付配列のパス |
+|---|---|
+| Mastodon | `media_attachments` |
+| Misskey | 🔴 **`createdNote.files`**（トップレベルの `files` ではない） |
+
+🔴 **Misskey は `{"createdNote": {...}}` で 1 枚ラップされている。**トップレベルの `files` を
+読むと**常に見つからず、「全部落ちた」と誤判定する**。
 
 `visibility` を省略すると、アカウント設定（WebUI「Slack互換webhook」セクション、`/webhook/visibility`）の
 既定が使われる。**未知の値も同じくアカウント設定の既定へ倒れる**（エラーにはせず、syslog に


### PR DESCRIPTION
PR #4667 の Codex P2 への対応。⚠ **指摘どおりでした。**

## 何を間違えていたか

添付の数え方の節で、応答の添付配列を「Mastodon は `media_attachments`、**Misskey は `files`**」と書きました。⚠⚠ **api.md 自身が別の節（[api.md:1017](docs/api.md#L1017)）で「Misskey は `POST /api/notes/create` と同じ `{"createdNote": {...}}`」と書いている**のに、そこと食い違っていました。

🔴 **トップレベルの `files` を読むと常に見つからず、「全部落ちた」と誤判定します。**

## 変更

| controller | 添付配列のパス |
|---|---|
| Mastodon | `media_attachments` |
| Misskey | 🔴 **`createdNote.files`** |

「応答は SNS 本体の投稿 API のものをそのまま返す（モロヘイヤ独自のラップは無い）」という前提も併記して、**なぜ場所が割れるのか**が読めるようにしました。

docs のみ。`rake lint` 緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)