### PR TITLE
fix: sidekiq が起動しない — Sidekiq::Config に timeout= は無い (#4687)

### DIFF
--- a/app/initializer/sidekiq.rb
+++ b/app/initializer/sidekiq.rb
@@ -17,31 +17,13 @@ require 'syslog/logger'
 module Mulukhiya
   daemon = SidekiqDaemon.new
   config = YAML.load_file(daemon.config_cache_path).deep_symbolize_keys
+  # ⚠⚠ **中身は SidekiqDaemon.configure_server に置く (#4687)。**
+  # `Sidekiq.configure_server` のブロックは **sidekiq の CLI でしか実行されない**
+  # (`Sidekiq.server?` が false の環境では yield されない) ため、ここに直接書くと
+  # `rake test` でも fedi-test-harness でも puma からも 1 行も走らない。
+  # 🔴 **#4687 はそれで CI 緑・harness 両系緑のまま本番の起動で初めて発火した。**
   Sidekiq.configure_server do |sidekiq|
-    sidekiq.redis = {url: config.dig(:redis, :dsn)}
-    sidekiq.concurrency = config[:concurrency]
-    # ⚠⚠ **停止の締切を上流の既定に任せない (#4675 の Codex P1)。**rc.d の
-    # `mulukhiya_sidekiq_kill_wait` はこの値より長くなければならず、暗黙の既定の
-    # ままだと上流のバージョン更新で黙って食い違う。詳細は SHUTDOWN_TIMEOUT。
-    sidekiq.timeout = SidekiqDaemon::SHUTDOWN_TIMEOUT
-    # Sidekiq 内部ログ (retry / scheduler / boot 等) を $stdout ではなく syslog へ。
-    # Ginseng::Logger と同じ ident (Package.name) / facility (LOG_USER) を使い、puma・
-    # WorkerLoggingMiddleware と同じ /var/log/mulukhiya-toot-proxy.log に集約する (#4362)。
-    # WorkerLoggingMiddleware が出すジョブライフサイクルログ (#4079) はそのまま維持。
-    sidekiq.logger = Syslog::Logger.new(Package.name)
-    sidekiq.logger.level = config.dig(:logger, :level)
-    sidekiq.logger.formatter = Sidekiq::Logger::Formatters::JSON.new
-    sidekiq.server_middleware do |chain|
-      chain.add WorkerLoggingMiddleware
-    end
-    # local.yaml で `capsule: null` が混入しても media_catalog キューを listen する
-    # capsule が必ず立ち上がるよう defensive default を取る。schema 上 optional だが
-    # 未設定 = 専用 capsule 無し = ジョブが Redis に溜まり続ける経路は塞ぐ。
-    capsule_config = config.dig(:capsule, :media_catalog) || {}
-    sidekiq.capsule(:media_catalog) do |cap|
-      cap.queues = ['media_catalog']
-      cap.concurrency = capsule_config[:concurrency] || 1
-    end
+    SidekiqDaemon.configure_server(sidekiq, config)
   end
   Sidekiq::Scheduler.enabled = true
   Sidekiq::Scheduler.dynamic = true

--- a/app/lib/mulukhiya/daemon/sidekiq_daemon.rb
+++ b/app/lib/mulukhiya/daemon/sidekiq_daemon.rb
@@ -1,4 +1,8 @@
 require 'sidekiq/api'
+# ⚠ capsule は sidekiq の CLI が読む。configure_server を CLI の外から
+# 検査できるようにここで明示的に読む (#4687)。
+require 'sidekiq/capsule'
+require 'syslog/logger'
 
 module Mulukhiya
   class SidekiqDaemon < Ginseng::Daemon
@@ -54,6 +58,44 @@ module Mulukhiya
     def self.restart
       CommandLine.new([File.join(Environment.dir, 'bin/sidekiq_daemon.rb'), 'restart'])
         .exec(timeout: config['/daemon/restart/timeout/seconds'])
+    end
+
+    # `Sidekiq.configure_server` に渡す設定をここへ置く (#4687)。
+    #
+    # ⚠⚠ **initializer のブロックへ直接書かないこと。**`Sidekiq.configure_server` は
+    # `Sidekiq.server?` が false の環境では yield しない ＝ **sidekiq の CLI でしか
+    # 実行されない**ので、あちらへ書いた行は `rake test` でも fedi-test-harness でも
+    # puma からも走らない。🔴 **#4687（`Sidekiq::Config#timeout=` は存在しない）は
+    # それで CI 緑・harness 両系緑のまま、本番の起動で初めて発火した。**
+    # ここへ置けば `test/unit/daemon/sidekiq_daemon.rb` が実物の `Sidekiq::Config` を
+    # 渡して検査できる。
+    def self.configure_server(sidekiq, config)
+      sidekiq.redis = {url: config.dig(:redis, :dsn)}
+      sidekiq.concurrency = config[:concurrency]
+      # ⚠⚠ **停止の締切を上流の既定に任せない (#4675 の Codex P1)。**rc.d の
+      # `mulukhiya_sidekiq_kill_wait` はこの値より長くなければならず、暗黙の既定の
+      # ままだと上流のバージョン更新で黙って食い違う。詳細は SHUTDOWN_TIMEOUT。
+      # ⚠ `timeout` は `Sidekiq::Config` の素のキーで、**setter は無い** (#4687)。
+      sidekiq[:timeout] = SHUTDOWN_TIMEOUT
+      # Sidekiq 内部ログ (retry / scheduler / boot 等) を $stdout ではなく syslog へ。
+      # Ginseng::Logger と同じ ident (Package.name) / facility (LOG_USER) を使い、puma・
+      # WorkerLoggingMiddleware と同じ /var/log/mulukhiya-toot-proxy.log に集約する (#4362)。
+      # WorkerLoggingMiddleware が出すジョブライフサイクルログ (#4079) はそのまま維持。
+      sidekiq.logger = Syslog::Logger.new(Package.name)
+      sidekiq.logger.level = config.dig(:logger, :level)
+      sidekiq.logger.formatter = Sidekiq::Logger::Formatters::JSON.new
+      sidekiq.server_middleware do |chain|
+        chain.add WorkerLoggingMiddleware
+      end
+      # local.yaml で `capsule: null` が混入しても media_catalog キューを listen する
+      # capsule が必ず立ち上がるよう defensive default を取る。schema 上 optional だが
+      # 未設定 = 専用 capsule 無し = ジョブが Redis に溜まり続ける経路は塞ぐ。
+      capsule_config = config.dig(:capsule, :media_catalog) || {}
+      sidekiq.capsule(:media_catalog) do |cap|
+        cap.queues = ['media_catalog']
+        cap.concurrency = capsule_config[:concurrency] || 1
+      end
+      return sidekiq
     end
 
     def self.health

--- a/test/unit/daemon/sidekiq_daemon.rb
+++ b/test/unit/daemon/sidekiq_daemon.rb
@@ -44,7 +44,52 @@ module Mulukhiya
       assert_operator(SidekiqDaemon::SHUTDOWN_TIMEOUT, :>, 0)
     end
 
+    # ⚠⚠ **initializer のブロックは sidekiq の CLI でしか実行されない (#4687)。**
+    # `Sidekiq.configure_server` は `Sidekiq.server?` が false の環境では yield しない
+    # ので、あそこに書いた行は `rake test` でも fedi-test-harness でも puma からも
+    # 1 行も走らない。🔴 **`Sidekiq::Config#timeout=` は存在しないのに CI 緑・harness
+    # 両系緑のまま本番の起動で初めて発火した**のがそれ。
+    #
+    # ⚠ **実物の `Sidekiq::Config` を渡す。**ダブルを渡すと「存在しない setter を
+    # 呼んでいる」というこの欠陥そのものを取り逃がす。
+    def test_configure_server
+      sidekiq = Sidekiq::Config.new
+      assert_nothing_raised do
+        SidekiqDaemon.configure_server(sidekiq, sidekiq_config)
+      end
+      assert_equal(SidekiqDaemon::SHUTDOWN_TIMEOUT, sidekiq[:timeout])
+      assert_equal(3, sidekiq.concurrency)
+      assert_equal(['media_catalog'], sidekiq.capsule(:media_catalog).queues)
+      assert_equal(2, sidekiq.capsule(:media_catalog).concurrency)
+    end
+
+    # ⚠ **`timeout` に setter は無い** (#4687)。`concurrency` にはあるので
+    # 「片方あるなら両方あるだろう」で書くと落ちる。上流が setter を生やしたら
+    # このテストは落ちてよい（そのときは initializer 側も見直す合図）。
+    def test_sidekiq_config_has_no_timeout_writer
+      assert_false(Sidekiq::Config.new.respond_to?(:timeout=))
+      assert_respond_to(Sidekiq::Config.new, :concurrency=)
+    end
+
+    # capsule の設定が無くても media_catalog キューを listen する capsule は立てる。
+    def test_configure_server_without_capsule_config
+      sidekiq = Sidekiq::Config.new
+      SidekiqDaemon.configure_server(sidekiq, sidekiq_config.merge(capsule: nil))
+
+      assert_equal(['media_catalog'], sidekiq.capsule(:media_catalog).queues)
+      assert_equal(1, sidekiq.capsule(:media_catalog).concurrency)
+    end
+
     private
+
+    def sidekiq_config
+      return {
+        redis: {dsn: 'redis://127.0.0.1:6379/2'},
+        concurrency: 3,
+        logger: {level: 1},
+        capsule: {media_catalog: {concurrency: 2}},
+      }
+    end
 
     def rcd_kill_wait
       path = File.join(Environment.dir, 'config/sample/freebsd/mulukhiya-sidekiq')


### PR DESCRIPTION
Fixes #4687

## 何が起きたか

5.36.0（`bf407f6c`）を **dev24 へデプロイした時点で sidekiq が起動しなくなった**。
`/mulukhiya/api/health` が `sidekiq: NG` の 503 を返し続け、**monit が 3 サイクルで
3 サービスの再起動を撃つループ**に入った。

```
$ bundle exec sidekiq --require ./app/initializer/sidekiq.rb
undefined method 'timeout=' for an instance of Sidekiq::Config
app/initializer/sidekiq.rb:26:in 'block in <module:Mulukhiya>'
```

`de3f8d01`（PR #4676・**#4675 の Codex P1**）で入れた `sidekiq.timeout = ...` が誤り。
**`Sidekiq::Config` に `timeout=` は無い**（`concurrency=` はある）。`timeout` は
`DEFAULTS` の素のキーなので `sidekiq[:timeout] = ...` が正しい。

```ruby
Sidekiq::Config.new.respond_to?(:timeout=)     #=> false
Sidekiq::Config.new.respond_to?(:concurrency=) #=> true
```

## ⚠⚠ なぜ CI も harness も通ったのか

🔴 **`Sidekiq.configure_server` のブロックは sidekiq の CLI でしか実行されない**
（`Sidekiq.server?` が false の環境では yield されない）。`app/initializer/sidekiq.rb`
の中身は **`rake test` でも fedi-test-harness でも puma からも 1 行も走らない**ので、
**CI 緑・harness 両系緑のまま、次の起動で初めて発火する**。

## 直し方

**1 行直して終わりにしていない。**同じ穴にまた次の行が置かれるので、ブロックの中身を
`SidekiqDaemon.configure_server(sidekiq, config)` へ切り出し、**実物の `Sidekiq::Config`
を渡す正テスト**を持たせた（ダブルを渡すと「存在しない setter を呼んでいる」という
この欠陥そのものを取り逃がす）。

- `test_configure_server` — 例外を出さずに設定が入ること。`[:timeout]` / `concurrency` /
  capsule の queue と concurrency を実値で確認
- `test_sidekiq_config_has_no_timeout_writer` — `timeout=` が無く `concurrency=` があること。
  上流が setter を生やしたら落ちてよい（initializer を見直す合図）
- `test_configure_server_without_capsule_config` — `capsule: null` でも media_catalog capsule が立つ

⚠ `require 'sidekiq/capsule'` を明示した。従来は sidekiq の CLI が読んでいたので、
CLI の外から `configure_server` を検査できなかった。

**修正前のコードでこのテストが `NoMethodError` で落ちることを確認済み**（回帰テストとして機能する）。

## 検証

- `rake lint` 緑（bundler-audit 含む）
- `rake test` **1275 tests / 1822 assertions / 0 failures / 0 errors / 322 omissions**（harness 無し）

## 影響範囲

- **本番は無傷**（5.36.0 は未リリース・本番 4 台は 5.35.0）
- ⚠ **このままリリースしていたら本番 4 台の sidekiq が全滅していた**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkesFRvmUH5d5EqKYN3N5f