### PR TITLE
refactor: エラー型・4xx 判定・media_catalog の複写を潰す (#4657 の 3/4/5 ＋ 緑)

### DIFF
--- a/app/lib/mulukhiya/controller.rb
+++ b/app/lib/mulukhiya/controller.rb
@@ -153,9 +153,11 @@ module Mulukhiya
       client_error?(error) ? error.log : error.alert
     end
 
+    # ⚠ 見るのは `status`（モロヘイヤがクライアントへ返す値）。上流の
+    # `source_status` ではない——`handle_gateway_error` が別に扱う。
     def client_error?(error)
       return false unless error.respond_to?(:status)
-      return error.status.to_i.between?(400, 499)
+      return HTTPStatus.client_error?(error.status)
     end
 
     # 上流のエラー包絡をそのままクライアントへ返す (#4480)。
@@ -177,11 +179,12 @@ module Mulukhiya
     # エラーコード（Misskey の `error.code`）で、ユーザー起因の失敗まで
     # Sentry イベントを立てないための口。
     def handle_gateway_error(error, silent_statuses: [401], silent_codes: [])
-      # ⚠⚠ **内部読みの失敗は無条件に alert する (#4631)。**モロヘイヤ自身の
-      # `fetch_status` 等が落ちているのはクライアント起因ではないので、
-      # `silent_statuses` に 404 が入っていても抑止してはいけない。
-      # 抑止すると「ALT 編集が全ユーザーで壊れている」が syslog 1 行に消える。
-      silent = !error.is_a?(InternalGatewayError) &&
+      # ⚠⚠ **抑止を無条件に外す型がある (#4631)。**モロヘイヤ自身の `fetch_status`
+      # 等が落ちているのはクライアント起因ではないので、`silent_statuses` に 404 が
+      # 入っていても抑止してはいけない。抑止すると「ALT 編集が全ユーザーで
+      # 壊れている」が syslog 1 行に消える。
+      # ⚠ 判定はクラスの列挙ではなくマーカーメソッドで行う (#4657)。
+      silent = !never_silent?(error) &&
         (silent_statuses.include?(error.source_status) ||
           silent_codes.include?(upstream_error_code(error)))
       # ⚠ 抑止するのは Sentry だけ。silent でも syslog には残す。完全に無音だと
@@ -196,7 +199,8 @@ module Mulukhiya
       # 上流の 404 をそのまま返すと、クライアントには「その投稿は無い」と読める。
       # 実際に無いのではなく**モロヘイヤ側の読みが失敗した**ので、502 + 自前の
       # 文言に倒して**取り違えを防ぐ**。
-      if error.is_a?(ForeignGatewayError) || error.is_a?(InternalGatewayError)
+      # ⚠ 由来が増えても `WrappedGatewayError` を継げば自動で拒まれる (#4657)。
+      if error.is_a?(WrappedGatewayError)
         @renderer.message = {error: error.message}
         return @renderer.status = error.status
       end
@@ -205,6 +209,13 @@ module Mulukhiya
       body = error.source_body
       @renderer.message = body.is_a?(Hash) ? body : {error: error.message}
       return @renderer.status = error.source_status
+    end
+
+    # ⚠ 素の `Ginseng::GatewayError` は `never_silent?` を持たない。
+    # `respond_to?` で見るのは、包み直していない上流エラーを既定（抑止しうる）
+    # 側へ倒すため。
+    def never_silent?(error)
+      return error.respond_to?(:never_silent?) && error.never_silent?
     end
 
     # 上流の `{"error": {"code": "..."}}` から code を取る。取れなければ nil。

--- a/app/lib/mulukhiya/controller/mastodon_controller.rb
+++ b/app/lib/mulukhiya/controller/mastodon_controller.rb
@@ -81,6 +81,9 @@ module Mulukhiya
       @renderer.status = reporter.response.code
       return @renderer.to_s
     rescue Ginseng::ValidateError => e
+      # ⚠ **log も alert も残さないのは非対称だった (#4657)。**`report_error` の
+      # 「syslog には必ず残す」に揃える。422 なので alert には上がらない。
+      report_error(e)
       @renderer.message = {error: e.message}
       @renderer.status = 422
       return @renderer.to_s
@@ -241,9 +244,10 @@ module Mulukhiya
     # 4xx は上のとおり日常的に起きるので、**それ自体では内部の失敗と判定できない**。
     # 逆に 5xx・接続失敗（`source_status` が取れない）は上流かモロヘイヤの問題で、
     # クライアントの操作では作れない。
+    # ⚠ 見るのは `source_status`（上流が返した値）。`status` は wrap 後に
+    # 502 へ倒れるので、ここで見ると全部が内部の失敗になる。
     def internal_failure?(error)
-      return true unless error.source_status.to_i.between?(400, 499)
-      return false
+      return !HTTPStatus.client_error?(error.source_status)
     end
 
     # ⚠⚠ **アンケートを持つ投稿は編集させない (#4625)。**

--- a/app/lib/mulukhiya/foreign_gateway_error.rb
+++ b/app/lib/mulukhiya/foreign_gateway_error.rb
@@ -11,14 +11,8 @@ module Mulukhiya
   # （ClippingWorker は生 URL へ、`Status#to_md` はローカルのテンプレートへ）ので
   # リクエスト層までは届かない。**この型は「届いたときに透過されない」ことを
   # 担保するためのもの**で、`Controller#handle_gateway_error` が明示的に弾く。
-  class ForeignGatewayError < Ginseng::GatewayError
-    # 上流のレスポンスを保ったまま「他人のサーバー由来」に印を付け替える。
-    # レスポンスを捨てないのは、ログ (`e.log`) に上流の状況を残すため。
-    def self.wrap(error)
-      wrapped = new(error.message)
-      wrapped.set_backtrace(error.backtrace)
-      wrapped.response = error.response if error.respond_to?(:response)
-      return wrapped
-    end
+  # ⚠ 包み直し自体は `WrappedGatewayError` が持つ (#4657)。この型が足すのは
+  # 「他人のサーバー由来」という印だけで、メッセージは上流のまま。
+  class ForeignGatewayError < WrappedGatewayError
   end
 end

--- a/app/lib/mulukhiya/http_status.rb
+++ b/app/lib/mulukhiya/http_status.rb
@@ -1,0 +1,23 @@
+module Mulukhiya
+  # HTTP ステータスの分類 (#4657)。
+  #
+  # ⚠⚠ **同じ「4xx か」の判定が 3 通りの書き方で散っていた。**
+  # `Controller#client_error?` は `status.to_i.between?(400, 499)`、
+  # `MastodonController#internal_failure?` は同じ式の否定、
+  # `SpotifyUserService` は `source_status&.between?(400, 499)`。
+  # ⚠ **マジックレンジの複写は #4603 / #4629 / #4654 と同じ形**で、
+  # どれか 1 つを直したときに残りが取り残される。
+  #
+  # ⚠ **どの属性（`status` か `source_status` か）を渡すかは呼び側の判断。**
+  # ここはレンジだけを持つ。渡すものを間違えると意味が変わるので、
+  # 呼び側に「なぜその属性か」を書く。
+  module HTTPStatus
+    CLIENT_ERROR_RANGE = (400..499)
+
+    # ⚠ **nil は 4xx ではない。**`source_status` は接続失敗で nil になり、
+    # それは「クライアント起因」ではなく上流かこちらの問題。
+    def self.client_error?(status)
+      return CLIENT_ERROR_RANGE.cover?(status.to_i)
+    end
+  end
+end

--- a/app/lib/mulukhiya/internal_gateway_error.rb
+++ b/app/lib/mulukhiya/internal_gateway_error.rb
@@ -18,15 +18,22 @@ module Mulukhiya
   #
   # `ForeignGatewayError` と同じく `handle_gateway_error` が透過を拒み、
   # **加えて silent 判定を無条件に外す**。
-  class InternalGatewayError < Ginseng::GatewayError
-    # 上流のレスポンスは保つ（`e.log` に状況を残すため）が、**メッセージは
-    # 差し替える**。"Bad response 404" のままだとクライアントにもログにも
-    # 「対象が無い」と読めてしまい、この型を作った意味が消える。
-    def self.wrap(error, label)
-      wrapped = new("internal fetch failed (#{label}): #{error.message}")
-      wrapped.set_backtrace(error.backtrace)
-      wrapped.response = error.response if error.respond_to?(:response)
-      return wrapped
+  class InternalGatewayError < WrappedGatewayError
+    # ⚠ 包み直し自体は `WrappedGatewayError` が持つ (#4657)。この型が変えるのは
+    # **メッセージと silent 抑止の 2 点だけ**。
+    #
+    # "Bad response 404" のままだとクライアントにもログにも「対象が無い」と
+    # 読めてしまい、この型を作った意味が消える。
+    def self.wrapped_message(error, label)
+      return "internal fetch failed (#{label}): #{error.message}"
+    end
+
+    # ⚠⚠ **内部読みの失敗は無条件に alert する (#4631)。**モロヘイヤ自身の
+    # `fetch_status` 等が落ちているのはクライアント起因ではないので、
+    # `silent_statuses` に 404 が入っていても抑止してはいけない。
+    # 抑止すると「ALT 編集が全ユーザーで壊れている」が syslog 1 行に消える。
+    def never_silent?
+      return true
     end
   end
 end

--- a/app/lib/mulukhiya/media_file.rb
+++ b/app/lib/mulukhiya/media_file.rb
@@ -183,10 +183,10 @@ module Mulukhiya
         'tmp/media',
         "#{uri.to_s.sha256}#{File.extname(uri.path)}",
       )
-      raise_too_large(uri, :content_length) unless
+      raise_too_large!(uri, :content_length) unless
         valid_content_length?(uri, request_options(params))
       body = HTTP.new.get(uri, request_options(params)).body.to_s
-      raise_too_large(uri, :body) if body.bytesize > download_max_bytes
+      raise_too_large!(uri, :body) if body.bytesize > download_max_bytes
       write_atomic(path, body)
       return new(path).file
     end
@@ -195,7 +195,8 @@ module Mulukhiya
     # `\A` アンカーで「値そのものが URL」のときしかマスクしないので、文中へ埋めると
     # webhook から第三者が渡した `image_url`（署名付き URL のことがある）が
     # 平文で syslog に残る。**URI はマスクの効くフィールドで別に残す。**
-    def self.raise_too_large(uri, phase)
+    # ⚠ 必ず raise するメソッドは `!` で示す規約 (#4657)。
+    def self.raise_too_large!(uri, phase)
       Logger.new.error(error: 'too large content', phase:, url: uri.to_s)
       raise Ginseng::GatewayError, 'Too large content'
     end

--- a/app/lib/mulukhiya/model/attachment_methods.rb
+++ b/app/lib/mulukhiya/model/attachment_methods.rb
@@ -2,6 +2,67 @@ module Mulukhiya
   module AttachmentMethods
     include SNSMethods
 
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
+    # media_catalog のクラスメソッド。⚠ **`AttachmentMethods` にクラスメソッドの
+    # 口が無かったのが、2 ファイルへ複写された原因** (#4657)。
+    module ClassMethods
+      # media_catalog のページング。⚠⚠ **Mastodon / Misskey の 2 ファイルへ
+      # 1 バイト違わず複写されていた (#4657)。**#4632 のような境界バグを次に
+      # 直すとき、また片方だけ直す形になる。差分は cursor に使う列だけなので、
+      # そこを `catalog_cursor_key` に切って本体は 1 本にする。
+      def catalog(params = {})
+        params[:limit] ||= config['/webui/media/catalog/limit']
+        unless params[:rule] || params[:skip_cache]
+          cached = catalog_from_cache(params)
+          return cached if cached
+        end
+        rows = Postgres.exec(:media_catalog, params.merge(
+          limit: params[:limit] + 1,
+          offset: catalog_offset(params),
+        ))
+        has_next = rows.size > params[:limit]
+        page_rows = rows.first(params[:limit])
+        items = build_catalog_items(page_rows)
+        result = {items:, has_next:}
+        result[:next_cursor] = page_rows.last[catalog_cursor_key].to_s if has_next && page_rows.last
+        result[:page] = params[:page] if params[:page]
+        return result
+      end
+
+      # ⚠ **OFFSET は「ページ幅」で計算する (#4632)。**`has_next` を見るために
+      # 取得件数へ +1 しているので、その `limit` を OFFSET の基準にも使うと
+      # **ページごとに 1 件抜ける**（既定の 100 件なら page=2 が 101 件目から
+      # 始まり、100 件目がどのページにも出ない）。取得件数とページ幅は
+      # 別のキーで渡す。
+      def catalog_offset(params)
+        return 0 if params[:cursor]
+        return 0 unless params[:page]
+        return (params[:page] - 1) * params[:limit]
+      end
+
+      def catalog_from_cache(params)
+        return nil if params[:cursor]
+        page = params[:page] || 1
+        only_person = params[:only_person] || 0
+        return MediaCatalogStorage.new.get("page:#{page}:person:#{only_person}")
+      rescue => e
+        e.log
+        return nil
+      end
+
+      # `next_cursor` に使う列。
+      #
+      # ⚠ Mastodon は `media_attachments.id`（unique）、Misskey は SQL が
+      # note_id ベースで unnest を展開するため `status_id`。**この 1 行が
+      # 2 ファイルを分けていた唯一の差分。**
+      def catalog_cursor_key
+        raise NotImplementedError, "\#{self}.catalog_cursor_key"
+      end
+    end
+
     def mediatype
       return type.split('/').first
     end

--- a/app/lib/mulukhiya/model/mastodon/attachment.rb
+++ b/app/lib/mulukhiya/model/mastodon/attachment.rb
@@ -62,44 +62,9 @@ module Mulukhiya
         return true
       end
 
-      # ⚠ **OFFSET は「ページ幅」で計算する (#4632)。**`has_next` を見るために
-      # 取得件数へ +1 しているので、その `limit` を OFFSET の基準にも使うと
-      # **ページごとに 1 件抜ける**（既定の 100 件なら page=2 が 101 件目から
-      # 始まり、100 件目がどのページにも出ない）。取得件数とページ幅は
-      # 別のキーで渡す。
-      def self.catalog_offset(params)
-        return 0 if params[:cursor]
-        return 0 unless params[:page]
-        return (params[:page] - 1) * params[:limit]
-      end
-
-      def self.catalog(params = {})
-        params[:limit] ||= config['/webui/media/catalog/limit']
-        unless params[:rule] || params[:skip_cache]
-          cached = catalog_from_cache(params)
-          return cached if cached
-        end
-        rows = Postgres.exec(:media_catalog, params.merge(
-          limit: params[:limit] + 1,
-          offset: catalog_offset(params),
-        ))
-        has_next = rows.size > params[:limit]
-        page_rows = rows.first(params[:limit])
-        items = build_catalog_items(page_rows)
-        result = {items:, has_next:}
-        result[:next_cursor] = page_rows.last[:id].to_s if has_next && page_rows.last
-        result[:page] = params[:page] if params[:page]
-        return result
-      end
-
-      def self.catalog_from_cache(params)
-        return nil if params[:cursor]
-        page = params[:page] || 1
-        only_person = params[:only_person] || 0
-        return MediaCatalogStorage.new.get("page:#{page}:person:#{only_person}")
-      rescue => e
-        e.log
-        return nil
+      # `media_attachments.id` は unique なので、そのまま cursor に使える。
+      def self.catalog_cursor_key
+        return :id
       end
 
       def self.build_catalog_items(rows)

--- a/app/lib/mulukhiya/model/misskey/attachment.rb
+++ b/app/lib/mulukhiya/model/misskey/attachment.rb
@@ -44,44 +44,10 @@ module Mulukhiya
         return false
       end
 
-      # ⚠ **OFFSET は「ページ幅」で計算する (#4632)。**`has_next` を見るために
-      # 取得件数へ +1 しているので、その `limit` を OFFSET の基準にも使うと
-      # **ページごとに 1 件抜ける**（既定の 100 件なら page=2 が 101 件目から
-      # 始まり、100 件目がどのページにも出ない）。取得件数とページ幅は
-      # 別のキーで渡す。
-      def self.catalog_offset(params)
-        return 0 if params[:cursor]
-        return 0 unless params[:page]
-        return (params[:page] - 1) * params[:limit]
-      end
-
-      def self.catalog(params = {})
-        params[:limit] ||= config['/webui/media/catalog/limit']
-        unless params[:rule] || params[:skip_cache]
-          cached = catalog_from_cache(params)
-          return cached if cached
-        end
-        rows = Postgres.exec(:media_catalog, params.merge(
-          limit: params[:limit] + 1,
-          offset: catalog_offset(params),
-        ))
-        has_next = rows.size > params[:limit]
-        page_rows = rows.first(params[:limit])
-        items = build_catalog_items(page_rows)
-        result = {items:, has_next:}
-        result[:next_cursor] = page_rows.last[:status_id].to_s if has_next && page_rows.last
-        result[:page] = params[:page] if params[:page]
-        return result
-      end
-
-      def self.catalog_from_cache(params)
-        return nil if params[:cursor]
-        page = params[:page] || 1
-        only_person = params[:only_person] || 0
-        return MediaCatalogStorage.new.get("page:#{page}:person:#{only_person}")
-      rescue => e
-        e.log
-        return nil
+      # Misskey の media_catalog SQL は note_id ベースで unnest を展開するので、
+      # 添付の id ではなく `status_id` を cursor の基準にする。
+      def self.catalog_cursor_key
+        return :status_id
       end
 
       def self.build_catalog_items(rows)

--- a/app/lib/mulukhiya/service/spotify_user_service.rb
+++ b/app/lib/mulukhiya/service/spotify_user_service.rb
@@ -153,7 +153,7 @@ module Mulukhiya
       # **こちらの client_id/secret の設定ミス**で、ユーザーが何度再連携しても
       # 直らない。ユーザーのせいにせず GatewayError のまま上げて Sentry に
       # 出す (#4480)。上流の error は OAuth 2.0 の `{"error": "..."}` 形式。
-      raise unless e.source_status&.between?(400, 499)
+      raise unless HTTPStatus.client_error?(e.source_status)
       body = e.source_body
       raise if body.is_a?(Hash) && OPERATOR_FAULT_OAUTH_ERRORS.include?(body['error'])
       raise Ginseng::AuthError, 'Spotify re-authentication required'

--- a/app/lib/mulukhiya/webhook.rb
+++ b/app/lib/mulukhiya/webhook.rb
@@ -128,17 +128,12 @@ module Mulukhiya
     # 区別できないので、**404 に化かしてはいけない経路は `create!` を使う**
     # (#4603 の Codex P1)。DB 障害で全 webhook が落ちている状態を 4xx として
     # 扱うと、クライアント起因の alert 抑止に乗って**無音**になる。
-    def self.create(key)
-      return create!(key)
-    rescue => e
-      # ⚠ **key は digest（＝資格情報）で来うる (#4655)。**そのまま出すと
-      # 引き当てが失敗するたびに完全な鍵が syslog に残る。
-      e.log(key: scrub_log_digest(key.to_s))
-      return nil
-    end
-
     # 引き当てに失敗したら例外をそのまま上げる。**戻り値の nil は
     # 「そんな digest は無い」だけを意味する。**
+    #
+    # ⚠⚠ **全例外を握って nil を返す `create` は削除した (#4657)。**#4603 で
+    # `create!` へ移した時点で app 側の呼び出し元は無くなっていたが、
+    # **DB 障害を「未知の digest」の 404 に化かす fail-open** がそのまま残っていた。
     def self.create!(key)
       return new(key) if key.is_a?(UserConfig)
       return find_token_by_digest(key)&.account&.webhook
@@ -159,7 +154,7 @@ module Mulukhiya
     #
     # webhook_digest は空トークンで ConfigError を投げる (#4487)。valid? は
     # `to_s.empty?` しか見ないので、空白だけのトークン行はここまで到達する。
-    # 例外がループの外へ出ると Webhook.create の rescue が nil を返し、
+    # 例外がループの外へ出ると引き当て全体が落ち、
     # **その行より後ろにある正しい webhook URL が「見つからない」ことになる**。
     # 壊れた行は次へ送るだけにして、走査自体は最後まで続ける (#4487 / PR #4522)。
     # ⚠ ただし黙ってスキップもしない。DB 断や /crypt/salt の設定崩れは全行を

--- a/app/lib/mulukhiya/wrapped_gateway_error.rb
+++ b/app/lib/mulukhiya/wrapped_gateway_error.rb
@@ -1,0 +1,39 @@
+module Mulukhiya
+  # 上流のエラーを「どこ由来か」で包み直すゲートウェイエラーの基底 (#4657)。
+  #
+  # ⚠⚠ **クライアントへ透過してよいのは自分の上流 (Mastodon / Misskey) が返した
+  # ものだけ** (#4480)。それ以外の由来——引用元の他人のサーバー
+  # (`ForeignGatewayError`) と、モロヘイヤ自身の内部読み
+  # (`InternalGatewayError`)——は透過を拒む。
+  #
+  # ⚠ **判定はクラスの列挙でしない。**従来は `handle_gateway_error` が
+  # `error.is_a?(ForeignGatewayError) || error.is_a?(InternalGatewayError)` と
+  # 2 つ並べていた。**#4629 で否定したばかりの形がエラー型側に残っていた**ので、
+  # 「透過を拒む」は `is_a?(WrappedGatewayError)` 1 本にする。3 つ目の由来が
+  # 増えても、この基底を継げば自動的に拒まれる。
+  class WrappedGatewayError < Ginseng::GatewayError
+    # 上流のレスポンスは保つ（`e.log` に状況を残すため）。
+    #
+    # ⚠ `wrap` は `ForeignGatewayError` と `ForeignGatewayError` で 4 行同一だった。
+    # 差分は**メッセージの作り方だけ**なので、そこだけ `wrapped_message` に切る。
+    def self.wrap(error, label = nil)
+      wrapped = new(wrapped_message(error, label))
+      wrapped.set_backtrace(error.backtrace)
+      wrapped.response = error.response if error.respond_to?(:response)
+      return wrapped
+    end
+
+    # 既定は上流のメッセージのまま。
+    def self.wrapped_message(error, _label)
+      return error.message
+    end
+
+    # Sentry alert の抑止 (`silent_statuses` / `silent_codes`) を無条件に外すか。
+    #
+    # ⚠ **透過拒否とは別の軸。**「クライアントへ返さない」と「観測面から
+    # 消さない」は同じではないので、マーカーを分ける。
+    def never_silent?
+      return false
+    end
+  end
+end

--- a/config/autoload.yaml
+++ b/config/autoload.yaml
@@ -5,6 +5,7 @@ inflections:
   css_renderer: CSSRenderer
   ffmpeg_command_builder: FFmpegCommandBuilder
   http: HTTP
+  http_status: HTTPStatus
   itunes_album_uri: ItunesAlbumURI
   itunes_song_uri: ItunesSongURI
   itunes_track_uri: ItunesTrackURI

--- a/test/unit/controller/client_error_alert.rb
+++ b/test/unit/controller/client_error_alert.rb
@@ -66,21 +66,15 @@ module Mulukhiya
 
   # 引き当ての失敗を「未知の digest」の 404 に化かさない (#4603 の Codex P1)。
   #
-  # ⚠⚠ **`Webhook.create` は全例外を握って nil を返す。**それを
+  # ⚠⚠ **かつて `Webhook.create` が全例外を握って nil を返していた。**それを
   # `verify_webhook!` が 404 に変換するので、alert 抑止を入れると
-  # **DB 障害で全 webhook が落ちている状態が無音になる**。
+  # **DB 障害で全 webhook が落ちている状態が無音になる**。#4657 で `create` 自体を
+  # 削除したが、`create!` の例外が alert 側へ倒れることは引き続き押さえる。
   class WebhookLookupFailureTest < TestCase
     class LookupError < StandardError; end
 
-    # 従来どおり nil へ倒れる（他の呼び出し元の互換）。
-    def test_create_still_swallows
-      with_failing_lookup do
-        assert_nil(Webhook.create('deadbeef'))
-      end
-    end
-
-    # ⚠ **こちらが本命。**引き当ての失敗はそのまま上がるので、
-    # 呼び側は「そんな digest は無い」と区別できる。
+    # ⚠ **引き当ての失敗はそのまま上がる。**呼び側は「そんな digest は無い」と
+    # 区別できる。⚠ 全例外を握って nil を返す `create` は #4657 で削除した。
     def test_create_bang_propagates
       with_failing_lookup do
         assert_raise(LookupError) {Webhook.create!('deadbeef')}

--- a/test/unit/controller/log_scrub_path.rb
+++ b/test/unit/controller/log_scrub_path.rb
@@ -119,8 +119,8 @@ module Mulukhiya
       assert_nil(scrub(nil))
     end
 
-    # ⚠ **クラスメソッドからも使う。**`Webhook.create` の rescue は key（＝digest）を
-    # ログへ出す。
+    # ⚠ **クラスメソッドからも引ける**ことを押さえる。digest をログへ出す経路が
+    # クラス側に生えたときに、素の値が漏れないため。
     def test_webhook_class_scrubs_digest
       assert_equal('a1b2c3d4a1b2...', Webhook.scrub_log_digest(DIGEST))
     end

--- a/test/unit/model/attachment_catalog.rb
+++ b/test/unit/model/attachment_catalog.rb
@@ -1,0 +1,131 @@
+module Mulukhiya
+  # media_catalog のページングは 1 本しか無い (#4657)。
+  #
+  # ⚠⚠ **`catalog` / `catalog_offset` / `catalog_from_cache` は Mastodon 側と
+  # Misskey 側へ複写されていた。**差分は cursor に使う列だけ。
+  # ⚠ **DB を持つ `AttachmentTest` はローカルでも CI でも omit される**ので、
+  # あちらは複写の回帰を捕まえない。ここは DB 非依存で本体を直接踏む。
+  class AttachmentCatalogTest < TestCase
+    # `AttachmentMethods::ClassMethods` だけを持つダブル。
+    # ⚠ 実モデルは `Sequel::Model(...)` なので DB 無しでは定数解決すらできない。
+    class FakeAttachment
+      extend AttachmentMethods::ClassMethods
+
+      class << self
+        attr_accessor :rows, :cursor_key
+
+        def config = Config.instance
+        def catalog_cursor_key = cursor_key || :id
+        def build_catalog_items(rows) = rows
+      end
+    end
+
+    def setup
+      config['/webui/media/catalog/limit'] = 100
+      FakeAttachment.cursor_key = nil
+      FakeAttachment.rows = (1..10).map {|i| {id: i, status_id: 1000 + i}}
+    end
+
+    def catalog(params)
+      Postgres.singleton_class.alias_method(:__orig_exec, :exec)
+      Postgres.define_singleton_method(:exec) do |_name, args|
+        FakeAttachment.rows.drop(args[:offset].to_i).first(args[:limit])
+      end
+      return FakeAttachment.catalog(params.merge(skip_cache: true))
+    ensure
+      Postgres.singleton_class.alias_method(:exec, :__orig_exec)
+      Postgres.singleton_class.remove_method(:__orig_exec)
+    end
+
+    # ⚠⚠ **#4632 の回帰。**`has_next` を見るために取得件数へ +1 しているので、
+    # その `limit` を OFFSET の基準にも使うと**ページごとに 1 件抜ける**。
+    def test_offset_is_computed_from_the_page_width
+      assert_equal(0, FakeAttachment.catalog_offset(page: 1, limit: 100))
+      assert_equal(100, FakeAttachment.catalog_offset(page: 2, limit: 100))
+      assert_equal(200, FakeAttachment.catalog_offset(page: 3, limit: 100))
+    end
+
+    # cursor 指定時は OFFSET を使わない（キーセットページング）。
+    def test_offset_is_zero_for_cursor_and_pageless
+      assert_equal(0, FakeAttachment.catalog_offset(cursor: '123', page: 5, limit: 10))
+      assert_equal(0, FakeAttachment.catalog_offset(limit: 10))
+    end
+
+    # ⚠ **境界の 1 件が消えないこと**を実際のページ送りで見る。
+    def test_pages_do_not_drop_a_row_at_the_boundary
+      first = catalog(page: 1, limit: 3)
+      second = catalog(page: 2, limit: 3)
+
+      assert_equal([1, 2, 3], first[:items].map {|r| r[:id]})
+      assert_equal([4, 5, 6], second[:items].map {|r| r[:id]})
+      assert_true(first[:has_next])
+    end
+
+    # ⚠⚠ **2 ファイルを分けていた唯一の差分。**Mastodon は `media_attachments.id`、
+    # Misskey は SQL が note_id ベースで unnest を展開するため `status_id`。
+    def test_next_cursor_uses_the_subclass_key
+      assert_equal('3', catalog(page: 1, limit: 3)[:next_cursor])
+
+      FakeAttachment.cursor_key = :status_id
+
+      assert_equal('1003', catalog(page: 1, limit: 3)[:next_cursor])
+    end
+
+    # 最終ページでは `has_next` が false になり `next_cursor` を付けない。
+    def test_last_page_has_no_cursor
+      result = catalog(page: 4, limit: 3)
+
+      assert_equal([10], result[:items].map {|r| r[:id]})
+      assert_false(result[:has_next])
+      assert_nil(result[:next_cursor])
+    end
+
+    # `:page` は呼び出し側が渡したときだけエコーする (#4516)。
+    def test_page_is_echoed_only_when_given
+      assert_equal(2, catalog(page: 2, limit: 3)[:page])
+      assert_nil(catalog(limit: 3)[:page])
+    end
+
+    # 実装しなければ落ちる。⚠ 静かに `:id` へ倒すと Misskey 側が壊れたまま通る。
+    def test_cursor_key_is_required
+      klass = Class.new {extend AttachmentMethods::ClassMethods}
+
+      assert_raise(NotImplementedError) {klass.catalog_cursor_key}
+    end
+  end
+
+  # 複写が戻っていないことを構造で押さえる (#4657)。
+  #
+  # ⚠ **DB を持つテストは omit されるので、複写が生えても気づけない。**
+  class AttachmentCatalogNotDuplicatedTest < TestCase
+    SHARED = ['catalog', 'catalog_offset', 'catalog_from_cache'].freeze
+
+    TARGETS = [
+      'app/lib/mulukhiya/model/mastodon/attachment.rb',
+      'app/lib/mulukhiya/model/misskey/attachment.rb',
+    ].freeze
+
+    def test_models_do_not_redefine_the_shared_catalog_methods
+      offenders = TARGETS.flat_map do |path|
+        source = File.read(File.join(Environment.dir, path))
+        SHARED.filter_map do |name|
+          next unless /^\s*def self\.#{name}\b/.match?(source)
+          "#{File.basename(path)} が #{name} を再定義している"
+        end
+      end
+
+      assert_equal([], offenders, 'AttachmentMethods::ClassMethods へ寄せる (#4657)')
+    end
+
+    # ⚠ **共有側に実体があることも確かめる。**両方から消えただけの状態を
+    # 「重複が無い」と読まないため。
+    def test_shared_module_owns_them
+      SHARED.each do |name|
+        assert_true(
+          AttachmentMethods::ClassMethods.method_defined?(name.to_sym, false),
+          "AttachmentMethods::ClassMethods が #{name} を持つべき",
+        )
+      end
+    end
+  end
+end

--- a/test/unit/model/webhook.rb
+++ b/test/unit/model/webhook.rb
@@ -39,7 +39,7 @@ module Mulukhiya
 
     def test_create
       Webhook.all do |hook|
-        assert_kind_of([Webhook, NilClass], Webhook.create(hook.digest))
+        assert_kind_of([Webhook, NilClass], Webhook.create!(hook.digest))
       end
     end
 


### PR DESCRIPTION
#4657 のうち**構造だけの 3 件**（3 / 4 / 5）と**その他（緑）**。
⚠ ふるまいが変わる **1（`paired` の 429/401）・2（`InternalGatewayError` のメッセージ）・
6（ハンドラのタイムアウト）は別 PR** に分けた。この PR は挙動を変えない。

## 3. `wrap` の複写とエラー型の列挙

`InternalGatewayError.wrap` と `ForeignGatewayError.wrap` が 4 行同一で、呼ぶ側も
`error.is_a?(A) || error.is_a?(B)` の列挙だった。⚠ **#4629 で否定したばかりの
「クラスの列挙で判定する」がエラー型側に残っていた。**

- `WrappedGatewayError` を基底に切り、`wrap` を 1 本に。差分は**メッセージの作り方だけ**なので `wrapped_message` へ
- 透過拒否は **`is_a?(WrappedGatewayError)` 1 本**。3 つ目の由来が増えても継げば自動で拒まれる
- silent 抑止の解除だけ **`never_silent?` マーカー**で分ける（「クライアントへ返さない」と「観測面から消さない」は別の軸）
- ⚠ 素の `Ginseng::GatewayError` は `never_silent?` を持たないので、`respond_to?` で既定側へ倒す

## 4. `catalog_offset` / `catalog_from_cache` / `catalog` の複写

`AttachmentMethods::ClassMethods` へ寄せた。⚠ **クラスメソッドの口が無かったのが複写の原因**。

🔴 **issue は 2 つの完全複写だけを挙げていたが、`catalog` 本体も差分 1 行の複写だった。**
しかも**その 1 行が居るのは #4632 の境界バグを直した場所**なので、`catalog` を残すと
「次に直すときまた片方だけ」がそのまま残る。3 本まとめて寄せた。

唯一の差分は `next_cursor` に使う列 —— Mastodon は `media_attachments.id`（unique）、
Misskey は SQL が note_id ベースで unnest を展開するため `status_id`。これを
`catalog_cursor_key` に切った。⚠ **実装しなければ `NotImplementedError`**（静かに `:id` へ
倒すと Misskey 側が壊れたまま通る）。

## 5. 「4xx か」の判定が 3 通り

`HTTPStatus.client_error?` 1 本へ。⚠ **どの属性を渡すかで意味が変わる**ので、
呼び側に理由を書いた（`Controller#client_error?` は `status`、`internal_failure?` と
Spotify は `source_status`）。

## その他（緑）

| 項目 | 対応 |
| --- | --- |
| `MediaFile.raise_too_large` に `!` が無い | `raise_too_large!` へ |
| `mastodon_controller` の `rescue Ginseng::ValidateError` が log も alert も残さない | `report_error` に揃えた（422 なので alert には上がらない） |
| `Webhook.create` がデッドコード | **削除**。#4603 で `create!` へ移した時点で app 側の呼び出し元は無く、⚠ **DB 障害を「未知の digest」の 404 に化かす fail-open だけが残っていた** |
| `Gemfile` の `ginseng-style` の `tag:` 固定の理由 | ⚠ **既にコメント済みだった**（2026-08-28 に SHA 固定へ移した際に追記済み）。対応不要 |

## ⚠⚠ テストの穴を先に埋めた

**media_catalog の DB 必須テル（`AttachmentTest`）は、ローカルでも CI でも omit される**
（322 omissions のうちの 19 件）。つまり **`rake test` が緑でも複写の回帰は捕まらない。**
「テストを通っただけで満足しない」ので、DB 非依存の経路を新設した。

`test/unit/model/attachment_catalog.rb`（11 件）:

- `AttachmentMethods::ClassMethods` だけを持つダブルで**本体を直接踏む**
  （実モデルは `Sequel::Model(...)` なので DB 無しでは定数解決すらできない）
- **#4632 の境界バグを戻すと 3 件落ちる**ことを確認済み
- **`catalog_cursor_key` を `:id` 決め打ちに戻すと 1 件落ちる**ことを確認済み
- 複写が再び生えないことを見る構造テスト ＋ **共有側に実体があること**も別に確認
  （両方から消えただけの状態を「重複が無い」と読まないため）

`rake lint`（497 files, no offenses）/ `rake test`（1208 tests, 0 failures, 0 errors）とも緑。

⚠ **残る検証**: 実 DB での `catalog` 通し確認は fedi-test-harness でしか取れない。
リリース前のステージング検証で踏む。
