### PR TITLE
fix: rc.d の保険 pkill が proctitle と一致せず孤児を落とせない (#4675)

### DIFF
--- a/app/initializer/sidekiq.rb
+++ b/app/initializer/sidekiq.rb
@@ -20,6 +20,10 @@ module Mulukhiya
   Sidekiq.configure_server do |sidekiq|
     sidekiq.redis = {url: config.dig(:redis, :dsn)}
     sidekiq.concurrency = config[:concurrency]
+    # ⚠⚠ **停止の締切を上流の既定に任せない (#4675 の Codex P1)。**rc.d の
+    # `mulukhiya_sidekiq_kill_wait` はこの値より長くなければならず、暗黙の既定の
+    # ままだと上流のバージョン更新で黙って食い違う。詳細は SHUTDOWN_TIMEOUT。
+    sidekiq.timeout = SidekiqDaemon::SHUTDOWN_TIMEOUT
     # Sidekiq 内部ログ (retry / scheduler / boot 等) を $stdout ではなく syslog へ。
     # Ginseng::Logger と同じ ident (Package.name) / facility (LOG_USER) を使い、puma・
     # WorkerLoggingMiddleware と同じ /var/log/mulukhiya-toot-proxy.log に集約する (#4362)。

--- a/app/lib/mulukhiya/daemon/sidekiq_daemon.rb
+++ b/app/lib/mulukhiya/daemon/sidekiq_daemon.rb
@@ -5,6 +5,18 @@ module Mulukhiya
     include Package
     extend DaemonHealthMethods
 
+    # 停止要求から hard shutdown（積み残しをキューへ戻す経路）までの締切 (秒)。
+    #
+    # ⚠⚠ **rc.d の `mulukhiya_sidekiq_kill_wait` と対になる値 (#4675 の Codex P1)。**
+    # rc.d の SIGKILL がこの締切より先に撃たれると、Sidekiq は hard shutdown へ
+    # 到達できない。⚠ **本リポジトリのワーカーは 15 本中 14 本が `retry: false`**
+    # なので、その仕事は再送もされずに**消える**。
+    #
+    # ⚠ 値そのものは Sidekiq 8.1.7 の既定と同じだが、**既定に任せない**。
+    # 上流が既定を動かすと rc.d 側と黙って食い違うため、ここで明示して
+    # `test/unit/daemon/sidekiq_daemon.rb` から rc.d の待ち時間と突き合わせる。
+    SHUTDOWN_TIMEOUT = 25
+
     def command
       return CommandLine.new([
         'sidekiq',

--- a/config/sample/freebsd/mulukhiya-listener
+++ b/config/sample/freebsd/mulukhiya-listener
@@ -24,6 +24,11 @@ export LC_ALL=ja_JP.UTF-8
 start_cmd=${name}_start
 stop_cmd=${name}_stop
 
+# listener は proctitle が "ruby: bin/listener_daemon.rb start" のままなので、
+# パターンは daemon スクリプト名で足りる (#4675)。
+mulukhiya_listener_pattern='listener_daemon\.rb'
+mulukhiya_listener_kill_wait=20
+
 mulukhiya_listener_start() {
   cd $mulukhiya_path
   sudo -u $mulukhiya_user /usr/sbin/daemon \
@@ -33,7 +38,17 @@ mulukhiya_listener_start() {
 mulukhiya_listener_stop() {
   cd $mulukhiya_path
   sudo -u $mulukhiya_user /usr/local/bin/bash -lc 'bundle exec bin/listener_daemon.rb stop' 2>/dev/null
-  pkill -9 -u $mulukhiya_user -f 'listener_daemon.rb' 2>/dev/null
+  # pid ファイルから辿れない取り残しにも TERM を送る (#4675)。
+  pkill -u $mulukhiya_user -f "$mulukhiya_listener_pattern" 2>/dev/null
+  # ⚠ SIGKILL の前に落ちきるのを待つ。待たずに -9 を撃つと、graceful stop の
+  # 直後に in-flight の処理を毎回強制終了することになる。
+  _i=0
+  while [ $_i -lt $mulukhiya_listener_kill_wait ]; do
+    pgrep -u $mulukhiya_user -f "$mulukhiya_listener_pattern" >/dev/null 2>&1 || return 0
+    sleep 1
+    _i=$((_i + 1))
+  done
+  pkill -9 -u $mulukhiya_user -f "$mulukhiya_listener_pattern" 2>/dev/null
   sleep 2
 }
 

--- a/config/sample/freebsd/mulukhiya-puma
+++ b/config/sample/freebsd/mulukhiya-puma
@@ -24,6 +24,14 @@ export LC_ALL=ja_JP.UTF-8
 start_cmd=${name}_start
 stop_cmd=${name}_stop
 
+# ⚠ puma も proctitle を "ruby: puma <version> (tcp://...) [mulukhiya-toot-proxy]"
+# へ書き換えるので、'puma_daemon.rb' だけでは一致しない (#4675)。cluster 時の
+# ワーカーは "puma: cluster worker ..." なので、区切りに [ :] を許している。
+# ⚠ 同じユーザーで動く Mastodon 側の puma を巻き込まないよう、必ず
+# mulukhiya-toot-proxy まで含めて絞ること。
+mulukhiya_puma_pattern='puma_daemon\.rb|puma[ :].*mulukhiya-toot-proxy'
+mulukhiya_puma_kill_wait=20
+
 mulukhiya_puma_start() {
   cd $mulukhiya_path
   sudo -u $mulukhiya_user /usr/sbin/daemon \
@@ -33,7 +41,17 @@ mulukhiya_puma_start() {
 mulukhiya_puma_stop() {
   cd $mulukhiya_path
   sudo -u $mulukhiya_user /usr/local/bin/bash -lc 'bundle exec bin/puma_daemon.rb stop' 2>/dev/null
-  pkill -9 -u $mulukhiya_user -f 'puma_daemon.rb' 2>/dev/null
+  # pid ファイルから辿れない取り残しにも TERM を送る (#4675)。
+  pkill -u $mulukhiya_user -f "$mulukhiya_puma_pattern" 2>/dev/null
+  # ⚠ SIGKILL の前に落ちきるのを待つ。待たずに -9 を撃つと、graceful stop の
+  # 直後に in-flight の処理を毎回強制終了することになる。
+  _i=0
+  while [ $_i -lt $mulukhiya_puma_kill_wait ]; do
+    pgrep -u $mulukhiya_user -f "$mulukhiya_puma_pattern" >/dev/null 2>&1 || return 0
+    sleep 1
+    _i=$((_i + 1))
+  done
+  pkill -9 -u $mulukhiya_user -f "$mulukhiya_puma_pattern" 2>/dev/null
   sleep 2
 }
 

--- a/config/sample/freebsd/mulukhiya-sidekiq
+++ b/config/sample/freebsd/mulukhiya-sidekiq
@@ -30,7 +30,14 @@ stop_cmd=${name}_stop
 # ⚠ 同じユーザーで動く Mastodon 側の sidekiq (proctitle は "sidekiq <version>
 # mastodon") を巻き込まないよう、必ず mulukhiya-toot-proxy まで含めて絞ること。
 mulukhiya_sidekiq_pattern='sidekiq_daemon\.rb|sidekiq .*mulukhiya-toot-proxy'
-mulukhiya_sidekiq_kill_wait=20
+# ⚠⚠ **Sidekiq の停止の締切 (SidekiqDaemon::SHUTDOWN_TIMEOUT = 25 秒) より長くする
+# こと (#4675 の Codex P1)。**短いと SIGKILL が hard shutdown より先に撃たれ、
+# Sidekiq は「積み残しをキューへ戻す」経路へ到達できない。
+# ⚠ モロヘイヤのワーカーは 15 本中 14 本が `retry: false` なので、そこで落ちた
+# 仕事は**再送もされずに消える**。
+# ⚠ 突き合わせは test/unit/daemon/sidekiq_daemon.rb が自動で行う（この行の値を
+# 直接読んでいる）。片方だけ動かすとテストが落ちる。
+mulukhiya_sidekiq_kill_wait=30
 
 mulukhiya_sidekiq_start() {
   cd $mulukhiya_path

--- a/config/sample/freebsd/mulukhiya-sidekiq
+++ b/config/sample/freebsd/mulukhiya-sidekiq
@@ -24,6 +24,14 @@ export LC_ALL=ja_JP.UTF-8
 start_cmd=${name}_start
 stop_cmd=${name}_stop
 
+# ⚠ sidekiq は proctitle を "ruby: sidekiq <version> mulukhiya-toot-proxy ..." へ
+# 書き換えるので、'sidekiq_daemon.rb' だけでは一致しない。この保険は導入以来ずっと
+# 空振りしており、pid ファイルから辿れない 2 本目を落とせなかった (#4675)。
+# ⚠ 同じユーザーで動く Mastodon 側の sidekiq (proctitle は "sidekiq <version>
+# mastodon") を巻き込まないよう、必ず mulukhiya-toot-proxy まで含めて絞ること。
+mulukhiya_sidekiq_pattern='sidekiq_daemon\.rb|sidekiq .*mulukhiya-toot-proxy'
+mulukhiya_sidekiq_kill_wait=20
+
 mulukhiya_sidekiq_start() {
   cd $mulukhiya_path
   sudo -u $mulukhiya_user /usr/sbin/daemon \
@@ -33,7 +41,17 @@ mulukhiya_sidekiq_start() {
 mulukhiya_sidekiq_stop() {
   cd $mulukhiya_path
   sudo -u $mulukhiya_user /usr/local/bin/bash -lc 'bundle exec bin/sidekiq_daemon.rb stop' 2>/dev/null
-  pkill -9 -u $mulukhiya_user -f 'sidekiq_daemon.rb' 2>/dev/null
+  # pid ファイルから辿れない取り残しにも TERM を送る (#4675)。
+  pkill -u $mulukhiya_user -f "$mulukhiya_sidekiq_pattern" 2>/dev/null
+  # ⚠ SIGKILL の前に落ちきるのを待つ。待たずに -9 を撃つと、graceful stop の
+  # 直後に in-flight の処理を毎回強制終了することになる。
+  _i=0
+  while [ $_i -lt $mulukhiya_sidekiq_kill_wait ]; do
+    pgrep -u $mulukhiya_user -f "$mulukhiya_sidekiq_pattern" >/dev/null 2>&1 || return 0
+    sleep 1
+    _i=$((_i + 1))
+  done
+  pkill -9 -u $mulukhiya_user -f "$mulukhiya_sidekiq_pattern" 2>/dev/null
   sleep 2
 }
 

--- a/test/unit/daemon/sidekiq_daemon.rb
+++ b/test/unit/daemon/sidekiq_daemon.rb
@@ -23,5 +23,34 @@ module Mulukhiya
     def test_disable?
       assert_false(SidekiqDaemon.disable?)
     end
+
+    # ⚠⚠ **rc.d の SIGKILL は Sidekiq の停止の締切より後に撃つ (#4675 の Codex P1)。**
+    # 先に撃つと hard shutdown（積み残しをキューへ戻す経路）へ到達できず、
+    # ⚠ ワーカーの 15 本中 14 本が `retry: false` なので**その仕事は消える**。
+    #
+    # ⚠ 「シェルスクリプトだから検査できない」で放置すると、片方だけ動かした時に
+    # 誰も気づけない。値を直接読んで突き合わせる。
+    def test_rcd_waits_past_the_shutdown_deadline
+      assert_operator(
+        rcd_kill_wait, :>, SidekiqDaemon::SHUTDOWN_TIMEOUT,
+        'rc.d の SIGKILL が Sidekiq の hard shutdown より先に撃たれる'
+      )
+    end
+
+    # 締切そのものを上流の既定に委ねない。委ねると Sidekiq のバージョン更新で
+    # rc.d 側と黙って食い違う。
+    def test_shutdown_timeout_is_explicit
+      assert_kind_of(Integer, SidekiqDaemon::SHUTDOWN_TIMEOUT)
+      assert_operator(SidekiqDaemon::SHUTDOWN_TIMEOUT, :>, 0)
+    end
+
+    private
+
+    def rcd_kill_wait
+      path = File.join(Environment.dir, 'config/sample/freebsd/mulukhiya-sidekiq')
+      matched = File.read(path)[/^mulukhiya_sidekiq_kill_wait=(\d+)$/, 1]
+      raise "mulukhiya_sidekiq_kill_wait not found in #{path}" unless matched
+      return matched.to_i
+    end
   end
 end


### PR DESCRIPTION
#4675 の本リポジトリ側（5.36.0 スコープ）。

## 直したこと

sidekiq と puma は proctitle を書き換えるため、rc.d の stop の保険だった `pkill -f '*_daemon.rb'` が**導入以来ずっと空振り**していた。pid ファイルは最後に `write_pid` した 1 本しか記録しないので、boot 時の競合で立った 2 本目はどこからも辿れず、`service mulukhiya-sidekiq restart` を打っても残り続ける。実際に gomander で sidekiq が 2 本になり、スケジューラが二重に回って「起動完了」通知が 5 分ごとに再送された（`feed_update` / `program_update` / `annict_polling` も二重投入されていた）。

1. **pkill / pgrep のパターンを実 proctitle に合わせた**
2. **pid ファイルから辿れない取り残しにも TERM を送るようにした**
3. **SIGKILL の前に停止を待つようにした（最大 20 秒）**

3. は 1. の副作用への対処。パターンを効くようにすると、猶予ゼロで `-9` が届き graceful stop の直後に in-flight の処理を毎回強制終了することになる。なお **listener はパターンが元から一致していたため、この待ちが無いまま毎回 SIGKILL されていた**（同じ欠陥の別の顔）ので、3 本とも同じ形に揃えた。

## パターンの検証

同じ `mastodon` ユーザーで Mastodon と cure-api も動いているため、巻き込みが致命的になる。gomander の実プロセスに対して `pgrep` で確認した:

| パターン | 一致 |
|---|---|
| `sidekiq_daemon\.rb｜sidekiq .*mulukhiya-toot-proxy` | 1986 `ruby: sidekiq 8.1.7 mulukhiya-toot-proxy` のみ |
| `puma_daemon\.rb｜puma[ :].*mulukhiya-toot-proxy` | 1752 `ruby: puma 8.0.2 (tcp://0.0.0.0:3008) [mulukhiya-toot-proxy]` のみ |
| `listener_daemon\.rb` | 1787 `ruby: bin/listener_daemon.rb start` のみ |

一致**しない**ことを確認した同ユーザーのプロセス:

```
1767   ruby: puma 8.0.2 (tcp://0.0.0.0:3009) [cure-api]
2078   ruby: puma 8.0.2 (tcp://127.0.0.1:3000) [mastodon]
2132   ruby: puma: cluster worker 0: 2078 [mastodon]
2133   ruby: puma: cluster worker 1: 2078 [mastodon]
31511  ruby: sidekiq 8.1.6 mastodon [0 of 20 busy]
```

puma のパターンで区切りを `[ :]` にしているのは、cluster 時のワーカーが `puma: cluster worker ...` になるため（mulukhiya は現状 single だが、mastodon 側の実例の通り形が変わる）。3 本とも `sh -n` で構文チェック済み。

## この PR で直らないこと

**二重起動そのものは防げない。** 引き金は別リポジトリにある:

- pooza/chubo-core#37 — monit に起動猶予が無く、boot 直後の初回チェックが rc.d の起動と競合する
- pooza/ginseng-core#622 — `Daemon#abort_if_running!` の check-then-write で同時 start が 2 本ともすり抜ける（本丸）

この PR で担保できるのは「起きても `service mulukhiya-<daemon> restart` で確実に 1 本へ収束できる」ところまで。現状は孤児が残るため手動 kill が要る（2026-08-31 の gomander で実際に手動 kill した）。

## デプロイ時の注意

`config/sample/freebsd/` は**サンプルであって配布物ではない**。反映するには各ホストの `/usr/local/etc/rc.d/mulukhiya-{sidekiq,puma,listener}` へ手で置き換える必要がある。現在 gomander の実ファイルは変更前のサンプルと同一であることを確認済み。
