### PR TITLE
obs: コントローラ層の rescue を report_error に寄せる (#4654)

### DIFF
--- a/app/lib/mulukhiya/controller.rb
+++ b/app/lib/mulukhiya/controller.rb
@@ -41,7 +41,10 @@ module Mulukhiya
       @sns = sns_class.new
       @sns.token = token
     rescue => e
-      e.log
+      # ⚠ **ここが黙ると原因の分からない 500 だけが残る (#4654)。**`before` の
+      # 失敗は Redis / Postgres 障害（`sns_class.new` / トークン引き当て）が主で、
+      # 従来は一律 `e.log` ＝ Sentry に何も出なかった。
+      report_error(e)
       @sns&.token = nil
     end
 
@@ -65,7 +68,12 @@ module Mulukhiya
       if e.is_a?(Ginseng::Error)
         @renderer.status = e.status
         @renderer.message = e.to_h.except(:backtrace).merge(error: e.message)
-        e.alert
+        # ⚠ **ここは最後の受け皿で、どのルートから来たか分からない (#4654)。**
+        # 判断材料はステータスしか無いので `report_error` に寄せる。従来は
+        # 無条件 `e.alert` で、ルートのローカル rescue をすり抜けた 4xx——
+        # `not_found` を通らない `AuthError` 等——まで Sentry と Event(:alert) に
+        # 落ちていた。⚠ **4 系統目**（#4542 / #4594 / #4603 / #4629）。
+        report_error(e)
       else
         @renderer.status = 500
         @renderer.message = {error: 'Internal Server Error'}
@@ -120,7 +128,12 @@ module Mulukhiya
     end
 
     # クライアント起因の失敗を Sentry alert に上げない共通判定
-    # (#4542 / #4594 / #4603 / #4629)。
+    # (#4542 / #4594 / #4603 / #4629 / #4654)。
+    #
+    # ⚠⚠ **コントローラ層の rescue はここ 1 本に寄せた (#4654)。**最上位の
+    # `error` ブロックも含め、`e.log` / `e.alert` / `e.status < 500 ? ... : ...` の
+    # 直書きは残さない。**唯一の例外は `WebhookController` の `post /admin`** で、
+    # 署名不一致（4xx）を黙らせたくないという理由が現地に書いてある。
     #
     # ⚠⚠ **例外クラスの列挙で判定しない。**同じ方針が 3 系統で別々に書かれ、
     # そのたびに取りこぼした——#4603 は `NotFoundError`、#4629 は `AuthError` と

--- a/app/lib/mulukhiya/controller/api_controller.rb
+++ b/app/lib/mulukhiya/controller/api_controller.rb
@@ -13,7 +13,7 @@ module Mulukhiya
       @renderer.message = about
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -42,7 +42,7 @@ module Mulukhiya
       }
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -54,7 +54,7 @@ module Mulukhiya
       @renderer.message = {config: sns.account.user_config.to_h}
       return @renderer.to_s
     rescue => e
-      e.alert
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -68,9 +68,7 @@ module Mulukhiya
       @renderer.message = {templates: ComposeTemplateContainer.new(sns.account).all}
       return @renderer.to_s
     rescue => e
-      # 認証失敗 (403) 等の想定内 4xx は log、read 経路の真の 5xx（Redis 障害等）は
-      # write 系と対称に alert する。
-      e.status < 500 ? e.log : e.alert
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -89,9 +87,7 @@ module Mulukhiya
       @renderer.message = {template:, templates: container.all}
       return @renderer.to_s
     rescue => e
-      # 上限超過 (409) 等の想定内クライアントエラーは log に留め、保存失敗 (5xx) だけ
-      # alert する（想定内 4xx で Sentry を汚さない）。
-      e.status < 500 ? e.log : e.alert
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -110,7 +106,7 @@ module Mulukhiya
       @renderer.message = {template:, templates: container.all}
       return @renderer.to_s
     rescue => e
-      e.status < 500 ? e.log : e.alert
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -123,8 +119,7 @@ module Mulukhiya
       @renderer.message = {template:, templates: container.all}
       return @renderer.to_s
     rescue => e
-      # 既に削除済み (404) は race で起こる想定内。log に留める。
-      e.status < 500 ? e.log : e.alert
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -143,7 +138,7 @@ module Mulukhiya
       end
       return @renderer.to_s
     rescue => e
-      e.alert
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -163,7 +158,7 @@ module Mulukhiya
       end
       return @renderer.to_s
     rescue => e
-      e.alert
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -199,7 +194,7 @@ module Mulukhiya
       }
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -221,7 +216,7 @@ module Mulukhiya
       @renderer.message = {state: removed ? 'unsubscribed' : 'not-subscribed'}
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -233,7 +228,7 @@ module Mulukhiya
       @renderer.message = sns.emoji_palettes(sns.account)
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -245,7 +240,7 @@ module Mulukhiya
       @renderer.message = sns.fetch_avatar_decorations
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -260,7 +255,7 @@ module Mulukhiya
       @renderer.message = {config: sns.account.user_config.to_h}
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -275,7 +270,7 @@ module Mulukhiya
       @renderer.message = Program.instance.sorted_data
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -288,13 +283,10 @@ module Mulukhiya
       @renderer = ProgramCalendarRenderer.new
       return @renderer.to_s
     rescue => e
-      # 404 (非対応サーバー) は期待動作なので log のみ。tomato-shrieker が定期 GET する
-      # 外部購読先なので、5xx の恒常失敗は検知できるよう alert に昇格する (#4394)。
-      if e.is_a?(Ginseng::NotFoundError)
-        e.log
-      else
-        e.alert
-      end
+      # ⚠ **クラスの列挙をやめて `report_error` に寄せた (#4654)。**tomato-shrieker が
+      # 定期 GET する外部購読先なので、非対応サーバーの 404 は静かなまま、
+      # 5xx の恒常失敗だけ alert に上げたい (#4394)。判定はステータスで足りる。
+      report_error(e)
       @renderer = default_renderer_class.new
       @renderer.status = e.status
       @renderer.message = {error: e.message}
@@ -306,7 +298,7 @@ module Mulukhiya
       ProgramUpdateWorker.perform_async
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -328,7 +320,7 @@ module Mulukhiya
       end
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -345,7 +337,7 @@ module Mulukhiya
       end
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -375,7 +367,7 @@ module Mulukhiya
       end
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -386,7 +378,7 @@ module Mulukhiya
       MediaCleaningWorker.perform_async
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -397,7 +389,7 @@ module Mulukhiya
       MediaMetadataStorage.new.clear
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -420,7 +412,7 @@ module Mulukhiya
       end
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -435,7 +427,7 @@ module Mulukhiya
       )
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -462,7 +454,7 @@ module Mulukhiya
       @renderer.message = {error: e.message}
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -490,7 +482,7 @@ module Mulukhiya
       @renderer.message = {error: e.message}
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -510,7 +502,7 @@ module Mulukhiya
       end
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -534,7 +526,7 @@ module Mulukhiya
       @renderer.message = resolver.resolve
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -551,7 +543,7 @@ module Mulukhiya
       @renderer.message = NowplayingUrlResolver.new(url: params[:url]).resolve
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -562,7 +554,7 @@ module Mulukhiya
       @renderer.message = {oauth_uri: AnnictService.new.oauth_uri.to_s}
       return @renderer.to_s
     rescue => e
-      e.alert
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -585,7 +577,7 @@ module Mulukhiya
       end
       return @renderer.to_s
     rescue => e
-      e.alert
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -596,7 +588,7 @@ module Mulukhiya
       @renderer.message = {oauth_uri: SpotifyUserService.new.oauth_uri.to_s}
       return @renderer.to_s
     rescue => e
-      e.alert
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -615,7 +607,7 @@ module Mulukhiya
       end
       return @renderer.to_s
     rescue => e
-      e.alert
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -641,7 +633,7 @@ module Mulukhiya
       @renderer.message = {error: e.message}
       return @renderer.to_s
     rescue => e
-      e.alert
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -654,7 +646,7 @@ module Mulukhiya
       @renderer.message = {config: sns.account.user_config.to_h}
       return @renderer.to_s
     rescue => e
-      e.alert
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -747,7 +739,7 @@ module Mulukhiya
       AnnouncementWorker.perform_async
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -762,7 +754,7 @@ module Mulukhiya
       @renderer.message = Announcement.new.load.values
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -774,7 +766,7 @@ module Mulukhiya
       @renderer.message = hash_tag_class.favorites
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -785,7 +777,7 @@ module Mulukhiya
       TaggingDictionaryUpdateWorker.perform_async
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -806,7 +798,7 @@ module Mulukhiya
       end.to_h
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -822,7 +814,7 @@ module Mulukhiya
       end
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -833,7 +825,7 @@ module Mulukhiya
       UserTagInitializeWorker.perform_async
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -851,7 +843,7 @@ module Mulukhiya
       end
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -873,7 +865,7 @@ module Mulukhiya
       @renderer.message = {words: dictionary.all, size: dictionary.size, digest:}
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -885,7 +877,7 @@ module Mulukhiya
       @renderer.message = sns.account.piefed&.communities || {}
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -910,7 +902,7 @@ module Mulukhiya
       FeedUpdateWorker.perform_async
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -1015,7 +1007,7 @@ module Mulukhiya
       end
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -1032,7 +1024,7 @@ module Mulukhiya
       end
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -1043,7 +1035,7 @@ module Mulukhiya
       @renderer.message = config.audit
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -1061,7 +1053,7 @@ module Mulukhiya
       end
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -1072,7 +1064,7 @@ module Mulukhiya
       PumaDaemonRestartWorker.perform_in(config['/puma/restart/seconds'], {})
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s
@@ -1107,7 +1099,7 @@ module Mulukhiya
       @renderer.message = result
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer.status = e.status
       @renderer.message = {error: e.message}
       return @renderer.to_s

--- a/app/lib/mulukhiya/controller/feed_controller.rb
+++ b/app/lib/mulukhiya/controller/feed_controller.rb
@@ -7,7 +7,7 @@ module Mulukhiya
       @renderer.status = 404 unless @renderer.exist?
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer = Ginseng::Web::XMLRenderer.new
       @renderer.status = e.status
       @renderer.message = e.message
@@ -24,7 +24,7 @@ module Mulukhiya
       end
       return @renderer.to_s
     rescue => e
-      e.log
+      report_error(e)
       @renderer = Ginseng::Web::XMLRenderer.new
       @renderer.status = e.status
       @renderer.message = e.message
@@ -36,7 +36,7 @@ module Mulukhiya
         @renderer = feed.renderer
         return @renderer.to_s
       rescue => e
-        e.log
+        report_error(e)
         @renderer = Ginseng::Web::XMLRenderer.new
         @renderer.status = e.status
         @renderer.message = e.message

--- a/app/lib/mulukhiya/controller/ui_controller.rb
+++ b/app/lib/mulukhiya/controller/ui_controller.rb
@@ -41,7 +41,7 @@ module Mulukhiya
       response['Location'] = redirect_url
       return ''
     rescue => e
-      e.alert
+      report_error(e)
       @renderer = SlimRenderer.new
       @renderer.template = 'token_error'
       @renderer[:error] = e.message

--- a/test/unit/controller/report_error_consolidation.rb
+++ b/test/unit/controller/report_error_consolidation.rb
@@ -1,0 +1,129 @@
+require 'rack/test'
+
+module Mulukhiya
+  # 最上位 `error` ブロックが 4xx を alert に上げない (#4654)。
+  #
+  # ⚠⚠ **ここはルートのローカル rescue をすり抜けた例外の最後の受け皿**で、
+  # どのルートから来たかは分からない。従来は無条件 `e.alert` だったので、
+  # 4xx でも Sentry ＋ `Event.new(:alert)`（slack / line / mail）に落ちていた。
+  class TopLevelErrorHandlerTest < TestCase
+    include Rack::Test::Methods
+
+    # ルート側で rescue しないコントローラ。`error do` は Controller から継承する。
+    class ErrorProbeController < Controller
+      # ⚠ Sinatra は環境によって `raise_errors` / `show_exceptions` の既定が変わり、
+      # true だと `error` ブロックへ入る前に例外を投げ直す。テストの意図は
+      # **error ブロックのふるまい**なので、両方を明示的に落として固定する。
+      set :raise_errors, false
+      set :show_exceptions, false
+
+      class << self
+        attr_accessor :probe
+      end
+
+      get '/probe' do
+        raise self.class.probe
+      end
+    end
+
+    def app = ErrorProbeController
+
+    # ⚠ Sinatra のホスト認可で 403 になるので Host を明示する。
+    def probe(error)
+      ErrorProbeController.probe = spy(error)
+      # ⚠ **Rack 3 では `rack.input` が任意**で、rack-test は省略する。省略すると
+      # `before` の `request.body.read` が `NoMethodError` で落ち、before ごと
+      # 飛んでしまう（本番の Puma は必ず入れるのでテスト固有）。明示して埋める。
+      get('/probe', {}, 'HTTP_HOST' => 'localhost', 'rack.input' => StringIO.new(''))
+      return ErrorProbeController.probe
+    end
+
+    def test_client_error_reaching_top_level_is_not_alerted
+      [
+        Ginseng::AuthError.new('Unauthorized'),
+        Ginseng::NotFoundError.new('Not Found'),
+        Ginseng::ValidateError.new('invalid'),
+      ].each do |raw|
+        error = probe(raw)
+
+        assert_equal([:log], error.mulukhiya_calls, "#{raw.class} は log であるべき")
+      end
+    end
+
+    # モロヘイヤ自身のバグは黙らせない。
+    def test_server_error_reaching_top_level_is_alerted
+      error = probe(Ginseng::GatewayError.new('Bad response 502'))
+
+      assert_equal([:alert], error.mulukhiya_calls)
+    end
+
+    def test_status_is_still_rendered
+      probe(Ginseng::NotFoundError.new('Not Found'))
+
+      assert_equal(404, last_response.status)
+    end
+
+    private
+
+    def spy(error)
+      calls = []
+      error.define_singleton_method(:mulukhiya_calls) {calls}
+      error.define_singleton_method(:alert) {calls << :alert}
+      error.define_singleton_method(:log) {calls << :log}
+      return error
+    end
+  end
+
+  # コントローラ層の rescue に `e.log` / `e.alert` の直書きを残さない (#4654)。
+  #
+  # ⚠⚠ **#4603 / #4629 / #4654 はいずれも「同じ判定の複写が片方だけ取り残された」形**で
+  # 起きている。複写が増えていないことをテストで押さえる。目視のレビューでは
+  # 3 回続けて漏れた。
+  class ControllerRescueConsolidationTest < TestCase
+    # 現地に理由が書いてある唯一の例外 (#4603)。署名検証の失敗 (`AuthError`) を
+    # 黙らせたくないので、4xx でも alert するのが正しい。
+    ALLOWED = {'webhook_controller.rb' => ['e.alert']}.freeze
+
+    DIRECT_CALL = /\A(e\.log|e\.alert|e\.status < 500 \? e\.log : e\.alert)\z/
+
+    def test_no_direct_log_or_alert_in_bare_rescue
+      offenders = controller_sources.flat_map do |path|
+        bare_rescue_bodies(path).filter_map do |lineno, body|
+          next unless DIRECT_CALL.match?(body)
+          next if ALLOWED[File.basename(path)]&.include?(body)
+          "#{File.basename(path)}:#{lineno} #{body}"
+        end
+      end
+
+      assert_equal([], offenders, 'report_error(e) に寄せる (#4654)')
+    end
+
+    # ⚠ **allowlist が腐らないようにする。**#4603 の意図した例外が消えたら
+    # allowlist ごと落とす。
+    def test_allowlist_is_still_live
+      bodies = bare_rescue_bodies("#{Environment.dir}/app/lib/mulukhiya/controller/webhook_controller.rb")
+
+      assert_include(bodies.map(&:last), 'e.alert')
+    end
+
+    private
+
+    def controller_sources
+      dir = "#{Environment.dir}/app/lib/mulukhiya"
+      return ["#{dir}/controller.rb"] + Dir.glob("#{dir}/controller/*.rb")
+    end
+
+    # 素の `rescue => e` の本体先頭（コメント・空行は飛ばす）を [行番号, 本文] で返す。
+    # ⚠ 型付きの `rescue Ginseng::GatewayError => e` は対象外。上流の 4xx をそのまま
+    # 透過する等、ステータスでは決められない判断が現地にある。
+    def bare_rescue_bodies(path)
+      lines = File.readlines(path)
+      return lines.each_with_index.filter_map do |line, i|
+        next unless /^\s*rescue\s*=>\s*e\s*$/.match?(line)
+        body = lines[(i + 1)..].find {|l| l.strip.present? && !l.strip.start_with?('#')}
+        next unless body
+        [lines[(i + 1)..].index(body) + i + 2, body.strip]
+      end
+    end
+  end
+end

--- a/test/unit/controller/report_error_consolidation.rb
+++ b/test/unit/controller/report_error_consolidation.rb
@@ -82,16 +82,21 @@ module Mulukhiya
   class ControllerRescueConsolidationTest < TestCase
     # 現地に理由が書いてある唯一の例外 (#4603)。署名検証の失敗 (`AuthError`) を
     # 黙らせたくないので、4xx でも alert するのが正しい。
-    ALLOWED = {'webhook_controller.rb' => ['e.alert']}.freeze
+    #
+    # ⚠⚠ **ファイル単位で許すと同じファイルの他ルートまで素通しになる**（Codex P2）。
+    # `webhook_controller.rb` には `post '/:digest'` / `get '/:digest'` も居て、
+    # そちらが `e.alert` に戻されても気づけなくなる。**ルート単位で固定する。**
+    ALLOWED = {'webhook_controller.rb' => {"post '/admin'" => 'e.alert'}}.freeze
 
     DIRECT_CALL = /\A(e\.log|e\.alert|e\.status < 500 \? e\.log : e\.alert)\z/
 
     def test_no_direct_log_or_alert_in_bare_rescue
       offenders = controller_sources.flat_map do |path|
-        bare_rescue_bodies(path).filter_map do |lineno, body|
+        name = File.basename(path)
+        bare_rescues(path).filter_map do |scope, lineno, body|
           next unless DIRECT_CALL.match?(body)
-          next if ALLOWED[File.basename(path)]&.include?(body)
-          "#{File.basename(path)}:#{lineno} #{body}"
+          next if ALLOWED.dig(name, scope) == body
+          "#{name}:#{lineno} (#{scope}) #{body}"
         end
       end
 
@@ -101,9 +106,24 @@ module Mulukhiya
     # ⚠ **allowlist が腐らないようにする。**#4603 の意図した例外が消えたら
     # allowlist ごと落とす。
     def test_allowlist_is_still_live
-      bodies = bare_rescue_bodies("#{Environment.dir}/app/lib/mulukhiya/controller/webhook_controller.rb")
+      ALLOWED.each do |name, routes|
+        found = bare_rescues("#{Environment.dir}/app/lib/mulukhiya/controller/#{name}")
+          .to_h {|scope, _lineno, body| [scope, body]}
 
-      assert_include(bodies.map(&:last), 'e.alert')
+        routes.each do |scope, body|
+          assert_equal(body, found[scope], "#{name} の #{scope} は allowlist と一致するべき")
+        end
+      end
+    end
+
+    # ⚠ allowlist に入れていない同居ルートが本当に検査対象になっているか。
+    # **これが無いと「ルート単位に絞った」という主張自体が検証されない。**
+    def test_sibling_routes_are_still_inspected
+      scopes = bare_rescues("#{Environment.dir}/app/lib/mulukhiya/controller/webhook_controller.rb")
+        .map(&:first)
+
+      assert_include(scopes, "post '/:digest'")
+      assert_include(scopes, "get '/:digest'")
     end
 
     private
@@ -113,17 +133,33 @@ module Mulukhiya
       return ["#{dir}/controller.rb"] + Dir.glob("#{dir}/controller/*.rb")
     end
 
-    # 素の `rescue => e` の本体先頭（コメント・空行は飛ばす）を [行番号, 本文] で返す。
+    # 素の `rescue => e` を [囲みスコープ, 行番号, 本体先頭] で返す。
     # ⚠ 型付きの `rescue Ginseng::GatewayError => e` は対象外。上流の 4xx をそのまま
     # 透過する等、ステータスでは決められない判断が現地にある。
-    def bare_rescue_bodies(path)
+    def bare_rescues(path)
       lines = File.readlines(path)
       return lines.each_with_index.filter_map do |line, i|
         next unless /^\s*rescue\s*=>\s*e\s*$/.match?(line)
-        body = lines[(i + 1)..].find {|l| l.strip.present? && !l.strip.start_with?('#')}
+        rest = lines[(i + 1)..]
+        body = rest.find {|l| l.strip.present? && !l.strip.start_with?('#')}
         next unless body
-        [lines[(i + 1)..].index(body) + i + 2, body.strip]
+        [scope_of(lines, i), rest.index(body) + i + 2, body.strip]
       end
+    end
+
+    # 直近の Sinatra ルートまたは `def` / ブロック名。⚠ **ルートを跨いで遡らない**よう、
+    # どちらか先に当たったほうで止める。
+    def scope_of(lines, index)
+      i = index
+      until i.negative?
+        case lines[i]
+        when /^\s*(get|post|put|delete|patch) (['"])(.+?)\2 do$/ then return "#{::Regexp.last_match(1)} '#{::Regexp.last_match(3)}'"
+        when /^\s*def (\S+)/ then return "def #{::Regexp.last_match(1)}"
+        when /^\s*(before|after|error|not_found) do/ then return "#{::Regexp.last_match(1)} block"
+        end
+        i -= 1
+      end
+      return '(toplevel)'
     end
   end
 end


### PR DESCRIPTION
#4654 の 3 項目に加えて、同じ形が残っていた 3 箇所も一緒に寄せた。

## 着地したもの

| # | 対象 | 従来 |
| --- | --- | --- |
| 1 | 最上位 `error` ブロック（`controller.rb`） | 無条件 `e.alert`。ルートのローカル rescue をすり抜けた 4xx まで Sentry ＋ `Event(:alert)` |
| 2 | 読み系の bare `e.log` **41 箇所**（api_controller / feed_controller） | Postgres / Redis 障害で `/media` が全滅していても Sentry に何も出ない |
| 3 | `e.status < 500 ? e.log : e.alert` の**インライン複写 4 本** | 意味は `report_error` と同じ。#4629 の教訓どおり複写が取りこぼしの原因 |

### issue に無かったが同じ形だったもの

| 対象 | 従来 | なぜ寄せたか |
| --- | --- | --- |
| `before` ブロックの `e.log` | Redis / Postgres 障害が**完全に無音** | 落ちると「原因の分からない 500」だけが残る。2 と同じ形 |
| `/program.ics` の `if e.is_a?(Ginseng::NotFoundError)` | クラスの列挙 | ⚠ **#4629 で否定した形そのもの**。ステータスで足りる |
| 認証・書き込み系の bare `e.alert` **10 箇所** | 4xx でも alert | 下記 |

## ⚠ 唯一「静かになる」向きの変更（要確認）

以下の 10 ルートは、**4xx が alert されなくなる**（syslog には従来どおり残る）。
他はすべて「5xx が alert されるようになる」＝ noisier な向きの変更なので、ここだけ判断が要る。

- `post /config/update` / `post /mastodon/auth` / `post /misskey/auth`
- `get /annict/oauth_uri` / `post /annict/auth`
- `get /spotify/oauth_uri` / `post /spotify/auth` / `delete /spotify/auth` / `get /spotify/currently_playing`
- `get /oauth/callback`（ui_controller）

いずれも冒頭が `raise Ginseng::NotFoundError, 'Not Found' unless <feature>?` と
`raise Ginseng::AuthError, 'Unauthorized' unless sns.account` で、**#4603 / #4629 が
名指しした 2 クラスがそのまま alert に落ちていた**。Spotify は全台 OFF（#570）なので、
capsicum が `get /spotify/oauth_uri` を叩けば 404 が毎回 Sentry に立つ形。

⚠ 代わりに失うのは「OAuth のトークン交換が全ユーザーで壊れた」の即時検知。ただし
それは `AuthError`（401）＝ #4629 が明示的に「alert しない」と決めたクラスなので、
**ステータスで判定するという既定の方針**に揃えた。**方針を変えるなら現地に理由を書いて
allowlist へ入れる**（下記）。

## 例外は 1 つだけ

`WebhookController` の `post /admin` は `e.alert` のまま。署名不一致（`AuthError`）を
黙らせたくないという理由が #4603 で現地に書かれている。**構造テストの allowlist に入れた。**

型付きの `rescue Ginseng::GatewayError => e` / `rescue Ginseng::AuthError => e`（4 箇所）は
対象外。上流の 4xx を 502 に潰さない等、ステータスでは決められない判断が現地にある。

## テスト

`test/unit/controller/report_error_consolidation.rb`（新規・7 件）

1. **`TopLevelErrorHandlerTest`** — rack-test で最上位 `error` ブロックを**実際に踏む**。
   `AuthError` / `NotFoundError` / `ValidateError` は `log` のみ、`GatewayError`（502）は
   `alert`、404 が描画されることまで見る
   - ⚠ Sinatra の `raise_errors` / `show_exceptions` は環境で既定が変わり、true だと
     error ブロックへ入る前に投げ直す。テストで明示的に落として固定した
   - ⚠ **Rack 3 では `rack.input` が任意**で rack-test は省略する。省略すると `before` の
     `request.body.read` が `NoMethodError` で落ちて before ごと飛ぶ（本番の Puma は必ず
     入れるのでテスト固有）。明示して埋めた
2. **`ControllerRescueConsolidationTest`** — コントローラ層の素の `rescue => e` に
   `e.log` / `e.alert` / インライン三項が**再び生えないこと**を構造で押さえる。
   ⚠ **allowlist が腐らないよう、`post /admin` の `e.alert` が現存することも別に確かめる**

`rake lint`（492 files, no offenses）/ `rake test`（1185 tests, 0 failures, 0 errors）とも緑。

Closes #4654
