### PR TITLE
chore: 小粒の掃除 4 件（手順 12・#4698 から外したもの）

### DIFF
--- a/app/lib/mulukhiya/dbms/postgres.rb
+++ b/app/lib/mulukhiya/dbms/postgres.rb
@@ -59,8 +59,10 @@ module Mulukhiya
       instance.connection.fetch('SELECT 1 AS ok').first
       return {status: 'OK'}.merge(snapshot).merge(Pgbouncer.health)
     rescue Sequel::PoolTimeout => e
-      return {error: e.message, status: 'WARN', reason: 'pool_exhausted'}
-          .merge(snapshot || pool).merge(Pgbouncer.health)
+      # ⚠ `snapshot` は必ず Hash。`pool` は自前の rescue で `{}` を返すので raise せず、
+      # ここへ来る時点で代入は済んでいる（`|| pool` は到達しない死にコードだった）。
+      result = {error: e.message, status: 'WARN', reason: 'pool_exhausted'}
+      return result.merge(snapshot).merge(Pgbouncer.health)
     rescue => e
       # ⚠ NG のときこそ pgbouncer の生死が要る。「Postgres NG だが pgbouncer は
       # 答える」と「両方死んでいる」は切り分けが真逆になる。

--- a/app/lib/mulukhiya/model/attachment_methods.rb
+++ b/app/lib/mulukhiya/model/attachment_methods.rb
@@ -59,7 +59,7 @@ module Mulukhiya
       # note_id ベースで unnest を展開するため `status_id`。**この 1 行が
       # 2 ファイルを分けていた唯一の差分。**
       def catalog_cursor_key
-        raise NotImplementedError, "\#{self}.catalog_cursor_key"
+        raise NotImplementedError, "#{self}.catalog_cursor_key"
       end
     end
 

--- a/app/lib/mulukhiya/tagging_dictionary.rb
+++ b/app/lib/mulukhiya/tagging_dictionary.rb
@@ -136,6 +136,9 @@ module Mulukhiya
     # 次の refresh が last-good で埋め直すので**「既知の状態から始める」にならない**。
     def self.invalidate_cache
       redis = Redis.new
+      # ⚠ `KEYS` は Redis 全体を走査してブロックするが、**呼び出し元はテストだけ**
+      # （`TestCase.invalidate_shared_caches` と辞書キャッシュのテスト 3 本）で、
+      # 本番の要求経路には乗らない。SCAN へ置き換える価値が無いので意図して残す。
       redis.keys("#{SOURCE_REDIS_KEY_PREFIX}/*").each {|key| redis.unlink(key)}
       return redis.unlink(REDIS_KEY)
     end

--- a/app/lib/mulukhiya/webhook.rb
+++ b/app/lib/mulukhiya/webhook.rb
@@ -2,7 +2,11 @@ module Mulukhiya
   class Webhook
     include Package
     include SNSMethods
-    # ⚠ クラスメソッド (`self.create`) から digest を丸めるので `extend` (#4655)。
+    # ⚠ **クラス側から digest を丸められるようにしておく (#4655)。**
+    # 導入時の呼び出し元だった `self.create` は #4657 で消えたが、これは
+    # **意図して残している** — digest をログへ出す経路がクラス側に生えたときに
+    # 素の値が漏れないための備えで、`LogScrubPathTest#test_webhook_class_scrubs_digest`
+    # が `Webhook.scrub_log_digest` を直接叩いて押さえている。**死にコードではない。**
     extend LogScrubber
 
     attr_reader :sns, :reporter

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1336,18 +1336,37 @@ DB 直読み層（account / status / attachment / postgres）も **omission 0 �
 改善ではあるが、測って決めた記録は無い。⚠⚠ **クローズしてよいかはユーザーに確認する**
 （[[feedback_defer-requires-followup-issue]]「元要件を先送りする時は受け皿を起票するまでクローズ不可・クローズ前に確認」）。
 
-### ⚠ 先にやること: 小粒の掃除（手順 12）
+### 小粒の掃除（手順 12）— ✅ 着地（2026-09-09）
 
-**#4698 から外した 5 件**を 1 PR で落とす。⚠ **動作を変えない・既存テストで担保される・lint 緑**のものだけ。
+**#4698 から外した 5 件**を 1 PR で落とした。⚠ **動作を変えない・既存テストで担保される・lint 緑**のものだけ。
 
-1. `app/lib/mulukhiya/model/attachment_methods.rb` — `"\#{self}.catalog_cursor_key"` の補間がエスケープされていて literal で出る（**1 文字**）
-2. `app/lib/mulukhiya/dbms/postgres.rb` — `return` に多行チェイン（ginseng-style の明示的禁止形）。⚠ `snapshot || pool` の `|| pool` は到達しない
-3. `test/unit/dbms/pgbouncer.rb` — 見栄えのための桁揃え 4 行
-4. `app/lib/mulukhiya/webhook.rb` — `extend LogScrubber` が死にコード（`self.create` は #4657 で削除済み）
-5. `test/unit/daemon/sidekiq_daemon.rb` — クラス名 `SudekiqDaemonTest` の綴り
+| | 対象 | 結果 |
+| --- | --- | --- |
+| 1 | `model/attachment_methods.rb` — `"\#{self}.catalog_cursor_key"` の補間がエスケープされ literal で出る | ✅ 修正（**1 文字**） |
+| 2 | `dbms/postgres.rb` — `return` に多行チェイン ＋ 到達しない `\|\| pool` | ✅ 修正（一時変数に割って 1 行 return・`\|\| pool` を削除） |
+| 3 | `test/unit/dbms/pgbouncer.rb` — 見栄えのための桁揃え 4 行 | ⚠ **既に無かった**（`459cfa75` で解消済み）。着手前に実測すること |
+| 4 | `webhook.rb` — `extend LogScrubber` が死にコード | 🔴 **誤り。取り下げた**（下記） |
+| 5 | `test/unit/daemon/sidekiq_daemon.rb` — クラス名 `SudekiqDaemonTest` の綴り | ✅ 修正 |
 
-あわせて ① として「起票しない」と決めたもの: `TaggingDictionary.invalidate_cache` の `KEYS` は
-**呼び出し元がテストと rake のみ＝本番影響なし**なので、**該当箇所へコメント 1 行**を残して終わりにする。
+あわせて ① として「起票しない」と決めていた `TaggingDictionary.invalidate_cache` の `KEYS` は、
+**該当箇所へコメント**を残して終わりにした。⚠ 起票時の「呼び出し元はテストと **rake**」は不正確で、
+**実際の呼び出し元はテストだけ**（`TestCase.invalidate_shared_caches` と辞書キャッシュのテスト 3 本）。
+`app/task/mulukhiya/tagging.rb` が叩いているのは `TaggingDictionaryUpdateWorker` で、これとは別物。
+
+#### 🔴 4 は死にコードではなかった — テストが根拠付きで依存していた
+
+`Webhook` の `extend LogScrubber` は、導入時の呼び出し元（`self.create`）こそ #4657 で消えているが、
+**`test/unit/controller/log_scrub_path.rb` の `test_webhook_class_scrubs_digest` が
+`Webhook.scrub_log_digest` を直接叩いている。**しかもそのテストには
+
+> ⚠ **クラスメソッドからも引ける**ことを押さえる。digest をログへ出す経路がクラス側に生えたときに、素の値が漏れないため。
+
+という**意図の明記**がある。⚠⚠ **「呼び出し元が消えた」だけで死にコードと判定してはいけない。**
+`extend` / `include` は**能力を生やす**ので、消費者はクラス本体の外（テスト・将来の経路）にいる。
+今回は `grep -rn "Webhook\.scrub"` を repo 全体へ打って初めて見つかった。
+
+取り下げの代わりに、**stale だったコメントのほうを直した**（`self.create` を根拠として挙げていたので、
+読んだ人が同じ誤判定を繰り返す形になっていた）。
 
 ## リリース済み: 5.36.0（2026-09-08）
 

--- a/test/unit/daemon/sidekiq_daemon.rb
+++ b/test/unit/daemon/sidekiq_daemon.rb
@@ -1,5 +1,5 @@
 module Mulukhiya
-  class SudekiqDaemonTest < TestCase
+  class SidekiqDaemonTest < TestCase
     def setup
       @daemon = SidekiqDaemon.new
       config['/crypt/password'] = 'mulukhiya'


### PR DESCRIPTION
`docs/CLAUDE.md`「開発中: 5.37.0 → 小粒の掃除（手順 12）」に溜めていたものを 1 PR で落とします。
⚠ **動作を変えない・既存テストで担保される・lint 緑**のものだけ。

## 落としたもの

| | 対象 | 内容 |
| --- | --- | --- |
| 1 | `model/attachment_methods.rb` | `"\#{self}.catalog_cursor_key"` の補間がエスケープされていて **literal で出ていた**（1 文字） |
| 2 | `dbms/postgres.rb` | `return` の多行チェイン（ginseng-style の明示的禁止形）を一時変数に割った。あわせて到達しない `\|\| pool` を削除 |
| 5 | `test/unit/daemon/sidekiq_daemon.rb` | クラス名 `SudekiqDaemonTest` の綴り |
| ＋ | `tagging_dictionary.rb` | `invalidate_cache` の `KEYS` に、本番経路に乗らない旨のコメント（① として「起票しない」と決めていたもの） |

2 の `|| pool` が到達しない理由: `pool` は自前の `rescue => e` で `{}` を返すので **raise しない**。
したがって `Sequel::PoolTimeout` を掴む時点で `snapshot` は必ず Hash（空でも truthy）。

## 🔴 4 は取り下げました — `webhook.rb` の `extend LogScrubber` は死にコードではない

起票時の根拠は「導入時の呼び出し元 `self.create` が #4657 で削除済み」でしたが、
**`test/unit/controller/log_scrub_path.rb` の `test_webhook_class_scrubs_digest` が
`Webhook.scrub_log_digest` を直接叩いています。**しかもそのテストには

> ⚠ **クラスメソッドからも引ける**ことを押さえる。digest をログへ出す経路がクラス側に生えたときに、素の値が漏れないため。

という**意図の明記**があります。消すと 1 件落ちます。

⚠⚠ **`extend` / `include` は能力を生やすので、消費者はクラス本体の外（テスト・将来の経路）にいる。
「呼び出し元が消えた」だけで死にコードと判定してはいけません。**
今回は `grep -rn "Webhook\.scrub"` を repo 全体へ打って初めて見つかりました。

代わりに、`self.create` を根拠として挙げていた **stale なコメントのほうを直しました**
（読んだ人が同じ誤判定を繰り返す形になっていたため）。

## ⚠ 3 は既に無くなっていました

`test/unit/dbms/pgbouncer.rb` の桁揃えは `459cfa75`（#4691）で解消済み。**着手前に実測すること。**

## 検証

- `bundle exec rubocop`（変更 5 ファイル）→ ✅ **no offenses**
- `bundle exec rake test` → ✅ **1277 tests / 1825 assertions / 0 failures / 0 errors / 322 omissions（100% passed）**

⚠ **最初の 2 周は 3 failures / 35 errors だったが、原因は Redis 未起動**（errors は全件
`Connection refused 127.0.0.1:6379`、failures 3 件は `TaggingDictionaryCacheTest` の下流症状）。
`redis-server --daemonize yes --save ''` を上げたら 0 になった。**走らせる前に `redis-cli ping` を打つこと。**

## 関連

- `docs/CLAUDE.md`「開発中: 5.37.0 → 小粒の掃除（手順 12）」に結果を反映済み
- #4698（この 5 件の出どころ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExMqJf1tfD174UoMBGVJNk
