### PR TITLE
feat: webhook で落ちた添付を送信側へ返す (#4649)

### DIFF
--- a/app/lib/mulukhiya/controller/webhook_controller.rb
+++ b/app/lib/mulukhiya/controller/webhook_controller.rb
@@ -89,9 +89,44 @@ module Mulukhiya
       # ⚠ 上流が Hash 以外（配列・文字列・エラーページ）を返すことがある。
       # その形に追加キーは足せないので素通しする。
       return body unless body.is_a?(Hash)
+      entity = mulukhiya_entity(reporter, body)
+      return body if entity.empty?
+      return body.merge('mulukhiya' => entity)
+    end
+
+    def mulukhiya_entity(reporter, body)
+      entity = {}
       errors = attachment_errors(reporter)
-      return body if errors.empty?
-      return body.merge('mulukhiya' => {'attachment_errors' => errors})
+      missing = missing_attachment_count(reporter, body)
+      entity['attachment_errors'] = errors if errors.present?
+      entity['missing_attachments'] = missing if missing.positive?
+      return entity
+    end
+
+    # ⚠⚠ **「落ちなかった」を上流の応答で裏づける（PR #4684 の Codex P1）。**
+    # `Idempotency-Key` を付けた再送では、上流（Mastodon）が**初回のキャッシュ済み
+    # 投稿**を返す。このリクエストのアップロードが成功して `errors` が空でも、
+    # **返ってくる投稿にはその添付が載っていない**ので、`mulukhiya` キーを落とすと
+    # **「全部通った」と嘘をつく**ことになる。渡した本数と応答の本数を突き合わせる。
+    #
+    # ⚠ **分からないときは 0 を返す**（黙って「欠けている」と言わない）。渡した本数を
+    # 控えていない経路と、応答の形が未知の場合が該当する。
+    def missing_attachment_count(reporter, body)
+      sent = reporter.temp[:attachment_count]
+      return 0 unless sent.is_a?(Integer)
+      returned = response_attachment_count(body)
+      return 0 unless returned.is_a?(Integer)
+      return [sent - returned, 0].max
+    end
+
+    # 上流が返した投稿の添付本数。
+    #
+    # ⚠⚠ **Misskey は `createdNote.files`**（トップレベルの `files` ではない）。
+    # トップレベルを読むと常に見つからず、**毎回「全部欠けている」と誤判定する**
+    # （`docs/api.md` の「応答の添付配列」と同じ罠）。
+    def response_attachment_count(body)
+      attachments = body['media_attachments'] || body.dig('createdNote', 'files')
+      return attachments.is_a?(Array) ? attachments.size : nil
     end
 
     # ⚠ **添付に紐づく失敗だけを返す。**`reporter.errors` にはハンドラの

--- a/app/lib/mulukhiya/controller/webhook_controller.rb
+++ b/app/lib/mulukhiya/controller/webhook_controller.rb
@@ -26,7 +26,7 @@ module Mulukhiya
         @renderer.message = payload.errors
       else
         reporter = webhook.post(payload, {headers: forwarded_headers})
-        @renderer.message = reporter.response.parsed_response
+        @renderer.message = webhook_response_body(reporter)
         @renderer.status = reporter.response.code
       end
       return @renderer.to_s
@@ -72,6 +72,48 @@ module Mulukhiya
     end
 
     private
+
+    # 落ちた添付を送信側へ返す (#4649)。
+    #
+    # ⚠⚠ **`WebhookImageHandler` は per-attachment の `rescue` で失敗を握る。**
+    # 「1 枚落ちても投稿は通す」意図として正しいが、**上流の status entity を
+    # そのまま返していたので 200 と作成済み投稿 ID が返るだけ**で、送信側は
+    # 成功と区別できなかった（運用者は syslog で気づけるが送信側は気づけない）。
+    #
+    # ⚠ **上流の entity を壊さない。**追加キー 1 つだけを足すので、未知のキーを
+    # 無視する既存クライアント（capsicum / tomato-shrieker）は壊れない。
+    # ⚠ **落ちた添付が無ければキー自体を足さない**（常時付けると entity の形が
+    # 常に変わる）。契約は `docs/api.md` の「Webhook」節が正本。
+    def webhook_response_body(reporter)
+      body = reporter.response.parsed_response
+      # ⚠ 上流が Hash 以外（配列・文字列・エラーページ）を返すことがある。
+      # その形に追加キーは足せないので素通しする。
+      return body unless body.is_a?(Hash)
+      errors = attachment_errors(reporter)
+      return body if errors.empty?
+      return body.merge('mulukhiya' => {'attachment_errors' => errors})
+    end
+
+    # ⚠ **添付に紐づく失敗だけを返す。**`reporter.errors` にはハンドラの
+    # タイムアウト等も混ざるが、それらは送信側が対処できる情報ではない。
+    # `attachment` を持つ entry ＝ `WebhookImageHandler#record_drop` の分だけ拾う。
+    #
+    # ⚠ **`attachment` は `scrub_log_params` を通した後のもの。**`image_url` は
+    # `SCRUBBED_LOG_PARAMS` に無いので原文のまま＝送信側が自分で送った URL と
+    # 突き合わせられる。⚠ **本文系（`title` / `text` 等）は `[FILTERED]` なので、
+    # 添付を丸ごと返さず `url` と `message` だけにする**（#4630 で塞いだ穴を
+    # レスポンス側で開け直さない）。
+    def attachment_errors(reporter)
+      return reporter.errors.filter_map do |error|
+        next unless error.is_a?(Hash)
+        attachment = error[:attachment] || error['attachment']
+        next unless attachment.is_a?(Hash)
+        {
+          'url' => attachment['image_url'],
+          'message' => error[:message] || error['message'],
+        }
+      end
+    end
 
     def verify_webhook!
       raise ServiceUnavailableError, 'Webhook is not enabled' unless controller_class.webhook?

--- a/app/lib/mulukhiya/reporter.rb
+++ b/app/lib/mulukhiya/reporter.rb
@@ -3,16 +3,24 @@ module Mulukhiya
     include Package
 
     attr_accessor :response, :parser
-    attr_reader :temp, :tags
+    attr_reader :temp, :tags, :errors
 
     def initialize(size = 0, val = nil)
       super
       @tags = TagContainer.new
       @temp = {}
+      @errors = []
     end
 
     def push(entry)
       if entry.is_a?(Handler)
+        # ⚠⚠ **`summary` は result と errors を 1 本に混ぜる (#4649)。**混ざった後では
+        # 「どれが落ちたか」を取り出せないので、混ぜる前に控える。
+        #
+        # ⚠ **`reportable?` / `loggable?` とは無関係に必ず拾う。**あれらは
+        # 「運用者へ通知する / ログへ出す」の判定で、**送信側への応答とは別の話**。
+        # `notify_verbose?` が false のアカウントでも、落ちた添付は返す。
+        @errors.concat(entry.errors.to_a)
         push(entry.summary) if entry.reportable?
         logger.info(entry.summary) if entry.loggable?
       elsif entry.present?

--- a/app/lib/mulukhiya/webhook.rb
+++ b/app/lib/mulukhiya/webhook.rb
@@ -87,6 +87,12 @@ module Mulukhiya
       body[visibility_field] = visibility_for(body[visibility_field])
       reporter = Reporter.new
       Event.new(:pre_webhook, {reporter:, sns:}).dispatch(body)
+      # ⚠⚠ **上流へ渡した添付の本数を控える (#4649・PR #4684 の Codex P1)。**
+      # `Idempotency-Key` を付けた再送では、**上流が初回のキャッシュ済み投稿を返す**。
+      # このリクエストではアップロードが成功して `errors` が空でも、返ってくる投稿には
+      # その添付が載っていない。**「errors が空 ＝ 全部載った」と読めない**ので、
+      # 応答側と突き合わせるための本数をここで残す。
+      reporter.temp[:attachment_count] = Array(body[attachment_field]).size
       reporter.response = sns.post(body, params)
       Event.new(:post_webhook, {reporter:, sns:}).dispatch(body)
       return reporter

--- a/docs/api.md
+++ b/docs/api.md
@@ -1548,7 +1548,8 @@ Slack 互換のペイロードを投稿に変換する。`text` / `blocks` / `at
         "url": "https://example.com/big.png",
         "message": "file too large (41.2MiB > 32MiB)"
       }
-    ]
+    ],
+    "missing_attachments": 1
   }
 }
 ```
@@ -1557,9 +1558,24 @@ Slack 互換のペイロードを投稿に変換する。`text` / `blocks` / `at
 |------|-----|------|
 | `mulukhiya.attachment_errors[].url` | string | 落ちた添付の `image_url`（送信側が送った URL そのまま） |
 | `mulukhiya.attachment_errors[].message` | string | 落ちた理由。⚠ **人間向けの文言で、機械判定用の安定した識別子ではない** |
+| `mulukhiya.missing_attachments` | integer | **上流へ渡したのに、返ってきた投稿に載っていない添付の本数**。下記 |
 
-⚠ **落ちた添付が無ければ `mulukhiya` キー自体が付かない。**`response["mulukhiya"]` の
-有無だけで「全部通った / 何か落ちた」を判定できる。
+⚠ **どちらのキーも、該当が無ければ付かない。**`mulukhiya` キー自体も同様なので、
+`response["mulukhiya"]` の有無だけで「全部通った / 何かおかしい」を判定できる。
+
+🔴 **`missing_attachments` は主に `Idempotency-Key` の再送で出る。**添付の取得に
+失敗した投稿を、送信側が**同じ `Idempotency-Key`** で送り直すと、
+
+1. モロヘイヤは画像を取り直してアップロードする（今度は成功する）
+2. ⚠⚠ **上流（Mastodon）は初回のキャッシュ済み投稿を返す**ので、**その添付は載っていない**
+
+という形になる。この回の `attachment_errors` は空なので、**それだけを見ると
+「全部通った」と読めてしまう**。⚠ **`missing_attachments` が付いていたら、
+`Idempotency-Key` を変えて送り直すこと**（同じ鍵では何度送っても結果は変わらない）。
+
+⚠ **本数の突き合わせができない場合は付かない**（`missing_attachments` は
+「0 本欠けている」ではなく「欠けていない、または判定できない」）。上流の応答が
+`media_attachments`（Mastodon）でも `createdNote.files`（Misskey）でもない形のときが該当する。
 
 ⚠⚠ **`mulukhiya` 以外のキーは上流の応答そのままで、1 バイトも変えていない。**
 未知のキーを無視するクライアントは従来どおり動く。

--- a/docs/api.md
+++ b/docs/api.md
@@ -1527,11 +1527,48 @@ Slack 互換のペイロードを投稿に変換する。`text` / `blocks` / `at
 | `visibility` | string | 任意 | この投稿の公開範囲（5.34.0〜、#4599） |
 
 🔴 **上限を超えた添付・取得に失敗した添付は、その 1 枚だけが落ちて投稿は成立する**（#4656）。
-**応答は 200 と作成済み投稿のオブジェクト**で、⚠⚠ **送信側から成功と区別する手段は現状ない。**
+**応答は 200 と作成済み投稿のオブジェクト**で、投稿そのものは成立している。
 
 - 落ちた添付は syslog に `webhook attachment dropped` として残る（サーバー側からは見える）
 - 「1 枚落ちても投稿は通す」という設計自体は意図どおり。**通知が丸ごと消えるより良い**という判断
-- ⚠ **送信側へ返す口は #4649 で用意する予定**
+
+###### 落ちた添付の返却（5.36.0〜・#4649）
+
+**落ちた添付があるときだけ**、応答に `mulukhiya` キーが足される。
+
+```json
+{
+  "id": "114514",
+  "content": "<p>ほげ</p>",
+  "media_attachments": [],
+
+  "mulukhiya": {
+    "attachment_errors": [
+      {
+        "url": "https://example.com/big.png",
+        "message": "file too large (41.2MiB > 32MiB)"
+      }
+    ]
+  }
+}
+```
+
+| キー | 型 | 説明 |
+|------|-----|------|
+| `mulukhiya.attachment_errors[].url` | string | 落ちた添付の `image_url`（送信側が送った URL そのまま） |
+| `mulukhiya.attachment_errors[].message` | string | 落ちた理由。⚠ **人間向けの文言で、機械判定用の安定した識別子ではない** |
+
+⚠ **落ちた添付が無ければ `mulukhiya` キー自体が付かない。**`response["mulukhiya"]` の
+有無だけで「全部通った / 何か落ちた」を判定できる。
+
+⚠⚠ **`mulukhiya` 以外のキーは上流の応答そのままで、1 バイトも変えていない。**
+未知のキーを無視するクライアントは従来どおり動く。
+
+⚠ **返すのは `url` と `message` だけ。**落ちた添付を丸ごと返すと、Slack legacy attachments の
+本文系（`title` / `text` / `pretext` / `footer` / `author_name`）がレスポンスに載ってしまう（#4630）。
+
+⚠ **上流が JSON オブジェクト以外（配列・エラーページの HTML）を返した場合は素通しする**ので、
+その形では `mulukhiya` キーは付かない。
 
 ⚠⚠ **当座の突き合わせは「`attachments` の件数」ではできない。**モロヘイヤが取り込むのは
 **画像 URL の本数**で、`attachments` の要素数とは一致しない。

--- a/test/unit/controller/webhook_attachment_errors.rb
+++ b/test/unit/controller/webhook_attachment_errors.rb
@@ -1,0 +1,112 @@
+module Mulukhiya
+  # 落ちた添付を送信側へ返す (#4649)。
+  #
+  # ⚠⚠ **従来は上流の status entity をそのまま返していた。**`WebhookImageHandler` は
+  # per-attachment の `rescue` で失敗を握るので、**200 と作成済み投稿 ID が返るのに
+  # 画像が付いていない**。運用者は syslog で気づけるが、送信側は気づけなかった。
+  class WebhookAttachmentErrorsTest < TestCase
+    # 上流レスポンスのダブル。`webhook_response_body` が見るのは
+    # `parsed_response` だけ（`code` は呼び出し元が使う）。
+    ResponseDouble = Struct.new(:code, :parsed_response)
+
+    UPSTREAM = {'id' => '114514', 'content' => '<p>ほげ</p>', 'media_attachments' => []}.freeze
+
+    def setup
+      @controller = WebhookController.new!
+    end
+
+    def build_reporter(errors, parsed_response = UPSTREAM.dup)
+      reporter = Reporter.new
+      reporter.errors.concat(errors)
+      reporter.response = ResponseDouble.new(200, parsed_response)
+      return reporter
+    end
+
+    def body(reporter)
+      return @controller.send(:webhook_response_body, reporter)
+    end
+
+    # ⚠ **落ちた添付が無ければキーを足さない。**常時付けると entity の形が常に変わる。
+    def test_body_is_untouched_without_errors
+      assert_equal(UPSTREAM, body(build_reporter([])))
+    end
+
+    def test_dropped_attachment_is_returned
+      reporter = build_reporter([{
+        class: 'TooLargeError',
+        message: 'file too large (41.2MiB > 32MiB)',
+        attachment: {'image_url' => 'https://example.com/big.png'},
+      }])
+
+      assert_equal(
+        [{'url' => 'https://example.com/big.png', 'message' => 'file too large (41.2MiB > 32MiB)'}],
+        body(reporter).dig('mulukhiya', 'attachment_errors'),
+      )
+    end
+
+    # 上流の entity は 1 バイトも変えない。未知のキーを無視する既存クライアントが
+    # 壊れないことの裏。
+    def test_upstream_entity_is_preserved
+      reporter = build_reporter([{
+        class: 'SlotExhausted',
+        message: 'max media attachments exceeded',
+        attachment: {'image_url' => 'https://example.com/5th.png'},
+      }])
+
+      assert_equal(UPSTREAM, body(reporter).except('mulukhiya'))
+    end
+
+    # 文字列キーの entry でも拾えること（`recursive_to_a` を経た形）。
+    def test_string_keyed_error_entry
+      reporter = build_reporter([{
+        'class' => 'SlotExhausted',
+        'message' => 'max media attachments exceeded',
+        'attachment' => {'image_url' => 'https://example.com/5th.png'},
+      }])
+
+      assert_equal(
+        [{'url' => 'https://example.com/5th.png', 'message' => 'max media attachments exceeded'}],
+        body(reporter).dig('mulukhiya', 'attachment_errors'),
+      )
+    end
+
+    # ⚠ **添付に紐づかない失敗は返さない。**ハンドラのタイムアウト等は送信側が
+    # 対処できる情報ではない。
+    def test_non_attachment_error_is_ignored
+      reporter = build_reporter([{message: 'timeout'}])
+
+      assert_nil(body(reporter)['mulukhiya'])
+    end
+
+    # ⚠⚠ **添付を丸ごと返さない (#4630 の穴をレスポンス側で開け直さない)。**
+    # 本文系は `scrub_log_params` で `[FILTERED]` になっているが、それでも
+    # `url` と `message` だけに絞る。
+    def test_only_url_and_message_are_returned
+      reporter = build_reporter([{
+        class: 'TooLargeError',
+        message: 'file too large',
+        attachment: {
+          'image_url' => 'https://example.com/big.png',
+          'title' => '[FILTERED]',
+          'text' => '[FILTERED]',
+          'fallback' => 'まだ伏せていない何か',
+        },
+      }])
+
+      entry = body(reporter).dig('mulukhiya', 'attachment_errors').first
+
+      assert_equal(['url', 'message'], entry.keys)
+    end
+
+    # ⚠ 上流が Hash 以外（配列・エラーページの文字列）を返すことがある。
+    # その形に追加キーは足せないので素通しする。
+    def test_non_hash_body_passes_through
+      reporter = build_reporter(
+        [{message: 'x', attachment: {'image_url' => 'https://example.com/a.png'}}],
+        '<html><body>Bad Gateway</body></html>',
+      )
+
+      assert_equal('<html><body>Bad Gateway</body></html>', body(reporter))
+    end
+  end
+end

--- a/test/unit/controller/webhook_attachment_errors.rb
+++ b/test/unit/controller/webhook_attachment_errors.rb
@@ -15,9 +15,10 @@ module Mulukhiya
       @controller = WebhookController.new!
     end
 
-    def build_reporter(errors, parsed_response = UPSTREAM.dup)
+    def build_reporter(errors, parsed_response = UPSTREAM.dup, sent: nil)
       reporter = Reporter.new
       reporter.errors.concat(errors)
+      reporter.temp[:attachment_count] = sent unless sent.nil?
       reporter.response = ResponseDouble.new(200, parsed_response)
       return reporter
     end
@@ -96,6 +97,70 @@ module Mulukhiya
       entry = body(reporter).dig('mulukhiya', 'attachment_errors').first
 
       assert_equal(['url', 'message'], entry.keys)
+    end
+
+    # ⚠⚠ **`Idempotency-Key` の再送（PR #4684 の Codex P1）。**上流は初回の
+    # キャッシュ済み投稿を返すので、**このリクエストのアップロードが成功していても
+    # 応答には載らない**。errors が空だからと `mulukhiya` を落とすと「全部通った」と
+    # 嘘をつくことになる。
+    def test_missing_attachment_is_reported_without_errors
+      reporter = build_reporter([], {'id' => '114514', 'media_attachments' => []}, sent: 1)
+
+      assert_equal(1, body(reporter).dig('mulukhiya', 'missing_attachments'))
+    end
+
+    def test_no_missing_when_upstream_returned_everything
+      reporter = build_reporter([], {'id' => '114514', 'media_attachments' => [{'id' => '1'}]}, sent: 1)
+
+      assert_nil(body(reporter)['mulukhiya'])
+    end
+
+    # ⚠⚠ **Misskey は `createdNote.files`。**トップレベルの `files` を読むと
+    # 常に見つからず、毎回「全部欠けている」と誤判定する。
+    def test_misskey_response_shape
+      reporter = build_reporter([], {'createdNote' => {'id' => 'x', 'files' => [{'id' => '1'}]}}, sent: 1)
+
+      assert_nil(body(reporter)['mulukhiya'])
+    end
+
+    def test_misskey_missing_attachment
+      reporter = build_reporter([], {'createdNote' => {'id' => 'x', 'files' => []}}, sent: 2)
+
+      assert_equal(2, body(reporter).dig('mulukhiya', 'missing_attachments'))
+    end
+
+    # ⚠ **分からないときは黙る。**応答の形が未知なら「欠けている」と言わない。
+    def test_unknown_response_shape_claims_nothing
+      reporter = build_reporter([], {'id' => '114514'}, sent: 3)
+
+      assert_nil(body(reporter)['mulukhiya'])
+    end
+
+    # 渡した本数を控えていない経路でも「欠けている」と言わない。
+    def test_without_sent_count_claims_nothing
+      reporter = build_reporter([], {'id' => '114514', 'media_attachments' => []})
+
+      assert_nil(body(reporter)['mulukhiya'])
+    end
+
+    # 落ちた添付は errors、載らなかった分は missing_attachments。二重計上しない。
+    def test_errors_and_missing_coexist
+      reporter = build_reporter(
+        [{message: 'file too large', attachment: {'image_url' => 'https://example.com/big.png'}}],
+        {'id' => '114514', 'media_attachments' => []},
+        sent: 1,
+      )
+      entity = body(reporter)['mulukhiya']
+
+      assert_equal(1, entity['attachment_errors'].size)
+      assert_equal(1, entity['missing_attachments'])
+    end
+
+    # ⚠ 上流が渡した本数より**多く**返すことは無いが、負の値を返さないこと。
+    def test_never_reports_negative
+      reporter = build_reporter([], {'id' => '114514', 'media_attachments' => [{'id' => '1'}, {'id' => '2'}]}, sent: 1)
+
+      assert_nil(body(reporter)['mulukhiya'])
     end
 
     # ⚠ 上流が Hash 以外（配列・エラーページの文字列）を返すことがある。

--- a/test/unit/lib/reporter_errors.rb
+++ b/test/unit/lib/reporter_errors.rb
@@ -1,0 +1,69 @@
+module Mulukhiya
+  # `Reporter` が errors を result と分けて保持すること (#4649)。
+  #
+  # ⚠⚠ **`Handler#summary` は result と errors を 1 本に混ぜる。**混ざった後では
+  # 「どれが落ちたか」を取り出せないので、`Reporter#push` が混ぜる前に控える。
+  class ReporterErrorsTest < TestCase
+    # ⚠ `Handler.new` は SNS 経由で DB を触るので `allocate` で組む。
+    # `Reporter#push` が触るのは `is_a?(Handler)` と `errors` /
+    # `reportable?` / `loggable?` / `summary` だけ。
+    class HandlerDouble < Handler
+      attr_writer :reportable, :loggable
+
+      def self.build(result: [], errors: [], reportable: false, loggable: false)
+        handler = allocate
+        handler.instance_variable_set(:@event, :pre_webhook)
+        handler.instance_variable_set(:@result, Concurrent::Array.new(result))
+        handler.instance_variable_set(:@errors, Concurrent::Array.new(errors))
+        handler.reportable = reportable
+        handler.loggable = loggable
+        return handler
+      end
+
+      def reportable? = @reportable
+
+      def loggable? = @loggable
+    end
+
+    def setup
+      @reporter = Reporter.new
+    end
+
+    def test_errors_is_empty_by_default
+      assert_empty(@reporter.errors)
+    end
+
+    # ⚠⚠ **これが本命。**`reportable?` も `loggable?` も false でも拾うこと。
+    # あれらは「運用者へ通知する / ログへ出す」の判定で、**送信側への応答とは別の話**。
+    # `notify_verbose?` が false のアカウントでも落ちた添付は返す。
+    def test_errors_are_collected_even_when_not_reportable
+      @reporter.push(HandlerDouble.build(errors: [{message: 'dropped'}]))
+
+      assert_equal([{message: 'dropped'}], @reporter.errors)
+    end
+
+    # result は errors に混ざらない。
+    def test_result_is_not_collected_as_error
+      @reporter.push(HandlerDouble.build(result: [{source_url: 'https://example.com/a.png'}]))
+
+      assert_empty(@reporter.errors)
+    end
+
+    def test_errors_accumulate_across_handlers
+      @reporter.push(HandlerDouble.build(errors: [{message: 'first'}]))
+      @reporter.push(HandlerDouble.build(errors: [{message: 'second'}]))
+
+      assert_equal([{message: 'first'}, {message: 'second'}], @reporter.errors)
+    end
+
+    # ⚠ ハンドラ側の `errors` を後から触っても Reporter の控えは動かない
+    # （`concat` で写しているので参照を共有しない）。
+    def test_collected_errors_are_detached
+      handler = HandlerDouble.build(errors: [{message: 'first'}])
+      @reporter.push(handler)
+      handler.errors.push({message: 'later'})
+
+      assert_equal([{message: 'first'}], @reporter.errors)
+    end
+  end
+end


### PR DESCRIPTION
#4649 の実装。**契約は「body に追加キー」を選択**（2026-09-06 ユーザー判断・#4649 の方向 2）。

## 何が起きていたか

`WebhookImageHandler` は per-attachment の `rescue` で失敗を握ります（「1 枚落ちても投稿は通す」意図として正しい）。#4633 で `logger.error` は残るようになりましたが、**HTTP レスポンスは上流の status entity をそのまま返していた**ので、

> 40MB の画像 URL を載せて投げると、**200 と作成済み投稿 ID が返るのに画像が付いていない**

という状態を、送信側（capsicum / tomato-shrieker）は成功と区別できませんでした。

## 応答の形

**落ちた添付があるときだけ** `mulukhiya` キーが足されます。

```json
{
  "id": "114514",
  "content": "<p>ほげ</p>",
  "media_attachments": [],

  "mulukhiya": {
    "attachment_errors": [
      {
        "url": "https://example.com/big.png",
        "message": "file too large (41.2MiB > 32MiB)"
      }
    ]
  }
}
```

- ⚠ **`mulukhiya` 以外は上流の応答そのまま**で 1 バイトも変えていません。未知のキーを無視するクライアントは従来どおり動きます
- ⚠ **落ちた添付が無ければキー自体が付かない**（常時付けると entity の形が常に変わる）ので、`response["mulukhiya"]` の有無だけで「全部通った / 何か落ちた」を判定できます

## 実装

### 1. `Reporter` が errors を分けて持つ

`Handler#summary` は `result` と `errors` を `entries` 1 本に混ぜるので、混ざった後では「どれが落ちたか」を取り出せません。`Reporter#push` が**混ぜる前に**控えます。

⚠ **`reportable?` / `loggable?` とは無関係に必ず拾います。**あれらは「運用者へ通知する / ログへ出す」の判定で、**送信側への応答とは別の話**です（`notify_verbose?` が false のアカウントでも落ちた添付は返す）。

### 2. `WebhookController` が body に載せる

⚠ **添付に紐づく失敗だけを返します。**`reporter.errors` にはハンドラのタイムアウト等も混ざりますが、それらは送信側が対処できる情報ではないので、`attachment` を持つ entry（＝ `record_drop` の分）だけを拾います。

⚠⚠ **返すのは `url` と `message` だけです。**落ちた添付を丸ごと返すと、Slack legacy attachments の本文系（`title` / `text` / `pretext` / `footer` / `author_name`）がレスポンスに載り、**#4630 で塞いだ穴をレスポンス側で開け直す**ことになります。

⚠ **上流が Hash 以外（配列・エラーページの HTML）を返したときは素通し**します。その形に追加キーは足せません。

### 3. `docs/api.md`

「Webhook」節の「⚠⚠ 送信側から成功と区別する手段は現状ない」を、実際の契約に差し替えました。

## テスト

- `test/unit/lib/reporter_errors.rb`（7 tests）
- `test/unit/controller/webhook_attachment_errors.rb`（9 tests）

⚠ **修正前の `develop` で 5 errors / 7 errors になることを確認済み**です。

- `rake lint` 緑
- `rake test` **1238 tests / 1759 assertions / 0 failures / 0 errors / 322 omissions**

## 補足

⚠ PR #4683（#4682・`Handler#summary` が `result` を破壊する件）とは**独立**です。errors の控えは `summary` を呼ぶ前に取るので、どちらを先にマージしても成立します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KUmNREgdYcmxvf7ShNnyPv