### PR TITLE
deps: ginseng-* 7 本を版で固定する (pooza/ginseng-style#103)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,14 +3,14 @@ ruby '>= 4.0.2', '< 5.0'
 gem 'concurrent-ruby'
 gem 'dry-validation'
 gem 'faye-websocket', github: 'pooza/faye-websocket-ruby'
-gem 'ginseng-core', github: 'pooza/ginseng-core', branch: 'main', require: 'ginseng'
-gem 'ginseng-fediverse', github: 'pooza/ginseng-fediverse', branch: 'main',
+gem 'ginseng-core', github: 'pooza/ginseng-core', tag: 'v1.23.7', require: 'ginseng'
+gem 'ginseng-fediverse', github: 'pooza/ginseng-fediverse', tag: 'v1.8.31',
   require: 'ginseng/fediverse'
-gem 'ginseng-piefed', github: 'pooza/ginseng-piefed', branch: 'main', require: 'ginseng/piefed'
-gem 'ginseng-postgres', github: 'pooza/ginseng-postgres', branch: 'main'
-gem 'ginseng-redis', github: 'pooza/ginseng-redis', branch: 'main', require: 'ginseng/redis'
-gem 'ginseng-web', github: 'pooza/ginseng-web', branch: 'main', require: 'ginseng/web'
-gem 'ginseng-youtube', github: 'pooza/ginseng-youtube', branch: 'main', require: 'ginseng/you_tube'
+gem 'ginseng-piefed', github: 'pooza/ginseng-piefed', tag: 'v0.1.1', require: 'ginseng/piefed'
+gem 'ginseng-postgres', github: 'pooza/ginseng-postgres', tag: 'v2.0.1'
+gem 'ginseng-redis', github: 'pooza/ginseng-redis', tag: 'v2.0.6', require: 'ginseng/redis'
+gem 'ginseng-web', github: 'pooza/ginseng-web', tag: 'v2.0.0', require: 'ginseng/web'
+gem 'ginseng-youtube', github: 'pooza/ginseng-youtube', tag: 'v3.0.1', require: 'ginseng/you_tube'
 gem 'icalendar'
 # ⚠⚠ **推移依存だが上限をこちらで持つ (#4699)。**`json` を要求している gem は
 # どれも `json (>= 2.3)` のように**下限しか書いていない**ので、`bundle update` の

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 GIT
   remote: https://github.com/pooza/ginseng-core.git
   revision: b6e736db820caca781890fb134b937e7e37ca61c
-  branch: main
+  tag: v1.23.7
   specs:
     ginseng-core (1.23.7)
       activesupport (>= 8.1.2.1)
@@ -42,22 +42,22 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-fediverse.git
-  revision: 8d6d1fa6f9e49f71347cd3b47eea794f12ae8f45
-  branch: main
+  revision: f6e160a2794db2573b9210eea23ab7593dcc5123
+  tag: v1.8.31
   specs:
     ginseng-fediverse (1.8.31)
 
 GIT
   remote: https://github.com/pooza/ginseng-piefed.git
-  revision: afddcdace7ae524cfba4967e5f7de97637bbea32
-  branch: main
+  revision: ec2bf39fd0c706c33a9d159fb13fd8006b001927
+  tag: v0.1.1
   specs:
     ginseng-piefed (0.1.1)
 
 GIT
   remote: https://github.com/pooza/ginseng-postgres.git
-  revision: 23e10ea2b7897f48f485caca4c8fd5cae6f4f2ca
-  branch: main
+  revision: dfb8e65fe645e745ae03f2cb9a84c1fb8e95188b
+  tag: v2.0.1
   specs:
     ginseng-postgres (2.0.1)
       pg
@@ -65,8 +65,8 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-redis.git
-  revision: 7a1e9c658de93b3bb9a8871d2aa35939fb07e69f
-  branch: main
+  revision: 0019c73ea1eed170ef40712f788171f1edf242c9
+  tag: v2.0.6
   specs:
     ginseng-redis (2.0.6)
       redis-client
@@ -84,8 +84,8 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-web.git
-  revision: 2f4fd0e68fe24fe56914648b5d3a967791f99309
-  branch: main
+  revision: 9814f164d64658c94923c55b0e8a920b6c798960
+  tag: v2.0.0
   specs:
     ginseng-web (2.0.0)
       erb
@@ -100,8 +100,8 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-youtube.git
-  revision: 71415a45d291f7a823e1b51c397e4651d9625237
-  branch: main
+  revision: 74b9f344df15ab8a2f6f09808781f97e6ad872a5
+  tag: v3.0.1
   specs:
     ginseng-youtube (3.0.1)
 


### PR DESCRIPTION
`ginseng-*` **7 本**の参照を **版（タグ）固定へ**移します。pooza/ginseng-style#103 のロールアウトです。

## なぜ

⚠⚠ **未固定だと、向こうの `main` にマージされた瞬間が露出**になります。いま壊れないのは `Gemfile.lock` が守っているからで、破綻は 🔴 **次の `bundle update`（＝無関係な PR の中）**で出ます。「どの変更のせいか」が分からない場所です。

固定すると、破綻する場所が **`bundle update` の中（無関係な PR）** から **タグを上げる差分そのもの** へ移ります。

⚠⚠ **訂正（2026-09-09・Codex P2 / #4702）**: 当初ここに「dependabot が `bump ginseng-core from v1.23.7 to ...` として出し、この repo の CI が受ける」と書いていましたが、**誤りでした。**`.github/dependabot.yml` は Bundler の 2 エントリとも `open-pull-requests-limit: 0` で、**version update が丸ごと無効**です（security update だけが残る）。**その自動経路は現状ありません。**受け皿の整備は **#4702** に分けました。

⚠ ただし凍結はしません。`docs/CLAUDE.md` §6-1 の「ginseng-* のピンのずれを見る」が毎セッション走っており、**タグ固定後も `Gemfile.lock` は `revision:` を書き続ける**ので、あのスクリプトは無改造で動きます（実測済み）。**受け皿は「無い」のではなく「手動・セッション頻度」**です。

## ⚠ これは「更新」ではなく「記録」です

⚠⚠ **版は 1 つも上げていません。**`Gemfile.lock` の版の行は 7 本とも変わりません。

| gem | revision | タグ |
| --- | --- | --- |
| `ginseng-core` | ✅ **`b6e736db`（動かない）** | `v1.23.7` |
| `ginseng-fediverse` | `8d6d1fa6` → `f6e160a2` | `v1.8.31` |
| `ginseng-piefed` | `afddcdac` → `ec2bf39f` | `v0.1.1` |
| `ginseng-postgres` | `23e10ea2` → `dfb8e65f` | `v2.0.1` |
| `ginseng-redis` | `7a1e9c65` → `0019c73e` | `v2.0.6` |
| `ginseng-web` | `2f4fd0e6` → `9814f164` | `v2.0.0` |
| `ginseng-youtube` | `71415a45` → `74b9f344` | `v3.0.1` |

⚠⚠ **revision が動く 6 本も、配布物は完全に同一**です。刺さっていたコミットはどれもタグの 1〜5 個先で、**差分は `.github/workflows/*` と gem 自身の `Gemfile`（`ginseng-style` の版上げ）だけ**。各 gem の `release.yml` の `paths` に入るファイルの差分は**全件ゼロ**であることを実測しました。

## 🔴 `ginseng-web` は `v2.0.0` のまま置いています

昨日 `v3.0.0` が出ていますが、⚠⚠ **破壊的変更**（`rack` / `rack-session` / `sinatra` / `tilt` / `puma` を gemspec から削除）です。こちらは #4679 で 5 つとも自前宣言済みなので**上げても壊れないはず**ですが、⚠ **版を上げるのはこの PR の仕事ではありません。**

⚠⚠ **訂正（2026-09-09）**: 「dependabot がそこで受けます」も上記のとおり成立しません。**v3.0.0 への追随は #6-1 のずれ検出（本日の同期で実際に検出済み）を起点に、別 PR で行います。**

## 検証

- `bundle install` → lock の差分は参照行のみ。**版の行に差分なし**
- `bundle exec rubocop` → ✅ **505 files / no offenses**
- ⚠ `bundle exec rake test` は手元では 10 分を超えて完走しなかったので、**判定は CI にお願いします**（他 9 本では、手元で赤くても CI は緑でした）
- ⚠ `ginseng-fediverse` の行は `tag:` を足すと 100 桁を超えるので `require:` の前で折りました（pooza/ginseng-style#80 で `Gemfile` も lint 対象）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CuNhF8dFKWunP99LifBqbV

