### PR TITLE
deps: 宣言した 4 つに require: false を付ける (#4680)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,8 +30,15 @@ gem 'puma', '~> 8.0'
 # 事故で、⚠ CVE になっておらず原因も未特定なので advisory では判定できない。
 # ⚠⚠ 上限を外してよい条件は #4678（同時アクセスの回帰テスト）が緑になること。
 # それまで sinatra 4.3 系 / rack 3.3 系へは動かさない。
-gem 'rack', '~> 3.2.5' # 2026-02 の同時アクセステスト (500 req × 2 並列・不整合 0、#4055) が通った版
-gem 'rack-session', '>= 2.1.1' # ⚠ ginseng-web の床をそのまま移すだけ。事故との関係は無い
+#
+# ⚠⚠ **4 つとも `require: false` (#4680)。**宣言の目的は**版の制約だけ**で、ロードの
+# 指示ではない。🔴 付けないと `Bundler.require` がトップレベルの sinatra
+# ＝ `sinatra/main` を読み、**classic の Sinatra::Application と at_exit runner** が入る
+# （モロヘイヤは controller.rb で `sinatra/base` だけを使っている）。
+# ⚠ Rack::Utils / Rack::Session::Cookie / Rack::URLMap / Rack::Auth::Basic は
+# `sinatra/base` 経由で入るので、`require: false` でも解決できる（実測）。
+gem 'rack', '~> 3.2.5', require: false # 2026-02 の同時アクセステスト (500 req × 2 並列・不整合 0、#4055) が通った版
+gem 'rack-session', '>= 2.1.1', require: false # ⚠ ginseng-web の床をそのまま移すだけ。事故との関係は無い
 gem 'rspotify', github: 'pooza/rspotify', branch: 'master.pooza'
 gem 'ruby-progressbar'
 gem 'ruby-vips', require: 'vips'
@@ -39,8 +46,8 @@ gem 'sentry-ruby'
 gem 'sentry-sidekiq'
 gem 'sidekiq', '~>8.1'
 gem 'sidekiq-scheduler', '~>6.0.1'
-gem 'sinatra', '~> 4.2.1' # 🔴 事故版は 4.2.0。4.2.1 は本番 4 台で 2026-08-09 から無事故 (#4508)
-gem 'tilt', '>= 2.1.0' # ⚠ ginseng-web の床をそのまま移すだけ。事故との関係は無い
+gem 'sinatra', '~> 4.2.1', require: false # 🔴 事故版は 4.2.0。4.2.1 は本番 4 台で 2026-08-09 から無事故 (#4508)
+gem 'tilt', '>= 2.1.0', require: false # ⚠ ginseng-web の床をそのまま移すだけ。事故との関係は無い
 group :development do
   gem 'bundler-audit'
   # RuboCop 設定の正本。本体と minitest/performance/rake プラグインもこの gem が抱える。

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1326,6 +1326,36 @@ DB 直読み層（account / status / attachment / postgres）も **omission 0 �
 どちらも現行と同じ）。**将来 4.3 / 3.3 が出たときに効く予防**であって、
 **外してよい条件は #4678 が緑になること**。
 
+#### ⚠⚠ 宣言を足すと `Bundler.require` の対象が増える（#4680・2026-09-06）
+
+**#4663 の ② で入れた退行。**気づいたのは **pooza/cure-api#360 に届いた Codex P1** で、
+⚠ **同じ形がモロヘイヤにもあった**（`app/lib/mulukhiya.rb:111` の `Bundler.require`）。
+
+🔴 **`Gemfile` に書いた gem は `Bundler.require` が全部 require する。**`sinatra` の
+トップレベルは `sinatra/main` で、**classic の `at_exit` runner** を仕込む。モロヘイヤは
+意図して `sinatra/base` だけを使っている（`controller.rb:1`）のに、宣言を足したことで
+`sinatra/main` まで読まれるようになっていた。
+
+| | #4679 の前 | #4679 の後 | `require: false` 後 |
+| --- | --- | --- | --- |
+| `sinatra/main` | 読まない | 🔴 **読む** | 読まない |
+| `Sinatra::Application.app_file` | `nil` | gem 側のファイル | `nil` |
+
+⚠ **`Sinatra::Application` という定数自体は `sinatra/base` が定義する。**`sinatra/main` が
+足すのは **`at_exit` runner** のほう。**「定数があるから classic が入っている」ではない。**
+
+⚠ **Codex の帰結部分（意図しない classic サーバーが起動しうる）はモロヘイヤでは再現しない**
+（`run?` が真でも `run!` を呼ぶのは `sinatra/main` の `at_exit` だけで、それが読まれていない）。
+🔴 **それでも直す。**`app_file` が何に解決されるかは**ロード順に依存する**ので、
+依存が 1 本増減しただけで変わりうる。偶然で成り立っている状態を残す理由が無い。
+
+✅ **`require: false` が #4679 以前と等価であることは実機で確かめた**
+（`6799ffcf` の worktree と突き合わせて、上の表の 1 列目と 3 列目が完全に一致）。
+
+⚠ **宣言の目的は「版の制約」であって「ロードの指示」ではない**、が一般則。
+`Rack::Utils` / `Rack::Session::Cookie` / `Rack::URLMap` / `Rack::Auth::Basic` は
+`sinatra/base` 経由で入るので `require: false` でも解決できる（実測）。
+
 #### ⚠ 依存の削除は 3 リポジトリの連鎖になる（2026-09-06 時点の現在地）
 
 **順序を間違えると `bundle install` が壊れる。**


### PR DESCRIPTION
#4663 の ②（PR #4679）で入れた退行の是正。**気づいたのは pooza/cure-api#360 に届いた Codex P1** で、⚠ **同じ形がモロヘイヤにもありました**（`app/lib/mulukhiya.rb:111` の `Bundler.require`）。

## 何が起きていたか

🔴 **`Gemfile` に書いた gem は `Bundler.require` が全部 require する。**`sinatra` のトップレベルは `sinatra/main` で、**classic の `at_exit` runner** を仕込みます。モロヘイヤは意図して `sinatra/base` だけを使っている（`controller.rb:1`）のに、#4679 で宣言を足したせいで `sinatra/main` まで読まれていました。

| | #4679 の前 | #4679 の後 | 本 PR 後 |
| --- | --- | --- | --- |
| `sinatra/main` | 読まない | 🔴 **読む** | 読まない |
| `Sinatra::Application.app_file` | `nil` | gem 側のファイル | `nil` |

⚠ **`Sinatra::Application` という定数自体は `sinatra/base` が定義します。**`sinatra/main` が足すのは `at_exit` runner のほう。**「定数があるから classic が入っている」ではない**ので、そこを混ぜないこと。

## ⚠ Codex の帰結部分は再現しません。それでも直します

「意図しない classic サーバーが起動しうる」までは**モロヘイヤでは成立しません** — `run!` を呼ぶのは `sinatra/main` の `at_exit` だけで、それが読まれていないからです。

🔴 **それでも直す理由**: `app_file` が何に解決されるかは**ロード順に依存する**ので、依存が 1 本増減しただけで変わりえます。偶然で成り立っている状態を残す理由がありません。

⚠ 一般則として、**宣言の目的は「版の制約」であって「ロードの指示」ではない**。Gemfile にコメントで残しました。

## 検証

✅ **`require: false` が #4679 以前と等価であることを実機で確認**しました。`6799ffcf`（#4679 の 1 つ前）の worktree を立てて突き合わせ、上の表の **1 列目と 3 列目が完全に一致**します。

⚠ `Rack::Utils` / `Rack::Session::Cookie` / `Rack::URLMap` / `Rack::Auth::Basic` は宣言が無くても `sinatra/base` 経由で入るので、`require: false` でも解決できます（6 定数を実際に `const_get` して確認）。`tilt` の直接参照は `grep` で 0 件。

`Gemfile.lock` は **1 行も動きません**。`rake lint` 緑・`rake test` **1208 tests / 1716 assertions / 0 failures / 0 errors / 322 omissions**。

## ⚠ cure-api 側にも同じ修正が要ります

pooza/cure-api#360 の Codex P1 がまさにそれですが、**あちらの持ち物**なので触っていません。

Closes #4680

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk1GcwnxVpQX4yMPgwjuMy
