### PR TITLE
chore: ginseng-style を v1.1.12 に上げる

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ group :development do
   # RuboCop 設定の正本。本体と minitest/performance/rake プラグインもこの gem が抱える。
   # ⚠⚠ タグではなく SHA で固定する（pooza/ginseng-style#75）。タグは付け替えられる。
   gem 'ginseng-style', github: 'pooza/ginseng-style',
-    ref: '91c49d3b512a31dcd714baf156cd253b84eb4f0f', require: false # v1.1.11
+    ref: 'ed862dcf9550d704ee670f65a30a333a694b883a', require: false # v1.1.12
   gem 'ostruct' # https://github.com/pooza/mulukhiya-toot-proxy/issues/4229
   gem 'rack-test'
   gem 'rails-erb-lint'

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,8 @@ gem 'concurrent-ruby'
 gem 'dry-validation'
 gem 'faye-websocket', github: 'pooza/faye-websocket-ruby'
 gem 'ginseng-core', github: 'pooza/ginseng-core', branch: 'main', require: 'ginseng'
-gem 'ginseng-fediverse', github: 'pooza/ginseng-fediverse', branch: 'main', require: 'ginseng/fediverse'
+gem 'ginseng-fediverse', github: 'pooza/ginseng-fediverse', branch: 'main',
+  require: 'ginseng/fediverse'
 gem 'ginseng-piefed', github: 'pooza/ginseng-piefed', branch: 'main', require: 'ginseng/piefed'
 gem 'ginseng-postgres', github: 'pooza/ginseng-postgres', branch: 'main'
 gem 'ginseng-redis', github: 'pooza/ginseng-redis', branch: 'main', require: 'ginseng/redis'
@@ -32,7 +33,7 @@ group :development do
   # RuboCop 設定の正本。本体と minitest/performance/rake プラグインもこの gem が抱える。
   # ⚠⚠ タグではなく SHA で固定する（pooza/ginseng-style#75）。タグは付け替えられる。
   gem 'ginseng-style', github: 'pooza/ginseng-style',
-      ref: 'e5917622d069be324c6879c2a1d2522069d48d2c', require: false # v1.1.10
+    ref: '91c49d3b512a31dcd714baf156cd253b84eb4f0f', require: false # v1.1.11
   gem 'ostruct' # https://github.com/pooza/mulukhiya-toot-proxy/issues/4229
   gem 'rack-test'
   gem 'rails-erb-lint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,14 +73,14 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-style.git
-  revision: 91c49d3b512a31dcd714baf156cd253b84eb4f0f
-  ref: 91c49d3b512a31dcd714baf156cd253b84eb4f0f
+  revision: ed862dcf9550d704ee670f65a30a333a694b883a
+  ref: ed862dcf9550d704ee670f65a30a333a694b883a
   specs:
-    ginseng-style (1.1.11)
-      rubocop
-      rubocop-minitest
-      rubocop-performance
-      rubocop-rake
+    ginseng-style (1.1.12)
+      rubocop (~> 1.90.0)
+      rubocop-minitest (~> 0.40.0)
+      rubocop-performance (~> 1.27.0)
+      rubocop-rake (~> 0.7.1)
 
 GIT
   remote: https://github.com/pooza/ginseng-web.git

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,10 +73,10 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-style.git
-  revision: e5917622d069be324c6879c2a1d2522069d48d2c
-  ref: e5917622d069be324c6879c2a1d2522069d48d2c
+  revision: 91c49d3b512a31dcd714baf156cd253b84eb4f0f
+  ref: 91c49d3b512a31dcd714baf156cd253b84eb4f0f
   specs:
-    ginseng-style (1.1.10)
+    ginseng-style (1.1.11)
       rubocop
       rubocop-minitest
       rubocop-performance


### PR DESCRIPTION
## なぜ

pooza/ginseng-style を **v1.1.4 → v1.1.11** へ上げる。⚠ **v1.1.11 で `AllCops/Include` に `**/Gemfile` と `**/*.gemspec` が入った**（pooza/ginseng-style#80）。

🔴 **`Include` は rubocop 既定の配列を「置換」する**ので、3 つしか書いていなかったこれまで、**`Gemfile` と `*.gemspec` はどのリポジトリでも lint されていなかった**。⚠ 実例として `ginseng-core` の `Gemfile` には 10 スペース字下げの行が残っていた（誰も気づかなかった）。

⚠ **cop の設定は v1.1.4 から変わっていない**（v1.1.5〜v1.1.10 は docs と配布物の整理）。**この PR で lint の結果が変わるのは、新しく対象になった 2 ファイルの分だけ。**

## 直した offense

`Gemfile` の `Layout/LineLength` ほか 4 件。すべて `rubocop -a` で直った。⚠ **参照は SHA 固定のまま**（`# v1.1.11` のコメントも更新）。

## ⚠ `Gemspec/RequiredRubyVersion` は正本で切った

`required_ruby_version`（どの版に入るか ＝ 利用側の最低版）と `TargetRubyVersion`（どの版向けに lint するか ＝ 揃えたい版）は**決め方が違う**ので、等しさを要求するこの cop は切ってある。⚠ `--show-cops` の差分はこの 1 か所だけ。

## 確認したこと

- `bundle exec rubocop`: **498 files inspected, no offenses detected**
- ⚠ **`Gemfile.lock` の差分は `ginseng-style` の GIT ブロックだけ**（development 依存）。**実行時の依存は 1 行も動いていない**


⚠ **マージの判断と時期はそちらでどうぞ。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)