### PR TITLE
fix: /health の pgbouncer 観測を期限で括る (#4691)

### DIFF
--- a/app/lib/mulukhiya/dbms/pgbouncer.rb
+++ b/app/lib/mulukhiya/dbms/pgbouncer.rb
@@ -1,4 +1,5 @@
 require 'pg'
+require 'timeout'
 
 module Mulukhiya
   # pgbouncer の待ち行列を `/health` に載せる (#4618 の P1)。
@@ -75,19 +76,31 @@ module Mulukhiya
 
       private
 
+      # ⚠⚠ **全体を期限で括る (#4691)。**`connect_timeout` が効くのは**接続確立まで**で、
+      # このあとの `SHOW` 4 往復は無界だった。`/health` は monit の唯一の判定材料
+      # （`check host mulukhiya ... request "/mulukhiya/api/health"` / `set daemon 30` ×
+      # `for 3 cycles`）なので、admin コンソールが「TCP は受けるが答えない」状態に
+      # なると、🔴 **puma / sidekiq / listener が健全でも 90 秒ごとに 3 本まとめて
+      # 再起動される**。⚠ モロヘイヤを再起動しても pgbouncer は直らないのでループになる。
+      #
+      # ⚠ 期限切れは `health` の rescue に落ちて `{pgbouncer: {error: ...}}` になる。
+      # **status は動かさない**という設計はそのまま（観測が取れないことで health を
+      # 落とさない）。
       def probe
-        connection = connect
-        pool = pool_row(connection)
-        return {
-          database: dsn.dbname,
-          # ⚠ 該当プールがまだ作られていないことはある（誰も繋いでいない）。
-          # **0 と「不明」は違う**ので、行が無いときは値を載せない。
-          **(pool ? POOL_FIELDS.to_h {|k| [k.to_sym, pool[k].to_i]} : {absent: true}),
-          **clients(connection),
-          **cumulative(connection),
-        }
-      ensure
-        connection&.close
+        Timeout.timeout(config['/postgres/pgbouncer/timeout']) do
+          connection = connect
+          pool = pool_row(connection)
+          return {
+            database: dsn.dbname,
+            # ⚠ 該当プールがまだ作られていないことはある（誰も繋いでいない）。
+            # **0 と「不明」は違う**ので、行が無いときは値を載せない。
+            **(pool ? POOL_FIELDS.to_h {|k| [k.to_sym, pool[k].to_i]} : {absent: true}),
+            **clients(connection),
+            **cumulative(connection),
+          }
+        ensure
+          connection&.close
+        end
       end
 
       def connect

--- a/test/unit/dbms/pgbouncer.rb
+++ b/test/unit/dbms/pgbouncer.rb
@@ -77,6 +77,24 @@ module Mulukhiya
       def close = @closed = true
     end
 
+    # ⚠⚠ **「TCP は受けるが答えない」admin コンソールのダブル (#4691)。**
+    # `connect_timeout` は接続確立までしか効かないので、詰まりはここに出る。
+    class HangingAdmin
+      attr_reader :closed
+
+      def initialize(seconds = 5)
+        @seconds = seconds
+        @closed = false
+      end
+
+      def exec(_sql)
+        sleep(@seconds)
+        raise 'unreachable'
+      end
+
+      def close = @closed = true
+    end
+
     def setup
       config['/postgres/dsn'] = 'postgres://mastodon:secret@127.0.0.1:6432/mastodon'
       config['/postgres/pgbouncer/enable'] = 'auto'
@@ -174,6 +192,29 @@ module Mulukhiya
       end
 
       assert_equal('no more connections allowed (max_client_conn)', health.dig(:pgbouncer, :error))
+    end
+
+    # 🔴 **`/health` は monit の唯一の判定材料 (#4691)。**`set daemon 30` ×
+    # `for 3 cycles` ＝ 90 秒で puma / sidekiq / listener が**まとめて再起動される**
+    # ので、admin コンソールが答えないときにここが返らないと、健全な 3 本を
+    # 巻き込んだ再起動ループになる。⚠ モロヘイヤを再起動しても pgbouncer は直らない。
+    def test_health_gives_up_when_the_admin_console_never_answers
+      config['/postgres/pgbouncer/timeout'] = 0.2
+      admin = HangingAdmin.new
+      started = Time.now
+      health = with_admin(admin) {Pgbouncer.health}
+
+      assert_operator(Time.now - started, :<, 2)
+      assert_predicate(health.dig(:pgbouncer, :error), :present?)
+    end
+
+    # ⚠ 期限切れでも接続は返す。`ensure` が期限の内側にあると閉じ損ねる。
+    def test_the_connection_is_closed_even_when_the_probe_times_out
+      config['/postgres/pgbouncer/timeout'] = 0.2
+      admin = HangingAdmin.new
+      with_admin(admin) {Pgbouncer.health}
+
+      assert_predicate(admin, :closed)
     end
 
     # ⚠⚠ **`cl_waiting` / `maxwait` は「いまキューに居る人」の値でしかない**


### PR DESCRIPTION
5.36.0 のリリース前 5 観点レビューで検出した**唯一の赤**。2 観点（エラー処理・観測性 / 並行性・ライフサイクル）が独立に指摘し、実コードで裏を取った。

## 事象

`Pgbouncer.probe` の `connect_timeout` は**接続確立まで**しか効かず、その後の `SHOW POOLS` / `SHOW LISTS` / `SHOW CONFIG` / `SHOW STATS` の 4 往復は**無界**だった。

## 🔴 なぜ赤か

`Pgbouncer.health` は `Postgres.health` の 3 分岐すべてから呼ばれ、`GET /mulukhiya/api/health` の本体になる。本番の monit はそれだけを判定材料にしている:

```
check host mulukhiya with address 127.0.0.1
  if failed port 3008 protocol http request "/mulukhiya/api/health" status = 200
    for 3 cycles
  then exec "... service mulukhiya-puma restart && ... sidekiq ... && ... listener ..."
```

`set daemon 30` × `for 3 cycles` ＝ **90 秒**。⚠⚠ **「pgbouncer の不調 → モロヘイヤの再起動」という向きの結合が、このリリースで初めて入った。**⚠ モロヘイヤを再起動しても pgbouncer は直らないのでループになる。⚠ **pgbouncer は restart 禁止**（SIGTERM が graceful drain）なので復旧手段も限られる。

## 直し方

`probe` 全体を既存の `/postgres/pgbouncer/timeout` で括った。⚠ 期限切れは `health` の既存 rescue に落ちて `{pgbouncer: {error: ...}}` になり、**`status` は動かさない**という設計（観測が取れないことで health を落とさない）はそのまま。

## テスト

- `test_health_gives_up_when_the_admin_console_never_answers` — 答えない admin で `health` が期限内に返る
- `test_the_connection_is_closed_even_when_the_probe_times_out` — ⚠ `ensure` が期限の内側にあると閉じ損ねるので、期限切れでも接続を返すことを見る

`ruby bin/test.rb pgbouncer` 18 tests / 0 failures / 0 errors。`rake lint` 緑（rubocop 505 files / bundler-audit 脆弱性 0）。

Closes #4691

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDCyVvccEAb72FBdnzDEvB