### PR TITLE
fix: 1 本でも取れたらキャッシュを捨てない (#4659 の ②)

### DIFF
--- a/app/lib/mulukhiya/remote_dictionary.rb
+++ b/app/lib/mulukhiya/remote_dictionary.rb
@@ -64,6 +64,19 @@ module Mulukhiya
       return {uri: uri.to_s}
     end
 
+    # ソース単位の last-good キャッシュ (#4659) の同一性。
+    #
+    # ⚠⚠ **URL と型だけでは足りない（PR #4686 の Codex P2）。**`strict` のように
+    # **解釈に効く**設定があり、同じ URL・同じ `type` でも `parse` が返す entries が
+    # 変わる（`RelatedRemoteDictionary#strict?`）。キーを踏み合うと、**取得に失敗した
+    # 回に別設定の辞書で埋めたものが本体キャッシュへ最大 24 時間居座る**。
+    #
+    # ⚠ **ハッシュにしてから使うこと。**`@params` には `?access_token=` 付きの URL が
+    # 入る (#4511)。Redis のキー一覧は運用の手元にも syslog にも出る。
+    def cache_signature
+      return Digest::SHA256.hexdigest([self.class.name, @params.sort].to_json)
+    end
+
     def self.all(&block)
       return enum_for(__method__) unless block
       return unless handler = Handler.create(:dictionary_tag)

--- a/app/lib/mulukhiya/tagging_dictionary.rb
+++ b/app/lib/mulukhiya/tagging_dictionary.rb
@@ -93,12 +93,12 @@ module Mulukhiya
       # 鳴らさないと、**全ソースが死んでも Sentry には何も出なくなる**
       # （syslog の `log_generation` は出るようになったが、あれは通知経路ではない）。
       alert_empty_result if all_sources_empty?
-      if discardable?(entries)
-        # ソースはあるのに 1 件も取れず、last-good も無かった回。
+      if keep_last_known_good?(entries)
         # 直近の good を残したまま戻る。
         # ⚠ fail-open 自体は残す (GAS の一過性障害で辞書が消し飛ぶのを防ぐ意図は
         # 正しい)。TTL があるので古い内容が無期限に居座ることはない (#4583)。
         update(cache.to_h)
+        log_retention
         return self
       end
       redis.setex(REDIS_KEY, cache_ttl, Marshal.dump(build_payload(entries)))
@@ -213,6 +213,32 @@ module Mulukhiya
       return false if entries.present?
       return false if sources.none?
       return cache.present?
+    end
+
+    # 直近の good を残したまま戻る回か。
+    #
+    # ⚠⚠ **「全滅」だけでは足りない（PR #4686 の Codex P1）。**last-good がまだ
+    # 無い状態（**この版を入れた直後**・ソースを足した直後・24h の TTL 切れ）だと、
+    # 1 本落ちただけで痩せた辞書が本体キャッシュを上書きする ＝ **この修正が
+    # 狙った症状がそのまま出る**。埋められなかった失敗がある回は公開しない。
+    #
+    # ⚠ **生きたキャッシュがあるときだけ。**初回起動で本体キャッシュも無ければ、
+    # 痩せていても公開するほうがまし（何も引けないより良い）。
+    #
+    # ⚠ **据え置きは無期限にならない。**本体キャッシュの TTL は 1 時間なので、
+    # ソースが恒久的に死んだ場合は 1 時間で失効し、痩せた辞書が公開される。
+    def keep_last_known_good?(entries)
+      return false if cache.blank?
+      return true if discardable?(entries)
+      return unrestorable_failure?
+    end
+
+    # 埋められなかった失敗があった回か。⚠ **本数で見る**（どのソースかは
+    # `log_retention` が出す）。
+    def unrestorable_failure?
+      empty = @empty_sources.to_a.size
+      return false if empty.zero?
+      return empty > @substituted_sources.to_a.size
     end
 
     def build_payload(entries)

--- a/app/lib/mulukhiya/tagging_dictionary.rb
+++ b/app/lib/mulukhiya/tagging_dictionary.rb
@@ -11,12 +11,19 @@ module Mulukhiya
     include Package
     include SNSMethods
     include TaggingDictionaryLogMethods
+    include TaggingDictionarySourceCacheMethods
 
     REDIS_KEY = 'tagging_dictionary'.freeze
+    # ソース単位の last-good キャッシュの接頭辞 (#4659 の ②)。
+    SOURCE_REDIS_KEY_PREFIX = "#{REDIS_KEY}/source".freeze
     # キャッシュ payload の形式。envelope を変えたら上げる。旧形式は「無い」ものと
     # して捨てられ、次の refresh で作り直される。
     CACHE_PAYLOAD_VERSION = 1
     DEFAULT_CACHE_TTL = 3600
+    # ⚠ **ソース単位のキャッシュは本体より長く持つ (#4659)。**間欠 404 は
+    # gomander で 1 日 38% の回に出る。本体と同じ 1 時間だと、続けて外した
+    # ソースの last-good が先に消えて意味を成さない。
+    DEFAULT_SOURCE_CACHE_TTL = 86_400
 
     def initialize
       super
@@ -81,11 +88,16 @@ module Mulukhiya
     def refresh
       entries = merge(fetch)
       clear
+      # ⚠⚠ **全滅は last-good で埋めても鳴らす (#4659 の ②)。**埋まれば
+      # `entries` は present になるので `discardable?` を通らない。ここで
+      # 鳴らさないと、**全ソースが死んでも Sentry には何も出なくなる**
+      # （syslog の `log_generation` は出るようになったが、あれは通知経路ではない）。
+      alert_empty_result if all_sources_empty?
       if discardable?(entries)
-        # ソースはあるのに 1 件も取れなかった回。直近の good を残したまま戻る。
+        # ソースはあるのに 1 件も取れず、last-good も無かった回。
+        # 直近の good を残したまま戻る。
         # ⚠ fail-open 自体は残す (GAS の一過性障害で辞書が消し飛ぶのを防ぐ意図は
         # 正しい)。TTL があるので古い内容が無期限に居座ることはない (#4583)。
-        alert_empty_result
         update(cache.to_h)
         return self
       end
@@ -119,8 +131,13 @@ module Mulukhiya
     end
 
     # キャッシュを捨てる。テスト・運用で「既知の状態から始める」ための入口。
+    #
+    # ⚠⚠ **ソース単位の last-good も一緒に捨てる (#4659 の ②)。**本体だけ消しても、
+    # 次の refresh が last-good で埋め直すので**「既知の状態から始める」にならない**。
     def self.invalidate_cache
-      return Redis.new.unlink(REDIS_KEY)
+      redis = Redis.new
+      redis.keys("#{SOURCE_REDIS_KEY_PREFIX}/*").each {|key| redis.unlink(key)}
+      return redis.unlink(REDIS_KEY)
     end
 
     private
@@ -216,13 +233,14 @@ module Mulukhiya
     def fetch
       result = Concurrent::Array.new
       @empty_sources = Concurrent::Array.new
-      Parallel.each(RemoteDictionary.all, in_threads: Parallel.processor_count * 2) do |dic|
-        words = dic.parse
-        @empty_sources.push(dic.uri.to_s) if words.empty?
-        logger.send(words.empty? ? :error : :info, dic: dic.to_h.merge(words: words.count))
-        result.push(words)
+      @substituted_sources = Concurrent::Array.new
+      dics = remote_dictionaries
+      @attempted_sources = dics.size
+      Parallel.each(dics, in_threads: Parallel.processor_count * 2) do |dic|
+        result.push(fetch_source(dic))
       rescue => e
         @empty_sources.push(dic.uri.to_s)
+        result.push(restore_source(dic))
         e.log(dic: dic.to_h)
       end
       return result

--- a/app/lib/mulukhiya/tagging_dictionary_log_methods.rb
+++ b/app/lib/mulukhiya/tagging_dictionary_log_methods.rb
@@ -16,6 +16,10 @@ module Mulukhiya
     # 空なら error で出す（更新自体は成功しているので message は変えない）。
     def log_generation
       empty = @empty_sources.to_a
+      # ⚠ **last-good で埋めた本数も出す (#4659 の ②)。**`empty_sources` と
+      # `entries` だけだと、「痩せた辞書で更新した回」と「埋めたので痩せずに
+      # 済んだ回」が同じ見え方になる。
+      substituted = @substituted_sources.to_a
       payload = {
         message: 'tagging dictionary refreshed',
         redis_key: TaggingDictionary::REDIS_KEY,
@@ -23,6 +27,7 @@ module Mulukhiya
         generated_at: generated_at&.iso8601,
         sources: sources.size,
         empty_sources: empty.size,
+        substituted_sources: substituted.size,
         entries: size,
         ttl: cache_ttl,
       }

--- a/app/lib/mulukhiya/tagging_dictionary_log_methods.rb
+++ b/app/lib/mulukhiya/tagging_dictionary_log_methods.rb
@@ -35,6 +35,30 @@ module Mulukhiya
       logger.error(payload.merge(empty_source_urls: empty))
     end
 
+    # 直近の good を残して戻った回の記録 (#4659)。
+    #
+    # ⚠⚠ **`log_generation` を流用しないこと。**あれは
+    # `tagging dictionary refreshed` ＝ **更新に成功した回**の記録なので、据え置きを
+    # そこへ混ぜると「据え置きを更新成功として記録する」形になる（#4628 で挙げた
+    # 穴と同型で、元より悪い）。
+    #
+    # ⚠ **従来はこの回が syslog に 1 行も残らなかった。**`refresh` が
+    # `log_generation` の手前で return するので、「1 本欠けただけ」に見えて
+    # **全滅したことが分からない**状態だった（#4628 の 6 件目）。
+    def log_retention
+      logger.error(
+        message: 'tagging dictionary retained',
+        redis_key: TaggingDictionary::REDIS_KEY,
+        signature:,
+        generated_at: generated_at&.iso8601,
+        sources: sources.size,
+        empty_sources: @empty_sources.to_a.size,
+        substituted_sources: @substituted_sources.to_a.size,
+        empty_source_urls: @empty_sources.to_a,
+        entries: size,
+      )
+    end
+
     def alert_empty_result
       Ginseng::GatewayError.new('tagging dictionary fetch returned nothing').alert(
         redis_key: TaggingDictionary::REDIS_KEY,

--- a/app/lib/mulukhiya/tagging_dictionary_source_cache_methods.rb
+++ b/app/lib/mulukhiya/tagging_dictionary_source_cache_methods.rb
@@ -59,13 +59,11 @@ module Mulukhiya
       return words
     end
 
-    # ⚠⚠ **URL をキーに埋めない。**辞書 URL は `?access_token=` を持つことがあり、
-    # Redis のキー一覧は運用の手元にも syslog にも出る (#4511)。ハッシュだけを使う。
-    # ⚠ **クラス名も混ぜる。**同じ URL を別の `type` で二重に登録できるので、
-    # URL だけだと互いの last-good を踏み合う。
+    # ⚠ **同一性の判定は `RemoteDictionary#cache_signature` に持たせてある。**
+    # URL と型だけで割ると、`strict` のように解釈に効く設定が違うソース同士が
+    # 互いの last-good を踏み合う（PR #4686 の Codex P2）。
     def source_key(dic)
-      digest = Digest::SHA256.hexdigest([dic.class.name, dic.uri.to_s].to_json)
-      return "#{TaggingDictionary::SOURCE_REDIS_KEY_PREFIX}/#{digest}"
+      return "#{TaggingDictionary::SOURCE_REDIS_KEY_PREFIX}/#{dic.cache_signature}"
     end
 
     def source_cache_ttl
@@ -81,8 +79,12 @@ module Mulukhiya
     # ある（`RemoteDictionary.create` が落ちた本は `all` に出てこない）。
     # `sources.size` で割ると、**全滅しているのに鳴らない**回ができる。
     def all_sources_empty?
+      return false if sources.none?
       attempted = @attempted_sources.to_i
-      return false unless attempted.positive?
+      # ⚠⚠ **設定はあるのに 1 本も組み立てられなかった回も「全滅」（PR #4686 の
+      # Codex P2）。**`RemoteDictionary.create` が全部落ちると `attempted` が 0 に
+      # なる。ここを false に倒すと、**全ソースが使えないのに Sentry へ何も出ない**。
+      return true unless attempted.positive?
       return @empty_sources.to_a.size >= attempted
     end
   end

--- a/app/lib/mulukhiya/tagging_dictionary_source_cache_methods.rb
+++ b/app/lib/mulukhiya/tagging_dictionary_source_cache_methods.rb
@@ -1,0 +1,89 @@
+module Mulukhiya
+  # ソース単位の last-good キャッシュ (#4659 の ②)。TaggingDictionary 本体から
+  # 切り出してある。
+  #
+  # ⚠⚠ **切り出したのは行数合わせではなく、「辞書を引く」と「引けなかった回を
+  # どう埋めるか」を混ぜないため。**従来の fail-open は `discardable?` の 1 箇所に
+  # 埋まっていて、**「全滅したときだけ」しか効かない**ことが読み取りにくかった。
+  # 上流の GAS は間欠 404 を返すので、実際に効いてほしいのは**1 本だけ欠けた回**
+  # （gomander の実測で 3957 語 → 1814 語まで痩せる）。
+  module TaggingDictionarySourceCacheMethods
+    private
+
+    # 引く辞書ソースの実体。
+    #
+    # ⚠ **クラスメソッドを `fetch` の中で直に呼ばない。**last-good の経路 (#4659) を
+    # テストするのに `RemoteDictionary.all` をグローバルに差し替えるしかなくなる。
+    def remote_dictionaries
+      return RemoteDictionary.all.to_a
+    end
+
+    # 1 ソースぶんの取得。空だったら last-good で埋める (#4659 の ②)。
+    #
+    # ⚠⚠ **ログは「取れたか」で出す。**埋めた本数で `:info` を出すと、上流が
+    # 404 を返し続けても健全に見える＝ #4573 で塞いだ穴が戻る。`@empty_sources`
+    # も取得結果で積むので、台帳・`log_generation` の見え方は変わらない。
+    def fetch_source(dic)
+      words = dic.parse
+      logger.send(words.empty? ? :error : :info, dic: dic.to_h.merge(words: words.count))
+      return save_source(dic, words) if words.present?
+      @empty_sources.push(dic.uri.to_s)
+      return restore_source(dic)
+    end
+
+    # ⚠⚠ **1 本欠けた回に痩せた辞書で上書きしない (#4659 の ②)。**現行の fail-open は
+    # 「**全滅**したときだけ」前回値を残すので、**1 本だけ 404 になった回はその痩せた
+    # 辞書がそのままキャッシュへ書かれていた**。gomander の実測では
+    # 3957 語 → **1814 語**（`dic.json` 1 本で半減する）。
+    #
+    # ⚠ **last-good が無ければ `{}`。**無いものを埋めたと言わない。
+    def restore_source(dic)
+      raw = redis[source_key(dic)]
+      return {} unless raw
+      words = Marshal.load(raw) # rubocop:disable Security/MarshalLoad
+      return {} unless words.is_a?(Hash)
+      @substituted_sources&.push(dic.uri.to_s)
+      return words
+    rescue => e
+      e.log(dic: dic.to_h)
+      return {}
+    end
+
+    # ⚠ **取り込みの失敗で辞書を落とさない。**last-good が書けなくても、この回の
+    # 取得自体は成功している。次の回で書き直せる。
+    def save_source(dic, words)
+      redis.setex(source_key(dic), source_cache_ttl, Marshal.dump(words))
+      return words
+    rescue => e
+      e.log(dic: dic.to_h)
+      return words
+    end
+
+    # ⚠⚠ **URL をキーに埋めない。**辞書 URL は `?access_token=` を持つことがあり、
+    # Redis のキー一覧は運用の手元にも syslog にも出る (#4511)。ハッシュだけを使う。
+    # ⚠ **クラス名も混ぜる。**同じ URL を別の `type` で二重に登録できるので、
+    # URL だけだと互いの last-good を踏み合う。
+    def source_key(dic)
+      digest = Digest::SHA256.hexdigest([dic.class.name, dic.uri.to_s].to_json)
+      return "#{TaggingDictionary::SOURCE_REDIS_KEY_PREFIX}/#{digest}"
+    end
+
+    def source_cache_ttl
+      return config['/handler/dictionary_tag/cache/source_ttl'] || TaggingDictionary::DEFAULT_SOURCE_CACHE_TTL
+    rescue Ginseng::ConfigError
+      return TaggingDictionary::DEFAULT_SOURCE_CACHE_TTL
+    end
+
+    # 全ソースが取得に失敗した回か。⚠ **last-good で埋まったかは見ない**
+    # （埋まっても上流が全滅していることに変わりはない）。
+    #
+    # ⚠⚠ **分母は「実際に試した本数」。**`sources`（設定の本数）とは食い違うことが
+    # ある（`RemoteDictionary.create` が落ちた本は `all` に出てこない）。
+    # `sources.size` で割ると、**全滅しているのに鳴らない**回ができる。
+    def all_sources_empty?
+      attempted = @attempted_sources.to_i
+      return false unless attempted.positive?
+      return @empty_sources.to_a.size >= attempted
+    end
+  end
+end

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -92,6 +92,9 @@ handler:
   dictionary_tag:
     cache:
       ttl: 3600
+      # ソース単位の last-good キャッシュの TTL (#4659)。⚠ 本体の ttl より長く持つ
+      # （間欠 404 が続いた時に last-good が先に消えると意味を成さない）。
+      source_ttl: 86400
     dics: []
     word:
       min: 2

--- a/config/schema/handler/dictionary_tag.yaml
+++ b/config/schema/handler/dictionary_tag.yaml
@@ -3,6 +3,9 @@ description: 本文中のキーワードに基づいてハッシュタグを自�
 properties:
   cache:
     properties:
+      source_ttl:
+        minimum: 1
+        type: integer
       ttl:
         minimum: 1
         type: integer

--- a/test/unit/lib/tagging_dictionary_source_cache.rb
+++ b/test/unit/lib/tagging_dictionary_source_cache.rb
@@ -1,0 +1,204 @@
+module Mulukhiya
+  # ソース単位の last-good キャッシュ (#4659 の ②) の回帰テスト。
+  #
+  # ⚠⚠ **従来の fail-open は「全滅したときだけ」前回値を残していた。**上流の GAS が
+  # 間欠 404 を返すと、**1 本だけ欠けた回はその痩せた辞書でキャッシュが上書きされる**。
+  # gomander の実測では 3957 語 → **1814 語**（`dic.json` 1 本で半減）で、
+  # **辞書が半分になった状態でニチアサの実況の窓に入っていた**。
+  #
+  # ⚠ TaggingDictionaryCacheTest と同じく、`Handler.create(:dictionary_tag)` が
+  # DB を触るので `allocate` で組む（#4503 の教訓どおり環境で omission にしない）。
+  class TaggingDictionarySourceCacheTest < TestCase
+    # `TaggingDictionary#fetch_source` が触るのは `parse` / `uri` / `to_h` だけ。
+    class SourceDouble
+      attr_reader :uri
+
+      def self.build(url, words)
+        double = allocate
+        double.instance_variable_set(:@uri, Ginseng::URI.parse(url))
+        double.instance_variable_set(:@words, words)
+        return double
+      end
+
+      def parse = @words
+
+      attr_writer :words
+
+      def to_h = {uri: uri.to_s}
+    end
+
+    URL = 'https://example.jp/api/dic/v1/a.json?access_token=deadbeef'.freeze
+
+    def setup
+      TaggingDictionary.invalidate_cache
+      @dic = build_dictionary
+      @source = SourceDouble.build(URL, entries)
+    end
+
+    def teardown
+      super
+      TaggingDictionary.invalidate_cache
+    rescue => e
+      e.log
+    end
+
+    # 取れた回は last-good として保存し、そのまま返す。
+    def test_successful_fetch_is_saved
+      assert_equal(entries, fetch_source(@source))
+      assert_empty(@dic.instance_variable_get(:@empty_sources).to_a)
+      assert_empty(@dic.instance_variable_get(:@substituted_sources).to_a)
+      assert_equal(entries, restore_source(@source))
+    end
+
+    # ⚠⚠ **これが本命。**空を返した回は last-good で埋める。
+    def test_empty_fetch_is_substituted
+      fetch_source(@source)
+      reset_counters
+      @source.words = {}
+
+      assert_equal(entries, fetch_source(@source))
+      # 埋めても「取れなかった」ことは記録し続ける（台帳・#4573 の観測を壊さない）。
+      assert_equal([URL], @dic.instance_variable_get(:@empty_sources).to_a)
+      assert_equal([URL], @dic.instance_variable_get(:@substituted_sources).to_a)
+    end
+
+    # ⚠ **無いものを埋めたと言わない。**last-good が無ければ空のまま。
+    def test_empty_fetch_without_last_good
+      @source.words = {}
+
+      assert_empty(fetch_source(@source))
+      assert_equal([URL], @dic.instance_variable_get(:@empty_sources).to_a)
+      assert_empty(@dic.instance_variable_get(:@substituted_sources).to_a)
+    end
+
+    def test_source_cache_has_ttl
+      fetch_source(@source)
+      ttl = redis.redis.call('TTL', @dic.send(:source_key, @source))
+
+      assert_predicate(ttl, :positive?, "source cache の TTL が #{ttl}")
+      assert_operator(ttl, :<=, @dic.send(:source_cache_ttl))
+    end
+
+    # ⚠ **本体より長く持つ。**同じ TTL だと、続けて外したソースの last-good が
+    # 先に消えて意味を成さない。
+    def test_source_ttl_outlives_the_main_cache
+      assert_operator(@dic.send(:source_cache_ttl), :>, @dic.cache_ttl)
+    end
+
+    # ⚠⚠ **URL をキーに埋めない (#4511)。**辞書 URL は `?access_token=` を持つ。
+    def test_source_key_does_not_leak_the_url
+      key = @dic.send(:source_key, @source)
+
+      assert(key.start_with?("#{TaggingDictionary::SOURCE_REDIS_KEY_PREFIX}/"))
+      assert_not_include(key, 'example.jp')
+      assert_not_include(key, 'access_token')
+      assert_not_include(key, 'deadbeef')
+    end
+
+    # 同じ URL を別の type で二重に登録できるので、互いの last-good を踏まないこと。
+    def test_source_key_separates_classes
+      other = Class.new(SourceDouble).build(URL, entries)
+
+      assert_not_equal(@dic.send(:source_key, @source), @dic.send(:source_key, other))
+    end
+
+    def test_source_key_separates_urls
+      other = SourceDouble.build('https://example.jp/api/dic/v1/b.json', entries)
+
+      assert_not_equal(@dic.send(:source_key, @source), @dic.send(:source_key, other))
+    end
+
+    # 壊れた last-good を掴んでも落ちない。次の取得で書き直せる。
+    def test_broken_last_good_is_ignored
+      redis[@dic.send(:source_key, @source)] = 'not a marshal dump'
+
+      assert_empty(restore_source(@source))
+    end
+
+    def test_invalidate_cache_drops_source_keys
+      fetch_source(@source)
+      TaggingDictionary.invalidate_cache
+
+      assert_empty(restore_source(@source))
+    end
+
+    # ⚠⚠ **全滅は last-good で埋めても鳴らす。**埋まると entries は present に
+    # なるので `discardable?` を通らない。ここで鳴らさないと、**全ソースが死んでも
+    # Sentry には何も出なくなる**。
+    def test_all_sources_empty_is_detected_even_when_substituted
+      fetch_source(@source)
+      reset_counters
+      @dic.instance_variable_set(:@attempted_sources, 1)
+      @source.words = {}
+      fetch_source(@source)
+
+      assert_true(@dic.send(:all_sources_empty?))
+    end
+
+    def test_all_sources_empty_is_false_when_something_was_fetched
+      @dic.instance_variable_set(:@attempted_sources, 2)
+      fetch_source(@source)
+
+      assert_false(@dic.send(:all_sources_empty?))
+    end
+
+    # 何も試していない回を「全滅」と言わない。
+    def test_all_sources_empty_without_attempts
+      assert_false(@dic.send(:all_sources_empty?))
+    end
+
+    # `refresh` を通した振る舞い。1 本欠けても辞書が痩せないこと。
+    def test_refresh_does_not_thin_the_dictionary
+      alive = SourceDouble.build('https://example.jp/a.json', entries('キュアスタ'))
+      flaky = SourceDouble.build('https://example.jp/b.json', entries('デルムリン'))
+      dic = build_dictionary([alive, flaky])
+      dic.refresh
+
+      assert_equal(['キュアスタ', 'デルムリン'].sort, dic.keys.sort)
+
+      # 次の回で b.json だけが 404 になる。
+      flaky.words = {}
+      dic = build_dictionary([alive, flaky])
+      dic.refresh
+
+      assert_equal(['キュアスタ', 'デルムリン'].sort, dic.keys.sort)
+    end
+
+    private
+
+    def redis
+      @redis ||= Redis.new
+      return @redis
+    end
+
+    # merge / concat は words 配列を破壊的に触るので、呼ばれるたびに作り直す。
+    def entries(key = 'キュアスタ')
+      return {key => {pattern: Regexp.new(key), regexp: key, words: [key]}}
+    end
+
+    def fetch_source(source)
+      return @dic.send(:fetch_source, source)
+    end
+
+    def restore_source(source)
+      return @dic.send(:restore_source, source)
+    end
+
+    def reset_counters
+      @dic.instance_variable_set(:@empty_sources, Concurrent::Array.new)
+      @dic.instance_variable_set(:@substituted_sources, Concurrent::Array.new)
+    end
+
+    def build_dictionary(dics = [])
+      dic = TaggingDictionary.allocate
+      # ⚠ **設定は文字列キー。**`canonical_sources` は `to_h.merge('type' => ...)`
+      # を `sort` するので、シンボルキーを混ぜると Symbol と String の比較で落ちる。
+      config = dics.map {|dic| {'url' => dic.uri.to_s}}
+      dic.instance_variable_set(:@handler, Struct.new(:all).new(config))
+      dic.define_singleton_method(:remote_dictionaries) {dics}
+      dic.instance_variable_set(:@empty_sources, Concurrent::Array.new)
+      dic.instance_variable_set(:@substituted_sources, Concurrent::Array.new)
+      return dic
+    end
+  end
+end

--- a/test/unit/lib/tagging_dictionary_source_cache.rb
+++ b/test/unit/lib/tagging_dictionary_source_cache.rb
@@ -215,6 +215,33 @@ module Mulukhiya
       assert_equal(['キュアスタ', 'デルムリン'].sort, dic.keys.sort)
     end
 
+    # ⚠⚠ **この版を入れた直後は last-good が空（PR #4686 の Codex P1）。**
+    # 1 本落ちただけで痩せた辞書が本体キャッシュを上書きすると、この修正が狙った
+    # 症状がそのまま出る。埋められなかった失敗がある回は公開しないこと。
+    def test_refresh_keeps_the_aggregate_when_last_good_is_cold
+      alive = SourceDouble.build('https://example.jp/a.json', entries('キュアスタ'))
+      flaky = SourceDouble.build('https://example.jp/b.json', entries('デルムリン'))
+      build_dictionary([alive, flaky]).refresh
+
+      # last-good を捨てて「この版を入れた直後」の状態にする。本体キャッシュは残す。
+      redis.keys("#{TaggingDictionary::SOURCE_REDIS_KEY_PREFIX}/*").each {|key| redis.unlink(key)}
+      flaky.words = {}
+      dic = build_dictionary([alive, flaky])
+      dic.refresh
+
+      assert_equal(['キュアスタ', 'デルムリン'].sort, dic.keys.sort)
+    end
+
+    # ⚠ 本体キャッシュも無ければ、痩せていても公開する（何も引けないより良い）。
+    def test_refresh_publishes_partial_without_any_cache
+      alive = SourceDouble.build('https://example.jp/a.json', entries('キュアスタ'))
+      flaky = SourceDouble.build('https://example.jp/b.json', {})
+      dic = build_dictionary([alive, flaky])
+      dic.refresh
+
+      assert_equal(['キュアスタ'], dic.keys)
+    end
+
     private
 
     def redis

--- a/test/unit/lib/tagging_dictionary_source_cache.rb
+++ b/test/unit/lib/tagging_dictionary_source_cache.rb
@@ -22,17 +22,22 @@ module Mulukhiya
 
       def parse = @words
 
-      attr_writer :words
+      attr_writer :words, :strict
 
       def to_h = {uri: uri.to_s}
+
+      # 本物と同じく「解釈に効く設定まで含めた」同一性を返す。
+      def cache_signature
+        return Digest::SHA256.hexdigest([self.class.name, uri.to_s, @strict].to_json)
+      end
     end
 
     URL = 'https://example.jp/api/dic/v1/a.json?access_token=deadbeef'.freeze
 
     def setup
       TaggingDictionary.invalidate_cache
-      @dic = build_dictionary
       @source = SourceDouble.build(URL, entries)
+      @dic = build_dictionary([@source])
     end
 
     def teardown
@@ -102,6 +107,13 @@ module Mulukhiya
       assert_not_equal(@dic.send(:source_key, @source), @dic.send(:source_key, other))
     end
 
+    def test_source_key_separates_parsing_options
+      other = SourceDouble.build(URL, entries)
+      other.strict = true
+
+      assert_not_equal(@dic.send(:source_key, @source), @dic.send(:source_key, other))
+    end
+
     def test_source_key_separates_urls
       other = SourceDouble.build('https://example.jp/api/dic/v1/b.json', entries)
 
@@ -142,9 +154,48 @@ module Mulukhiya
       assert_false(@dic.send(:all_sources_empty?))
     end
 
-    # 何も試していない回を「全滅」と言わない。
-    def test_all_sources_empty_without_attempts
-      assert_false(@dic.send(:all_sources_empty?))
+    # ⚠ 1 本でも取れていれば全滅ではない（残りが空でも）。
+    def test_all_sources_empty_is_false_with_a_partial_failure
+      other = SourceDouble.build('https://example.jp/api/dic/v1/b.json', {})
+      dic = build_dictionary([@source, other])
+      dic.instance_variable_set(:@attempted_sources, 2)
+      dic.send(:fetch_source, @source)
+      dic.send(:fetch_source, other)
+
+      assert_false(dic.send(:all_sources_empty?))
+    end
+
+    # ソースが 1 本も設定されていない回を「全滅」と言わない。
+    def test_all_sources_empty_without_sources
+      assert_false(build_dictionary.send(:all_sources_empty?))
+    end
+
+    # ⚠⚠ **設定はあるのに 1 本も組み立てられなかった回は「全滅」（PR #4686 の
+    # Codex P2）。**`RemoteDictionary.create` が全部落ちると `attempted` が 0 になる。
+    # ここを取り逃がすと、全ソースが使えないのに Sentry へ何も出ない。
+    def test_all_sources_empty_when_nothing_could_be_built
+      dic = build_dictionary([@source])
+      dic.instance_variable_set(:@attempted_sources, 0)
+
+      assert_true(dic.send(:all_sources_empty?))
+    end
+
+    # ⚠⚠ **解釈に効く設定が違えば別のキー（PR #4686 の Codex P2）。**
+    # 同じ URL・同じ type でも `strict` で entries が変わるので、踏み合うと
+    # 別設定の辞書で埋めたものが本体キャッシュへ最大 24 時間居座る。
+    def test_cache_signature_follows_parsing_options
+      loose = RemoteDictionary.create({'url' => URL, 'type' => 'related'})
+      strict = RemoteDictionary.create({'url' => URL, 'type' => 'related', 'strict' => true})
+
+      assert_not_equal(loose.cache_signature, strict.cache_signature)
+      assert_not_equal(@dic.send(:source_key, loose), @dic.send(:source_key, strict))
+    end
+
+    def test_cache_signature_does_not_leak_the_url
+      signature = RemoteDictionary.create({'url' => URL, 'type' => 'related'}).cache_signature
+
+      assert_not_include(signature, 'example.jp')
+      assert_not_include(signature, 'deadbeef')
     end
 
     # `refresh` を通した振る舞い。1 本欠けても辞書が痩せないこと。


### PR DESCRIPTION
#4659 の **②（本命）**。①（リトライ）と ③（呼び出し回数を減らす）は手を付けていません。

## 何が起きていたか

上流の GAS が**間欠 404** を返します（gomander の実測で **1 日 38% の回**にどれかが欠ける）。現行の fail-open は `discardable?` ＝ **「全滅したときだけ」**前回値を残す形なので、**1 本だけ欠けた回はその痩せた辞書がそのままキャッシュへ書かれていました**。

| ホスト | 欠けた率 |
| --- | --- |
| **gomander（キュアスタ！）** | **38%** |
| vulcan（ダイスキー） | 15% |
| zugoga（デルムリン丼） | 10% |

⚠ **entries が実際に痩せます。**gomander の健全値 3957 語に対し、欠けた回は **1814 語**まで落ちます（`dic.json` 単独で 2401 語あるため、1 本欠けるだけで半減する）。

🔴 **キュアスタ！のニチアサ実況に直結します。**辞書が半分の状態で日曜 08:30-09:00 の窓に入ると、タグ付けの取りこぼしがそのまま出ます。

## 直したこと

**ソース単位の last-good を Redis に持ち、空を返した回はそれで埋めます。**

- ⚠ **TTL は本体（1 時間）より長い 24 時間**（`/handler/dictionary_tag/cache/source_ttl`）。同じにすると、続けて外したソースの last-good が先に消えて意味を成しません
- ⚠ **URL をキーに埋めません。**辞書 URL は `?access_token=` を持ちうるうえ、Redis のキー一覧は運用の手元にも syslog にも出ます（#4511）。SHA256 だけを使い、**クラス名も混ぜます**（同じ URL を別の `type` で二重登録できるので、URL だけだと互いの last-good を踏み合う）
- ⚠ **ログは「取れたか」で出します。**埋めた本数で `:info` を出すと、上流が 404 を返し続けても健全に見える ＝ **#4573 で塞いだ穴が戻ります**。`@empty_sources` も取得結果で積むので、**台帳（pooza/chubo2 の `dictionary-registry.md`）の 🟡 間欠の見え方は変わりません**
- `log_generation` に `substituted_sources` を足しました。これが無いと「痩せた辞書で更新した回」と「埋めたので痩せずに済んだ回」が同じ見え方になります

### ⚠⚠ 全滅の alert を落とさないこと

埋まると `entries` は present になるので **`discardable?` を通りません**。従来の `alert_empty_result` はその枝の中にあったので、**そのままだと全ソースが死んでも Sentry には何も出なくなります**（MULUKHIYA-TOOT-PROXY-2Q が鳴らなくなる）。`refresh` の手前で「全ソースが取得に失敗した回か」を見て鳴らす形に移しました。

⚠ **分母は「実際に試した本数」です。**`sources`（設定の本数）とは食い違うことがあり（`RemoteDictionary.create` が落ちた本は `all` に出てこない）、`sources.size` で割ると**全滅しているのに鳴らない**回ができます。

⚠ 副次的に、**last-good も無く全滅した回が `log_generation` にも残るようになりました**（従来は早期 return で syslog に 1 行も残らなかった。#4628 の 6 件目）。

## リファクタ

`TaggingDictionary` が `Metrics/ClassLength` を超えたので、`TaggingDictionaryLogMethods` と同じ形で `TaggingDictionarySourceCacheMethods` へ切り出しました。⚠ 行数合わせではなく、**「辞書を引く」と「引けなかった回をどう埋めるか」を混ぜない**ためです（従来は fail-open が `discardable?` の 1 箇所に埋まっていて、「全滅したときだけ」しか効かないことが読み取りにくかった）。

`fetch` が `RemoteDictionary.all` を直に呼んでいた箇所を `remote_dictionaries` に切り出しました。⚠ これが無いと、last-good の経路をテストするのに**クラスメソッドをグローバルに差し替えるしかなくなります**。

## Redis の使用量

ソース単位の Marshal が増えるので、**タグ辞書まわりの Redis 使用量はおおよそ 2 倍**になります（部分の合計 ≒ 全体）。gomander で健全値 3957 エントリぶんが目安です。

## テスト

`test/unit/lib/tagging_dictionary_source_cache.rb`（16 tests）。⚠ **修正前の `develop` で 1 failures / 13 errors** になることを確認済みです。

- `rake lint` 緑
- `rake test` **1265 tests / 1804 assertions / 0 failures / 0 errors / 322 omissions**

⚠ **本番での効きは syslog の `substituted_sources` で確かめられます**（0 より大きい回が出れば、従来なら痩せていた回）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KUmNREgdYcmxvf7ShNnyPv