### PR TITLE
fix: Handler#summary が result を壊し、syslog にエラーが二重で出る (#4682)

### DIFF
--- a/app/lib/mulukhiya/handler.rb
+++ b/app/lib/mulukhiya/handler.rb
@@ -116,7 +116,10 @@ module Mulukhiya
       return {
         event: event.to_s,
         handler: underscore,
-        entries: recursive_to_a(result.concat(errors)),
+        # 🔴 `concat` にしないこと。`Reporter#push` は 1 つのハンドラに対して
+        # `summary` を 2 回呼ぶので、破壊的だとログ側だけ `errors` が二重になり、
+        # `result` にも染み出す (#4682)。
+        entries: recursive_to_a(result + errors),
       }
     end
 

--- a/test/unit/lib/handler_summary.rb
+++ b/test/unit/lib/handler_summary.rb
@@ -1,0 +1,59 @@
+module Mulukhiya
+  # `Handler#summary` が `result` を壊さないこと (#4682)。
+  #
+  # ⚠⚠ **従来は `result.concat(errors)` と破壊的だった。**`Reporter#push` は
+  # 1 つのハンドラに対して `summary` を 2 回呼ぶ（`push` 側と `logger.info` 側）ので、
+  # **ログの方だけ `errors` が 2 回入る**。通知と突き合わせると件数が合わない。
+  class HandlerSummaryTest < TestCase
+    # ⚠ `Handler.new` は SNS 経由で DB を触るので `allocate` で組む。
+    # `summary` が読むのは `@event` / `@result` / `@errors` だけ。
+    def create_handler(result:, errors:)
+      handler = Handler.allocate
+      handler.instance_variable_set(:@event, :pre_toot)
+      handler.instance_variable_set(:@result, Concurrent::Array.new(result))
+      handler.instance_variable_set(:@errors, Concurrent::Array.new(errors))
+      return handler
+    end
+
+    def test_entries_merges_result_and_errors
+      handler = create_handler(result: ['R1'], errors: ['E1'])
+
+      assert_equal(['R1', 'E1'], handler.summary[:entries])
+    end
+
+    # ⚠⚠ **これが本命。**従来は 2 回目が `['R1', 'E1', 'E1']` になっていた。
+    def test_summary_is_idempotent
+      handler = create_handler(result: ['R1'], errors: ['E1'])
+
+      assert_equal(handler.summary[:entries], handler.summary[:entries])
+      assert_equal(['R1', 'E1'], handler.summary[:entries])
+    end
+
+    # `errors` が `result` に染み出さないこと。染み出すと `debug_info[:result]` が
+    # 「成功した結果」でなくなり、`loggable?` の判定も変わる。
+    def test_summary_does_not_pollute_result
+      handler = create_handler(result: ['R1'], errors: ['E1'])
+      3.times {handler.summary}
+
+      assert_equal(['R1'], handler.result)
+      assert_equal(['E1'], handler.errors)
+      assert_equal({result: ['R1'], errors: ['E1']}, handler.debug_info)
+    end
+
+    def test_summary_without_errors
+      handler = create_handler(result: ['R1'], errors: [])
+      2.times {handler.summary}
+
+      assert_equal(['R1'], handler.summary[:entries])
+      assert_equal(['R1'], handler.result)
+    end
+
+    def test_summary_without_result
+      handler = create_handler(result: [], errors: ['E1'])
+      2.times {handler.summary}
+
+      assert_equal(['E1'], handler.summary[:entries])
+      assert_empty(handler.result)
+    end
+  end
+end


### PR DESCRIPTION
#4682 の是正。**#4649 の前提**として切り出したもので、契約の変更（#4649 の 1/2/3）とは独立です。

## 何が起きていたか

`Handler#summary` が `result.concat(errors)` と **破壊的な `concat`** を使っていました。`Reporter#push` は 1 つのハンドラに対して `summary` を **2 回**呼びます:

```ruby
def push(entry)
  if entry.is_a?(Handler)
    push(entry.summary) if entry.reportable?
    logger.info(entry.summary) if entry.loggable?
```

`reportable?` は（`verbose?` の抑止に掛からなければ）`loggable?` を返すので、**エラーを持つハンドラでは 2 回とも真**になります。

### 実測（修正前・`develop` `898c5d2f`）

| 呼び出し | `summary[:entries]` |
| --- | --- |
| 1 回目 | `["R1", "E1"]` |
| 2 回目 | `["R1", "E1", "E1"]` |
| 3 回目 | `["R1", "E1", "E1", "E1"]` |

```
result     = ["R1", "E1", "E1", "E1"]
debug_info = {result: ["R1", "E1", "E1", "E1"], errors: ["E1"]}
```

⚠ **投稿結果通知（`push` 側）は 1 回目なので正しく、ログ（`logger.info` 側）だけが二重**になります。通知とログを突き合わせると件数が合わない、という形で出ます。

## 直したこと

`result + errors`（非破壊）にしただけです。`entries` の形は変わらないので、**投稿結果通知のレンダリングにも `Reporter#to_h` にも影響しません**。

⚠ `summary` の呼び出しは `Reporter#push` の 2 箇所だけです（`ProgramCalendar#summary` は同名の別物）。

## テスト

`test/unit/lib/handler_summary.rb` を追加。⚠ **修正前の `develop` で 3 failures になることを確認済み**（回帰テストとして機能します）。

- `rake lint` 緑
- `rake test` **1231 tests / 1757 assertions / 0 failures / 0 errors / 322 omissions**

⚠ `Handler.new` は SNS 経由で DB を触るので、テストは `Handler.allocate` で組んでいます（`summary` が読むのは `@event` / `@result` / `@errors` だけ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KUmNREgdYcmxvf7ShNnyPv