### PR TITLE
obs: pgbouncer の待ち行列を /health に載せる (#4618 の P1)

### DIFF
--- a/app/lib/mulukhiya/dbms/pgbouncer.rb
+++ b/app/lib/mulukhiya/dbms/pgbouncer.rb
@@ -1,0 +1,124 @@
+require 'pg'
+
+module Mulukhiya
+  # pgbouncer の待ち行列を `/health` に載せる (#4618 の P1)。
+  #
+  # ⚠⚠ **`Postgres.pool` が読むのは `/health` を処理した Puma プロセスの Sequel
+  # プール 1 つだけ**で、実際に枯れる資源とは別物。pgbouncer は **Mastodon 本体・
+  # モロヘイヤの Puma・Sidekiq が共有**していて、重い SQL を流す
+  # `MediaCatalogUpdateWorker` は別プロセス＝別プールなので、worker が pgbouncer を
+  # 占有しても Puma 側の `allocated` / `waiting` には直接出ない。
+  #
+  # ⚠ **#4639（Gate 2 の overlay flip）の rollback 信号。**flip する前に、
+  # 信号のほうを信用できる状態にしておく。2026-05-19 の全サーバー投稿不可は
+  # ここの枯渇が最有力だった（#4323 / pooza/chubo2#37）。
+  #
+  # ⚠ **admin コンソールは資格情報を要らない。**chubo-core の pgbouncer cookbook が
+  # `auth_type = trust` / `admin_users = pgbouncer` を書くので、アプリの DSN と
+  # **同じ host:port** へ `pgbouncer` ユーザーで入れる。秘密を増やさないので config も
+  # 増やさない。⚠ trust はローカルホスト前提であり、**同じ箱で動くプロセスなら
+  # 誰でも既に持っている経路**。モロヘイヤが新しい権限を得るわけではない。
+  class Pgbouncer
+    include Package
+
+    ADMIN_USER = 'pgbouncer'.freeze
+    ADMIN_DBNAME = 'pgbouncer'.freeze
+
+    # 素の PostgreSQL の既定ポート。ここを向いているなら pgbouncer は挟まっていない
+    # （本番 4 台のうち vulcan がこれ＝ Misskey / Linux で cookbook の対象外）。
+    #
+    # ⚠⚠ **素の Postgres へ `pgbouncer` ユーザーで入りに行かないこと。**認証失敗が
+    # `/health` を叩くたびに PostgreSQL のログへ溜まる。ポートで手前に切る。
+    DIRECT_PORT = 5432
+
+    # `SHOW POOLS` から読む列。⚠ **`cl_waiting` が本命**——サーバー接続を待って
+    # ブロックしているクライアント数で、これが 0 を超えたらプールが要求に足りていない。
+    # `maxwait` は待ちの最長秒数で、瞬間値の `cl_waiting` が 0 に戻っていても
+    # 直前の詰まりが残る。
+    POOL_FIELDS = ['cl_active', 'cl_waiting', 'sv_active', 'sv_idle', 'maxwait'].freeze
+
+    class << self
+      # `{pgbouncer: {...}}` を返す。⚠ **観測が取れないこと自体で health を落とさない**
+      # （`Postgres.pool` と同じ設計）。status は呼び側で触らない。
+      def health
+        return {} unless enable?
+        return {pgbouncer: probe}
+      rescue => e
+        # ⚠ **繋がらないこと自体が信号になりうる**（`max_client_conn` 枯渇なら
+        # 「no more connections allowed」が返る）。潰さずメッセージを出す。
+        # ⚠ ただし status は動かさない。pgbouncer の停止と枯渇を接続失敗からは
+        # 区別できず、health を WARN に倒すと再起動のたびに揺れる。
+        e.log
+        return {pgbouncer: {error: e.message}}
+      end
+
+      # ⚠ 既定は `null` ＝ ポートによる自動判定。`true` / `false` で固定できる。
+      # config の参照を rescue で握り潰さないこと。既定値は application.yaml が
+      # 必ず持つので、引けない状態は設定の破損である
+      # (MEMORY feedback_fail-open-guard-footgun)。
+      def enable?
+        value = config['/postgres/pgbouncer/enable']
+        return value if [true, false].include?(value)
+        return proxied?
+      end
+
+      # DSN が素の PostgreSQL 以外のポートを向いていれば pgbouncer とみなす。
+      def proxied?
+        port = Postgres.dsn&.port
+        return false unless port
+        return port.to_i != DIRECT_PORT
+      end
+
+      private
+
+      def probe
+        connection = connect
+        pool = pool_row(connection)
+        return {
+          database: dsn.dbname,
+          # ⚠ 該当プールがまだ作られていないことはある（誰も繋いでいない）。
+          # **0 と「不明」は違う**ので、行が無いときは値を載せない。
+          **(pool ? POOL_FIELDS.to_h {|k| [k.to_sym, pool[k].to_i]} : {absent: true}),
+          **clients(connection),
+        }
+      ensure
+        connection&.close
+      end
+
+      def connect
+        return PG.connect(
+          host: dsn.host,
+          port: dsn.port,
+          user: ADMIN_USER,
+          dbname: ADMIN_DBNAME,
+          connect_timeout: config['/postgres/pgbouncer/timeout'],
+        )
+      end
+
+      # 自分と同じ (database, user) の行。⚠ **Mastodon 本体と同じ行になる**——
+      # 同じ DSN で繋いでいるので、これがまさに共有している待ち行列。
+      def pool_row(connection)
+        return connection.exec('SHOW POOLS').find do |row|
+          row['database'] == dsn.dbname && row['user'] == dsn.user
+        end
+      end
+
+      # 全プール合計のクライアント数と上限。⚠ **2026-08-02 の gomander
+      # （FeedUpdateWorker 全滅）と 2026-08-08 の shallu はどちらも
+      # `no more connections allowed (max_client_conn)`** で、枯れたのは
+      # プールごとの待ちではなく**箱全体のクライアント数**だった。
+      def clients(connection)
+        used = connection.exec('SHOW LISTS').find {|row| row['list'] == 'used_clients'}
+        max = connection.exec('SHOW CONFIG').find {|row| row['key'] == 'max_client_conn'}
+        return {
+          clients_used: used && used['items'].to_i,
+          clients_max: max && max['value'].to_i,
+        }.compact
+      end
+
+      def dsn
+        return Postgres.dsn
+      end
+    end
+  end
+end

--- a/app/lib/mulukhiya/dbms/pgbouncer.rb
+++ b/app/lib/mulukhiya/dbms/pgbouncer.rb
@@ -33,8 +33,12 @@ module Mulukhiya
 
     # `SHOW POOLS` から読む列。⚠ **`cl_waiting` が本命**——サーバー接続を待って
     # ブロックしているクライアント数で、これが 0 を超えたらプールが要求に足りていない。
-    # `maxwait` は待ちの最長秒数で、瞬間値の `cl_waiting` が 0 に戻っていても
-    # 直前の詰まりが残る。
+    #
+    # ⚠⚠ **`cl_waiting` も `maxwait` も「いまキューに居る人」の値でしかない。**
+    # pgbouncer の man は `maxwait` を "How long the first (oldest) client in the
+    # queue has waited" と定義しており、**キューが捌けば両方 0 に戻る**。
+    # スクレイプの合間に起きて終わった詰まりは、この 2 つには残らない
+    # （PR #4671 の Codex P2）。**残るのは `SHOW STATS` の `total_wait_time` のほう。**
     POOL_FIELDS = ['cl_active', 'cl_waiting', 'sv_active', 'sv_idle', 'maxwait'].freeze
 
     class << self
@@ -80,6 +84,7 @@ module Mulukhiya
           # **0 と「不明」は違う**ので、行が無いときは値を載せない。
           **(pool ? POOL_FIELDS.to_h {|k| [k.to_sym, pool[k].to_i]} : {absent: true}),
           **clients(connection),
+          **cumulative(connection),
         }
       ensure
         connection&.close
@@ -114,6 +119,21 @@ module Mulukhiya
           clients_used: used && used['items'].to_i,
           clients_max: max && max['value'].to_i,
         }.compact
+      end
+
+      # ⚠⚠ **スクレイプの合間に起きて終わった詰まりは、これでしか見えない。**
+      # `cl_waiting` / `maxwait` は現在キューに居るクライアントの値なので、
+      # **有限のスパイクは 2 回のスクレイプの間に消える**。`total_wait_time` は
+      # 起動からの累計（マイクロ秒）＝単調増加なので、**差分を取れば「前回から
+      # 今回までに待ちが発生したか」が分かる**。#4639 の flip の前後で比べるならこちら。
+      #
+      # ⚠ **pgbouncer を再起動すると 0 に戻る。**差分を取る側はカウンタの巻き戻りを
+      # 扱うこと（負の差分は「再起動した」と読む）。
+      # ⚠ `SHOW STATS` の行は database 単位で、user 列を持たない。
+      def cumulative(connection)
+        row = connection.exec('SHOW STATS').find {|r| r['database'] == dsn.dbname}
+        return {} unless row
+        return {total_wait_time_us: row['total_wait_time'].to_i}
       end
 
       def dsn

--- a/app/lib/mulukhiya/dbms/postgres.rb
+++ b/app/lib/mulukhiya/dbms/postgres.rb
@@ -42,6 +42,10 @@ module Mulukhiya
       return Ginseng::Postgres::DSN.parse(config['/postgres/dsn']) rescue nil
     end
 
+    # ⚠ **`pool` はこのプロセスの Sequel プールしか見ていない (#4618 の P1)。**
+    # 実際に枯れるのは Mastodon 本体・Sidekiq と共有する pgbouncer のほうなので、
+    # `Pgbouncer.health` を併せて返す。⚠ **どちらか片方では判断できない。**
+    #
     # ⚠⚠ **プールの観測は `SELECT 1` より先に取る (#4618)。**
     # `SELECT 1` 自身がプールから接続を借りるので、詰まっているときは
     # **health のリクエストが待ち行列に並ぶ**。並び終えてから読むと
@@ -53,11 +57,14 @@ module Mulukhiya
 
       snapshot = pool
       instance.connection.fetch('SELECT 1 AS ok').first
-      return {status: 'OK'}.merge(snapshot)
+      return {status: 'OK'}.merge(snapshot).merge(Pgbouncer.health)
     rescue Sequel::PoolTimeout => e
-      return {error: e.message, status: 'WARN', reason: 'pool_exhausted'}.merge(snapshot || pool)
+      return {error: e.message, status: 'WARN', reason: 'pool_exhausted'}
+          .merge(snapshot || pool).merge(Pgbouncer.health)
     rescue => e
-      return {error: e.message, status: 'NG'}
+      # ⚠ NG のときこそ pgbouncer の生死が要る。「Postgres NG だが pgbouncer は
+      # 答える」と「両方死んでいる」は切り分けが真逆になる。
+      return {error: e.message, status: 'NG'}.merge(Pgbouncer.health)
     end
 
     # 接続プールの使用状況 (#4351 Gate 2)。

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -495,6 +495,16 @@ parser:
       visibility: visibility
 postgres:
   dsn: null
+  # pgbouncer の待ち行列を /health に載せるか (#4618)。
+  # auto = dsn のポートが 5432 以外なら pgbouncer が挟まっているとみなす。
+  # ⚠⚠ **null を既定値にしないこと。**Ginseng の config は null を「キーが無い」と
+  # 同じに扱って ConfigError を上げる。三値は文字列で表す。
+  # ⚠ 素の PostgreSQL へ pgbouncer ユーザーで入りに行くと、認証失敗が /health を
+  # 叩くたびに PostgreSQL のログへ溜まる。true 固定にするのは pgbouncer が
+  # 5432 で待っている構成に限ること。
+  pgbouncer:
+    enable: auto
+    timeout: 2
   pool:
     size: 10
     timeout: 5

--- a/config/schema/base.yaml
+++ b/config/schema/base.yaml
@@ -236,6 +236,22 @@ properties:
       dsn:
         format: uri
         type: string
+      pgbouncer:
+        properties:
+          # auto = dsn のポートが 5432 以外なら pgbouncer が挟まっているとみなす (#4618)
+          enable:
+            oneOf:
+              - type: boolean
+              - enum:
+                  - auto
+          timeout:
+            minimum: 1
+            maximum: 30
+            type: integer
+        required:
+          - enable
+          - timeout
+        type: object
       pool:
         properties:
           size:

--- a/docs/api.md
+++ b/docs/api.md
@@ -563,7 +563,16 @@ Web Push サブスクリプションを解除する。
   "redis": {"status": "OK"},
   "sidekiq": {"status": "OK"},
   "streaming": {"status": "OK"},
-  "postgres": {"status": "OK", "pool": {"max": 10, "allocated": 1, "waiting": 0}},
+  "postgres": {
+    "status": "OK",
+    "pool": {"max": 10, "allocated": 1, "waiting": 0},
+    "pgbouncer": {
+      "database": "mastodon",
+      "cl_active": 12, "cl_waiting": 0, "maxwait": 0,
+      "sv_active": 0, "sv_idle": 1,
+      "clients_used": 13, "clients_max": 500
+    }
+  },
   "ruby": {"version": "4.0.6", "yjit_available": true, "yjit_enabled": true, "status": "OK"},
   "status": 200
 }
@@ -578,8 +587,36 @@ Web Push サブスクリプションを解除する。
 | `allocated` | 確保済みの接続数。⚠ **`max` に張り付いていても正常**（作った接続を使い回す設計） |
 | `waiting` | 接続の空きを待っているスレッド数。**これが本命の指標で、0 を超えたらプールが要求に足りていない** |
 
-⚠ **この値は Puma プロセスローカル**（#4618）。pgbouncer 側と Sidekiq 側の逼迫は映らないので、
-**1 プロセスの `waiting` が 0 でも全体が健全とは限らない**。
+⚠ **この値は Puma プロセスローカル**（#4618）。**1 プロセスの `waiting` が 0 でも全体が健全とは
+限らない**ので、共有資源のほうは `postgres.pgbouncer` を見る。
+
+**`postgres.pgbouncer` は pgbouncer の待ち行列** (5.36.0〜、#4618)。⚠⚠ **`pool` と違い、
+Mastodon 本体・モロヘイヤの Puma・Sidekiq を合算した値**で、`#4351` Gate 2 の overlay flip を
+戻すかどうかの信号としては**こちらが本命**。重い SQL を流す `MediaCatalogUpdateWorker` は
+別プロセス＝別プールなので、`pool` には出ない。
+
+| キー | 意味 |
+|------|------|
+| `database` | 引き当てたプール（アプリの DSN と同じ database / user の行） |
+| `cl_active` | サーバー接続を持っているクライアント数 |
+| `cl_waiting` | **サーバー接続を待っているクライアント数。これが本命** |
+| `maxwait` | 待ちの最長秒数。⚠ 瞬間値の `cl_waiting` が 0 に戻っていても直前の詰まりが残る |
+| `sv_active` / `sv_idle` | 使用中／待機中のサーバー接続数 |
+| `clients_used` | **箱全体**のクライアント数（全プール合計） |
+| `clients_max` | `max_client_conn`。⚠ **2026-08-02 の gomander も 2026-08-08 の shallu も、枯れたのはプールごとの待ちではなくここ** |
+
+🔴 **`pgbouncer` は無いことのほうが多い。**⚠ **欠けていても異常ではない。**
+
+| 状況 | `pgbouncer` |
+|------|-------------|
+| DSN が 5432（pgbouncer を経由していない） | ⚠ **キーごと無い**（本番では vulcan がこれ） |
+| `/postgres/pgbouncer/enable` が `false` | ⚠ **キーごと無い** |
+| admin コンソールへ繋がらない | `{"error": "..."}` のみ。⚠ **`status` は動かない**（下記） |
+| プールの行がまだ無い（誰も繋いでいない） | `{"absent": true}` ＋ `clients_*`。⚠ **0 とは違う** |
+
+⚠⚠ **pgbouncer の観測は `status` を動かさない。**pgbouncer の停止と `max_client_conn` 枯渇は
+接続失敗からは区別できず、`status` を倒すと再起動のたびに health が揺れて信号として使えなくなる。
+**`pgbouncer.error` があっても `status` は `OK` のまま**なので、監視側はエラーの有無を別に見ること。
 
 🔴 **`pool` も `waiting` も欠けることがある**（#4656）。⚠ **欠落は「正常」でも「異常」でもない**ので、
 監視側が直に読むと `nil` を掴む。

--- a/docs/api.md
+++ b/docs/api.md
@@ -570,7 +570,8 @@ Web Push サブスクリプションを解除する。
       "database": "mastodon",
       "cl_active": 12, "cl_waiting": 0, "maxwait": 0,
       "sv_active": 0, "sv_idle": 1,
-      "clients_used": 13, "clients_max": 500
+      "clients_used": 13, "clients_max": 500,
+      "total_wait_time_us": 29082533
     }
   },
   "ruby": {"version": "4.0.6", "yjit_available": true, "yjit_enabled": true, "status": "OK"},
@@ -600,10 +601,19 @@ Mastodon 本体・モロヘイヤの Puma・Sidekiq を合算した値**で、`#
 | `database` | 引き当てたプール（アプリの DSN と同じ database / user の行） |
 | `cl_active` | サーバー接続を持っているクライアント数 |
 | `cl_waiting` | **サーバー接続を待っているクライアント数。これが本命** |
-| `maxwait` | 待ちの最長秒数。⚠ 瞬間値の `cl_waiting` が 0 に戻っていても直前の詰まりが残る |
+| `maxwait` | **いまキューの先頭に居るクライアント**が待った秒数 |
 | `sv_active` / `sv_idle` | 使用中／待機中のサーバー接続数 |
 | `clients_used` | **箱全体**のクライアント数（全プール合計） |
 | `clients_max` | `max_client_conn`。⚠ **2026-08-02 の gomander も 2026-08-08 の shallu も、枯れたのはプールごとの待ちではなくここ** |
+| `total_wait_time_us` | 起動からの**累計**待ち時間（マイクロ秒・単調増加）。`SHOW STATS` の `total_wait_time` |
+
+⚠⚠ **`cl_waiting` と `maxwait` は「いまキューに居る人」の値でしかない。**pgbouncer は `maxwait` を
+"How long the first (oldest) client in the queue has waited" と定義しており、
+**キューが捌けば両方 0 に戻る**。⚠ **スクレイプの合間に起きて終わった詰まりは、この 2 つには残らない。**
+
+🎯 **有限のスパイクを拾いたいなら `total_wait_time_us` の差分を取る。**単調増加のカウンタなので、
+**前回のスクレイプとの差が 0 より大きければ、その間に待ちが発生した**と分かる。#4639 の flip の
+前後を比べるならこちら。⚠ **pgbouncer を再起動すると 0 に戻る**ので、負の差分は「再起動した」と読むこと。
 
 🔴 **`pgbouncer` は無いことのほうが多い。**⚠ **欠けていても異常ではない。**
 

--- a/test/unit/dbms/pgbouncer.rb
+++ b/test/unit/dbms/pgbouncer.rb
@@ -1,0 +1,235 @@
+module Mulukhiya
+  # `PG.connect` の差し替え。⚠ **2 つのテストクラスで同じ細工が要る**ので、
+  # #4654 の教訓どおり複写せず 1 本に寄せる。
+  module PgbouncerStub
+    def with_admin(admin)
+      stub_connect {|**_params| admin}
+      return yield
+    ensure
+      restore_connect
+    end
+
+    def with_failing_connect(message = 'refused')
+      stub_connect {|**_params| raise PG::ConnectionBad, message}
+      return yield
+    ensure
+      restore_connect
+    end
+
+    private
+
+    def stub_connect(&)
+      PG.singleton_class.alias_method(:__orig_connect, :connect)
+      PG.define_singleton_method(:connect, &)
+    end
+
+    def restore_connect
+      PG.singleton_class.alias_method(:connect, :__orig_connect)
+      PG.singleton_class.remove_method(:__orig_connect)
+    end
+  end
+end
+
+module Mulukhiya
+  # pgbouncer の待ち行列を /health に載せる (#4618 の P1)。
+  #
+  # ⚠⚠ **`Postgres.pool` はプロセスローカルの Sequel プールしか見ていない。**
+  # 実際に枯れるのは Mastodon 本体・Sidekiq と共有する pgbouncer のほうで、
+  # 2026-05-19 の全サーバー投稿不可も 2026-08-02 / 08-08 の枯渇も、そちらだった。
+  class PgbouncerTest < TestCase
+    include PgbouncerStub
+
+    # admin コンソールのダブル。SHOW POOLS / SHOW LISTS / SHOW CONFIG を返す。
+    class FakeAdmin
+      attr_reader :closed, :queries
+
+      def initialize(pools: nil, used_clients: 13, max_client_conn: 500)
+        @pools = pools || [
+          # ⚠ **自分の行より先に別の行が来る。**先頭を拾う実装だと取り違える。
+          {'database' => 'other', 'user' => 'other', 'cl_active' => '99', 'cl_waiting' => '99',
+           'sv_active' => '99', 'sv_idle' => '99', 'maxwait' => '99'},
+          {'database' => 'mastodon', 'user' => 'mastodon', 'cl_active' => '12', 'cl_waiting' => '3',
+           'sv_active' => '1', 'sv_idle' => '2', 'maxwait' => '7'},
+          {'database' => 'pgbouncer', 'user' => 'pgbouncer', 'cl_active' => '1', 'cl_waiting' => '0',
+           'sv_active' => '0', 'sv_idle' => '0', 'maxwait' => '0'},
+        ]
+        @used_clients = used_clients
+        @max_client_conn = max_client_conn
+        @queries = []
+      end
+
+      def exec(sql)
+        @queries << sql
+        case sql
+        when 'SHOW POOLS' then return @pools
+        when 'SHOW LISTS' then return [{'list' => 'databases', 'items' => '2'},
+          {'list' => 'used_clients', 'items' => @used_clients.to_s}]
+        when 'SHOW CONFIG' then return [{'key' => 'admin_users', 'value' => 'pgbouncer'},
+          {'key' => 'max_client_conn', 'value' => @max_client_conn.to_s}]
+        end
+        raise "unexpected query: #{sql}"
+      end
+
+      def close = @closed = true
+    end
+
+    def setup
+      config['/postgres/dsn'] = 'postgres://mastodon:secret@127.0.0.1:6432/mastodon'
+      config['/postgres/pgbouncer/enable'] = 'auto'
+      config['/postgres/pgbouncer/timeout'] = 2
+    end
+
+    # ⚠ **素の PostgreSQL へ `pgbouncer` ユーザーで入りに行かない。**認証失敗が
+    # /health を叩くたびに PostgreSQL のログへ溜まる。本番 4 台のうち vulcan が
+    # 5432 直結（Misskey / Linux で cookbook の対象外）。
+    def test_direct_postgres_is_not_probed
+      config['/postgres/dsn'] = 'postgres://misskey@127.0.0.1:5432/misskey'
+
+      assert_false(Pgbouncer.enable?)
+      assert_empty(Pgbouncer.health)
+    end
+
+    def test_proxied_port_is_probed
+      assert_predicate(Pgbouncer, :enable?)
+    end
+
+    # ポートを省略した DSN は素の PostgreSQL とみなす（自動判定の材料が無い）。
+    def test_portless_dsn_is_not_probed
+      config['/postgres/dsn'] = 'postgres://example.invalid/dummy'
+
+      assert_false(Pgbouncer.enable?)
+    end
+
+    def test_explicit_config_overrides_auto_detection
+      config['/postgres/pgbouncer/enable'] = false
+
+      assert_false(Pgbouncer.enable?)
+
+      config['/postgres/dsn'] = 'postgres://misskey@127.0.0.1:5432/misskey'
+      config['/postgres/pgbouncer/enable'] = true
+
+      assert_predicate(Pgbouncer, :enable?)
+    end
+
+    # ⚠⚠ **`cl_waiting` が本命。**サーバー接続を待ってブロックしているクライアント数で、
+    # Mastodon 本体・モロヘイヤ Puma・Sidekiq の合算になる。
+    def test_health_reports_the_shared_queue
+      admin = FakeAdmin.new
+      health = with_admin(admin) {Pgbouncer.health}
+
+      assert_equal({
+        database: 'mastodon',
+        cl_active: 12,
+        cl_waiting: 3,
+        sv_active: 1,
+        sv_idle: 2,
+        maxwait: 7,
+        clients_used: 13,
+        clients_max: 500,
+      }, health[:pgbouncer])
+    end
+
+    # ⚠ **自分と同じ (database, user) の行を選ぶ。**先頭や `pgbouncer` の管理行を
+    # 拾うと、共有している待ち行列とは無関係の数字を報告する。
+    def test_health_picks_the_row_for_our_own_dsn
+      health = with_admin(FakeAdmin.new) {Pgbouncer.health}
+
+      refute_equal(99, health.dig(:pgbouncer, :cl_waiting))
+      assert_equal(3, health.dig(:pgbouncer, :cl_waiting))
+    end
+
+    # ⚠ **0 と「不明」は違う。**誰も繋いでいなければプールの行はまだ無い。
+    # そこで 0 を報告すると「詰まっていない」と読めてしまう。
+    def test_absent_pool_is_not_reported_as_zero
+      admin = FakeAdmin.new(pools: [])
+      health = with_admin(admin) {Pgbouncer.health}
+
+      assert_predicate(health.dig(:pgbouncer, :absent), :present?)
+      assert_nil(health.dig(:pgbouncer, :cl_waiting))
+      # 箱全体のクライアント数は行が無くても読める。
+      assert_equal(13, health.dig(:pgbouncer, :clients_used))
+    end
+
+    # ⚠ **2026-08-02 の gomander も 2026-08-08 の shallu も
+    # `no more connections allowed (max_client_conn)`** で、枯れたのはプールごとの
+    # 待ちではなく**箱全体のクライアント数**だった。上限との比較が要る。
+    def test_health_reports_client_headroom
+      admin = FakeAdmin.new(used_clients: 498, max_client_conn: 500)
+      health = with_admin(admin) {Pgbouncer.health}
+
+      assert_equal(498, health.dig(:pgbouncer, :clients_used))
+      assert_equal(500, health.dig(:pgbouncer, :clients_max))
+    end
+
+    # ⚠ **繋がらないこと自体が信号になりうる**（max_client_conn 枯渇なら
+    # 「no more connections allowed」が返る）。潰さずメッセージを出す。
+    def test_connection_failure_is_reported_not_swallowed
+      health = with_failing_connect('no more connections allowed (max_client_conn)') do
+        Pgbouncer.health
+      end
+
+      assert_equal('no more connections allowed (max_client_conn)', health.dig(:pgbouncer, :error))
+    end
+
+    def test_connection_is_closed
+      admin = FakeAdmin.new
+      with_admin(admin) {Pgbouncer.health}
+
+      assert(admin.closed)
+    end
+
+    # ⚠ クエリの途中で落ちても接続を残さない。
+    def test_connection_is_closed_on_error
+      admin = FakeAdmin.new
+      admin.define_singleton_method(:exec) {|_sql| raise 'boom'}
+      with_admin(admin) {Pgbouncer.health}
+
+      assert(admin.closed)
+    end
+  end
+
+  # pgbouncer の観測は health の status を動かさない (#4618)。
+  #
+  # ⚠⚠ **pgbouncer の停止と枯渇は接続失敗からは区別できない。**status を倒すと
+  # 再起動のたびに health が揺れて、逆に信号として使えなくなる。
+  class PgbouncerDoesNotFlipStatusTest < TestCase
+    include PgbouncerStub
+
+    # ⚠ PostgresTest のダブルを借りない。`bin/test.rb pgbouncer` のように
+    # 1 ケースだけ回すと向こうが読み込まれず、**テストの都合で落ちる**。
+    class FakePool
+      def max_size = 10
+      def size = 2
+      def num_waiting = 0
+    end
+
+    class FakeConnection
+      def pool = FakePool.new
+      def fetch(_sql) = [{ok: 1}]
+    end
+
+    class FakeInstance
+      def connection = FakeConnection.new
+    end
+
+    def setup
+      config['/postgres/dsn'] = 'postgres://mastodon:secret@127.0.0.1:6432/mastodon'
+      config['/postgres/pgbouncer/enable'] = 'auto'
+      config['/postgres/pgbouncer/timeout'] = 2
+      Postgres.instance_variable_set(:@singleton__instance__, FakeInstance.new)
+    end
+
+    def teardown
+      Singleton.__init__(Postgres)
+      super
+    end
+
+    def test_status_stays_ok_when_pgbouncer_is_unreachable
+      health = with_failing_connect {Postgres.health}
+
+      assert_equal('OK', health[:status])
+      assert_equal({max: 10, allocated: 2, waiting: 0}, health[:pool])
+      assert_predicate(health.dig(:pgbouncer, :error), :present?)
+    end
+  end
+end

--- a/test/unit/dbms/pgbouncer.rb
+++ b/test/unit/dbms/pgbouncer.rb
@@ -43,7 +43,7 @@ module Mulukhiya
     class FakeAdmin
       attr_reader :closed, :queries
 
-      def initialize(pools: nil, used_clients: 13, max_client_conn: 500)
+      def initialize(pools: nil, used_clients: 13, max_client_conn: 500, total_wait_time: 29_082_533)
         @pools = pools || [
           # ⚠ **自分の行より先に別の行が来る。**先頭を拾う実装だと取り違える。
           {'database' => 'other', 'user' => 'other', 'cl_active' => '99', 'cl_waiting' => '99',
@@ -55,6 +55,7 @@ module Mulukhiya
         ]
         @used_clients = used_clients
         @max_client_conn = max_client_conn
+        @total_wait_time = total_wait_time
         @queries = []
       end
 
@@ -66,6 +67,9 @@ module Mulukhiya
           {'list' => 'used_clients', 'items' => @used_clients.to_s}]
         when 'SHOW CONFIG' then return [{'key' => 'admin_users', 'value' => 'pgbouncer'},
           {'key' => 'max_client_conn', 'value' => @max_client_conn.to_s}]
+        # ⚠ SHOW STATS の行は database 単位で user 列を持たない。
+        when 'SHOW STATS' then return [{'database' => 'other', 'total_wait_time' => '99'},
+          {'database' => 'mastodon', 'total_wait_time' => @total_wait_time.to_s}]
         end
         raise "unexpected query: #{sql}"
       end
@@ -126,6 +130,7 @@ module Mulukhiya
         maxwait: 7,
         clients_used: 13,
         clients_max: 500,
+        total_wait_time_us: 29_082_533,
       }, health[:pgbouncer])
     end
 
@@ -169,6 +174,33 @@ module Mulukhiya
       end
 
       assert_equal('no more connections allowed (max_client_conn)', health.dig(:pgbouncer, :error))
+    end
+
+    # ⚠⚠ **`cl_waiting` / `maxwait` は「いまキューに居る人」の値でしかない**
+    # （PR #4671 の Codex P2）。pgbouncer の man は `maxwait` を "How long the first
+    # (oldest) client in the queue has waited" と定義しており、**キューが捌けば
+    # 両方 0 に戻る**。スクレイプの合間に起きて終わった詰まりが見えるのは、
+    # 起動からの累計（単調増加）である `total_wait_time` のほうだけ。
+    def test_finished_congestion_survives_in_the_cumulative_counter
+      drained = FakeAdmin.new(
+        pools: [{'database' => 'mastodon', 'user' => 'mastodon', 'cl_active' => '3',
+                 'cl_waiting' => '0', 'sv_active' => '0', 'sv_idle' => '1', 'maxwait' => '0'}],
+        total_wait_time: 1_500_000,
+      )
+      health = with_admin(drained) {Pgbouncer.health}
+
+      # 瞬間値はどちらも 0 ＝ ここだけ見ると「詰まっていない」
+      assert_equal(0, health.dig(:pgbouncer, :cl_waiting))
+      assert_equal(0, health.dig(:pgbouncer, :maxwait))
+      # 累計には残る。前回のスクレイプとの差分で「待ちが発生した」と分かる
+      assert_equal(1_500_000, health.dig(:pgbouncer, :total_wait_time_us))
+    end
+
+    # ⚠ SHOW STATS も自分の database の行を選ぶ。
+    def test_cumulative_counter_picks_our_own_database
+      health = with_admin(FakeAdmin.new) {Pgbouncer.health}
+
+      refute_equal(99, health.dig(:pgbouncer, :total_wait_time_us))
     end
 
     def test_connection_is_closed


### PR DESCRIPTION
#4618 の **P1 のみ**（P2 は PR #4660 で着地済み）。方針は issue の**案 1**（`SHOW POOLS` を読む）。

## 何が見えていなかったか

`Postgres.pool` が読むのは **`/health` を処理した Puma プロセスの Sequel プール 1 つ**だけ。
実際に枯れる資源は違う:

- ⚠ **pgbouncer は Mastodon 本体・モロヘイヤの Puma・Sidekiq が共有**していて、`/health` からは一切見えない
- ⚠ 重い SQL を流す `MediaCatalogUpdateWorker` は**別プロセス＝別プール**なので、worker が pgbouncer を占有しても Puma 側の `waiting` には直接出ない

## 実機で確かめてから決めた（本番 4 台）

| ホスト | mulukhiya の DSN | pgbouncer |
| --- | --- | --- |
| zugoga / shallu / gomander | `127.0.0.1:**6432**` | **あり**（`SHOW POOLS` が通る） |
| vulcan | `127.0.0.1:**5432**` | **なし**（Misskey / Linux ＝ cookbook の対象外） |

🎯 **Mastodon 3 台はすでに pgbouncer 経由。**そして **admin コンソールは資格情報を要らない** —
chubo-core の cookbook が `auth_type = trust` / `admin_users = pgbouncer` を書くので、
**アプリの DSN と同じ host:port** へ入れる。⚠ trust はローカルホスト前提で、
**同じ箱で動くプロセスなら誰でも既に持っている経路**。モロヘイヤが新しい権限を得るわけではない。

⚠⚠ **`psql` の出力だけを根拠にしていない。**zugoga の pgbouncer へ **`pg` gem で実際に繋いで**、
列名（`SHOW POOLS` / `SHOW LISTS` / `SHOW CONFIG`）と (database, user) による行の引き当てを確認した。

## 返すもの

```json
"postgres": {
  "status": "OK",
  "pool": {"max": 10, "allocated": 1, "waiting": 0},
  "pgbouncer": {
    "database": "mastodon",
    "cl_active": 12, "cl_waiting": 0, "maxwait": 0,
    "sv_active": 0, "sv_idle": 1,
    "clients_used": 13, "clients_max": 500
  }
}
```

- **`cl_waiting` が本命** — サーバー接続を待っているクライアント数で、**本体 + Puma + Sidekiq の合算**
- `maxwait` — 待ちの最長秒数。⚠ 瞬間値の `cl_waiting` が 0 に戻っていても直前の詰まりが残る
- **`clients_used` / `clients_max`** — ⚠ **2026-08-02 の gomander（FeedUpdateWorker 全滅）も
  2026-08-08 の shallu も `no more connections allowed (max_client_conn)`** で、
  枯れたのは**プールごとの待ちではなく箱全体のクライアント数**だった

## 設計上の判断 3 つ

1. **既定は `auto`**（DSN のポートが 5432 以外なら pgbouncer とみなす）。
   ⚠ **素の PostgreSQL へ `pgbouncer` ユーザーで入りに行かない** — 認証失敗が `/health` を叩くたびに
   PostgreSQL のログへ溜まる。`/postgres/pgbouncer/enable` で `true` / `false` に固定できる
   - ⚠⚠ **`null` を既定値にできない。**Ginseng の config は null を「キーが無い」と同じに扱って
     `ConfigError` を上げる。三値は**文字列**で表す（スキーマは `boolean | "auto"` で弾く。実際に弾くことを確認済み）
2. ⚠⚠ **観測は `status` を動かさない。**pgbouncer の停止と `max_client_conn` 枯渇は
   **接続失敗からは区別できず**、`status` を倒すと再起動のたびに health が揺れて信号として使えなくなる。
   ⚠ 繋がらないこと自体は信号になりうるので、**潰さず `pgbouncer.error` に出す**
3. **`NG` のときも pgbouncer を見る。**「Postgres NG だが pgbouncer は答える」と「両方死んでいる」は
   切り分けが真逆になる

## テスト（`test/unit/dbms/pgbouncer.rb`・14 件）

- **自分と同じ (database, user) の行を選ぶこと** — ⚠ **先頭行を拾う実装に戻すと 2 件落ちる**ことを確認済み
- **`{absent: true}` と `0` を分ける** — 誰も繋いでいなければ行がまだ無い。そこで 0 を出すと「詰まっていない」と読める
- 5432 直結を probe しない / `enable` の明示指定が自動判定に勝つ
- 接続失敗を握り潰さない・**それでも `Postgres.health` の `status` は `OK` のまま**
- クエリ途中で落ちても接続を閉じる

`rake lint`（492 files, no offenses）/ `rake test`（1198 tests, 0 failures, 0 errors）とも緑。
`docs/api.md` の `/health` 契約も追随済み（#4656 の教訓どおり、docs もコードと同じ密度で）。

Closes #4618
