### PR TITLE
fix: config 検証の strict を実際に発火させる (#4596)

### DIFF
--- a/app/lib/mulukhiya.rb
+++ b/app/lib/mulukhiya.rb
@@ -88,14 +88,40 @@ module Mulukhiya
     return Rack::URLMap.new(Environment.route)
   end
 
+  # ⚠⚠ **`rescue` をメソッド全体に掛けてはいけない (#4596)。**
+  # `Ginseng::ConfigError < Ginseng::Error < StandardError` なので、以前の形は
+  # **最後の `raise` を自分の `rescue => e` が握り込んでいた**＝ `strict` が
+  # 構造的に発火しなかった。`config validation skipped: config validation failed`
+  # という「失敗した」と「飛ばした」が 1 行に同居した警告が、その状態の目印。
+  # **握るのは「検証そのものが実行できなかった」場合だけ**に絞る。
   def self.validate_config
-    errors = Config.instance.errors
+    errors = config_validation_errors
     return if errors.empty?
     errors.each {|e| warn "config validation: #{e}"}
-    return unless Config.instance['/config/validation/strict']
+    return unless config_validation_strict?
     raise Ginseng::ConfigError, "config validation failed (#{errors.length} errors)"
+  end
+
+  # 検証そのものが実行できなかった場合だけ握る。⚠ ここでの fail-open は
+  # 「schema を読めない環境でも起動はできる」ための意図的なもの。
+  def self.config_validation_errors
+    return Config.instance.errors
   rescue => e
     warn "config validation skipped: #{e.message}"
+    return []
+  end
+
+  # ⚠⚠ **ガードのパラメータを fail-open な `rescue` の内側で読まない (#4596)。**
+  # `Ginseng::Config#[]` はキーが無ければ `ConfigError` を上げるので、素で読むと
+  # **設定パスの typo がガードの恒常 no-op に化ける**（pooza/makoto2#77 と同型）。
+  # 既定値は `config/application.yaml` の `/config/validation/strict: false` にあるので、
+  # ここへ例外で来るのは**設定そのものが壊れている**とき。⚠ **黙って false に倒さず、
+  # 必ず警告を残す** — 無音だと「strict を書いたのに止まらない」が観測できない。
+  def self.config_validation_strict?
+    return Config.instance['/config/validation/strict'] == true
+  rescue => e
+    warn "config validation: strict flag unreadable (#{e.message})"
+    return false
   end
 
   def self.load_tasks

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -37,6 +37,13 @@ cherrypick:
 cli:
   progress_bar:
     format: '%c/%C (%p%%)| %B'
+config:
+  validation:
+    # ⚠ 真にすると、schema 検証エラーがある状態では起動そのものを止める (#4596)。
+    # 既定は偽（警告だけ出して起動する）。⚠⚠ **ここに既定値があること自体が
+    # ガードの一部** — 宣言が無いと `Config#[]` が ConfigError を上げ、
+    # 「厳格かどうか」を判定する前に検証が飛ぶ。
+    strict: false
 controller: mastodon
 daemon:
   restart:

--- a/config/schema/base.yaml
+++ b/config/schema/base.yaml
@@ -121,6 +121,16 @@ properties:
           type: object
         type: array
     type: object
+  config:
+    properties:
+      validation:
+        properties:
+          strict:
+            type: boolean
+        required:
+          - strict
+        type: object
+    type: object
   controller:
     enum:
       - mastodon

--- a/test/unit/lib/config_validation.rb
+++ b/test/unit/lib/config_validation.rb
@@ -1,0 +1,103 @@
+module Mulukhiya
+  # `Mulukhiya.validate_config` の strict が**実際に起動を止める**こと (#4596)。
+  #
+  # ⚠⚠ **直す前は「strict を書いたのに止まらない」だった。**`raise` が同じメソッドの
+  # `rescue => e` に捕まっていて（`Ginseng::ConfigError < Ginseng::Error < StandardError`）、
+  # 構造的に発火しなかった。⚠ **fail-open ガードは「素通りする」テストだけでは守れない**
+  # ので、ここは **実際にブロックする正テスト**を主役に置く。
+  class ConfigValidationTest < TestCase
+    STRICT_KEY = '/config/validation/strict'.freeze
+    DUMMY_ERRORS = ["The property '#/dummy' did not contain a required property"].freeze
+
+    def setup
+      @strict = config[STRICT_KEY] rescue nil
+    end
+
+    def teardown
+      config[STRICT_KEY] = @strict
+      restore_errors
+    end
+
+    # 🔴 **本体。**strict が真で検証エラーがあるなら、例外が**外へ出る**。
+    def test_strict_raises_when_errors_exist
+      stub_errors(DUMMY_ERRORS)
+      config[STRICT_KEY] = true
+
+      captured = capture_stderr do
+        assert_raises(Ginseng::ConfigError) {Mulukhiya.validate_config}
+      end
+
+      # ⚠ **退行の目印はこの文字列。**「失敗した」と「飛ばした」が 1 行に同居していたら、
+      # また自分の rescue が raise を握っている。
+      assert_not_match(/config validation skipped: config validation failed/, captured)
+    end
+
+    # strict が偽なら、エラーがあっても警告だけで起動は続く（既定の振る舞い）。
+    def test_non_strict_only_warns
+      stub_errors(DUMMY_ERRORS)
+      config[STRICT_KEY] = false
+
+      captured = capture_stderr {assert_nil(Mulukhiya.validate_config)}
+
+      assert_match(/config validation: /, captured)
+    end
+
+    # ⚠⚠ **strict のキーが引けない環境でも、その 1 点だけで検証は飛ばない。**
+    # `Ginseng::Config#[]` は未定義パスで ConfigError を上げるので、以前はここで
+    # 検証そのものが落ちていた ＝ **設定パスの typo がガードの恒常 no-op に化けた**。
+    def test_validation_runs_without_the_strict_key
+      stub_errors(DUMMY_ERRORS)
+      config[STRICT_KEY] = nil
+      assert_raises(Ginseng::ConfigError) {config[STRICT_KEY]}
+
+      captured = capture_stderr {assert_nil(Mulukhiya.validate_config)}
+
+      # エラーの警告は出ている＝検証は走った。
+      assert_match(/config validation: /, captured)
+      # ⚠ 黙って false に倒さない。倒したことが観測できる。
+      assert_match(/strict flag unreadable/, captured)
+    end
+
+    # 検証そのものが実行できない場合だけは握る（schema を読めない環境でも起動する）。
+    def test_unreadable_errors_are_skipped
+      Config.instance.define_singleton_method(:errors) {raise 'schema unreadable'}
+      config[STRICT_KEY] = true
+
+      captured = capture_stderr {assert_nil(Mulukhiya.validate_config)}
+
+      assert_match(/config validation skipped: schema unreadable/, captured)
+    end
+
+    # エラーが無ければ strict でも何も起きない。
+    def test_strict_is_silent_without_errors
+      stub_errors([])
+      config[STRICT_KEY] = true
+
+      captured = capture_stderr {assert_nil(Mulukhiya.validate_config)}
+
+      assert_equal('', captured)
+    end
+
+    private
+
+    def stub_errors(value)
+      Config.instance.define_singleton_method(:errors) {value}
+    end
+
+    def restore_errors
+      return unless Config.instance.singleton_methods.include?(:errors)
+      Config.instance.singleton_class.remove_method(:errors)
+    end
+
+    # `warn` は $stderr へ出るので、素で走らせるとテスト出力が汚れる。
+    # 出力そのものが仕様（黙って倒さない）なので、捨てずに掴んで検証に使う。
+    def capture_stderr
+      original = $stderr
+      $stderr = StringIO.new
+      yield
+      return $stderr.string
+    ensure
+      $stderr = original
+    end
+  end
+end


### PR DESCRIPTION
Refs #4596 — ⚠ **自動クローズしません**（下記「着地の条件」）。

## 何が起きていたか

`Mulukhiya.validate_config` の `raise` が、**同じメソッドの `rescue => e` に捕まっていた。**
`Ginseng::ConfigError < Ginseng::Error < StandardError` なので、`strict` を真にしても
例外は外へ出ず、**構造的に発火しませんでした。**

⚠ 症状は警告そのものに出ていました:

```
config validation skipped: config validation failed (1 errors)
```

**「失敗した」と「飛ばした」が 1 行に同居しています。**

## 直した点

### 1. `rescue` を「検証そのものが実行できなかった」場合だけに絞った

`Config.instance.errors` の読み出しだけを握り、`raise` は外へ出します。
⚠ ここでの fail-open は「schema を読めない環境でも起動はできる」ための**意図的な**もの。

### 2. `/config/validation/strict` を宣言した

`config/application.yaml` に既定値 `false`、`config/schema/base.yaml` に型。

⚠⚠ **この宣言自体がガードの一部です。**宣言が無いと `Ginseng::Config#[]` が `ConfigError` を
上げ、**「厳格かどうか」を判定する前に検証が飛びます**（Issue の 2 つ目の穴）。
⚠ **設定パスの typo でも同じことが起き、ガードの恒常 no-op に化けます**（pooza/makoto2#77 と同型）。

### 3. `strict` の読みは既定値付きにしたうえで、読めなかったら必ず警告を出す

```ruby
warn "config validation: strict flag unreadable (#{e.message})"
```

**黙って false に倒すと、no-op に化けたことが観測できません。**

## テスト（5 本・新規 `test/unit/lib/config_validation.rb`）

🔴 **主役は「実際にブロックする」正テスト**です（`feedback_fail-open-guard-footgun` の
「ガードは定数化＋実際にブロックする正テスト必須」）。

| テスト | 何を押さえるか |
| --- | --- |
| `test_strict_raises_when_errors_exist` | 🔴 **strict が真＋エラーありで例外が外へ出る。**あわせて退行の目印 `config validation skipped: config validation failed` が**出ないこと**を assert |
| `test_non_strict_only_warns` | 既定（偽）では警告だけで起動は続く |
| `test_validation_runs_without_the_strict_key` | ⚠⚠ **strict のキーが引けなくても、その 1 点だけで検証は飛ばない。**倒したことが `strict flag unreadable` で観測できる |
| `test_unreadable_errors_are_skipped` | 検証そのものが実行できない場合だけは握る |
| `test_strict_is_silent_without_errors` | エラーが無ければ strict でも無音 |

## 検証

- `bundle exec rake lint` → ✅ **506 files / no offenses**、YAML 58 件 no errors、**脆弱性 0**
- `bundle exec rake test` → ✅ **1282 tests / 1837 assertions / 0 failures / 0 errors**（+5 は新規）
- この環境の schema エラーは `/postgres/dsn` 未設定の 1 件だけで、**追加した `config:` ブロック自体は schema を通る**ことを実測

## ⚠ 着地の条件

⚠⚠ **これは起動時にしか走らない経路なので、CI 緑を着地の根拠にできません**
（`project_latent-landmine-fires-on-next-restart` ／ #4687 で実際に踏んだ型）。
**ステージングで実際に再起動させて確認するまで #4596 はクローズしません。**

なお本番への影響は無いはずです。既定は `false` で、`strict` を真にしている環境は
（そもそも動いていなかったので）ありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExMqJf1tfD174UoMBGVJNk
