### PR TITLE
fix: Listener の root_cert_file に存在しないパスを渡さない (#4586)

### DIFF
--- a/app/lib/mulukhiya/listener.rb
+++ b/app/lib/mulukhiya/listener.rb
@@ -11,10 +11,37 @@ module Mulukhiya
       return config["/#{Environment.controller_name}/streaming/verify_peer"]
     end
 
+    # ⚠⚠ **ここに渡る値は env ではなく `ca_file` 相当 (#4586)。**
+    # `SSL_CERT_FILE` として読まれるぶんには存在しないパスは無害だが、
+    # `Faye::WebSocket::Client` の `tls[:root_cert_file]` へ渡すと
+    # `SSL_CTX_load_verify_file` が即座に `OpenSSL::SSL::SSLError` で落ちる。
+    # **実在するものだけ通す。**nil なら OS の CA ストアに倒れ、`verify_peer` は効く。
+    #
+    # ⚠ **`rescue` は「未設定」だけに絞る。**裸の `rescue` は未設定・typo・型違いを
+    # 同じ穴に落として区別できなくしていた。
+    #
+    # **2026-09-09 の実機確認（shallu 本番）**: `cert/cacert.pem` は存在せず、
+    # ginseng-core 側が `File.exist?` で守っている（#512 / #548）ので
+    # `SSL_CERT_FILE` は `HTTP.new` の後でも nil のまま。⚠ **つまり現状は常に nil が
+    # 渡っており、検証は OS の CA ストアで効いている**（「検証が素通り」ではない）。
+    # ⚠⚠ **これは潜在的な地雷で、`rake cert:update` を打った瞬間に経路が生きる。**
     def root_cert_file
-      return config["/#{Environment.controller_name}/streaming/root_cert_file"]
-    rescue
-      return ENV.fetch('SSL_CERT_FILE', nil)
+      return readable_cert_file(config[root_cert_file_key], :config)
+    rescue Ginseng::ConfigError
+      return readable_cert_file(ENV.fetch('SSL_CERT_FILE', nil), :env)
+    end
+
+    def root_cert_file_key
+      return "/#{Environment.controller_name}/streaming/root_cert_file"
+    end
+
+    # ⚠ **黙って nil に倒さない。**運用者が指定した CA が落ちたことに気付けないと、
+    # 「検証しているつもりで OS のストアを見ている」状態が無音で続く。
+    def readable_cert_file(path, source)
+      return nil if path.blank?
+      return path if File.exist?(path)
+      logger.error(error: 'root_cert_file not found', source:, path: path.to_s)
+      return nil
     end
 
     def keepalive

--- a/test/unit/lib/listener_root_cert.rb
+++ b/test/unit/lib/listener_root_cert.rb
@@ -1,0 +1,73 @@
+module Mulukhiya
+  # `Listener#root_cert_file` が **実在するパスしか返さない**こと (#4586)。
+  #
+  # ⚠⚠ **ここに渡る値は env ではなく `ca_file` 相当。**`SSL_CERT_FILE` として
+  # 読まれるぶんには存在しないパスは無害だが、`tls[:root_cert_file]` へ渡すと
+  # `SSL_CTX_load_verify_file` が即座に `OpenSSL::SSL::SSLError` で落ちる。
+  #
+  # ⚠ `Listener#initialize` は実際に `Faye::WebSocket::Client` を張るので、
+  # ここでは `allocate` でインスタンスだけ作る（`root_cert_file` は public）。
+  class ListenerRootCertTest < TestCase
+    def setup
+      @listener = Listener.allocate
+      @key = @listener.root_cert_file_key
+      @config = config[@key] rescue nil
+      @env = ENV.fetch('SSL_CERT_FILE', nil)
+    end
+
+    def teardown
+      config[@key] = @config
+      ENV['SSL_CERT_FILE'] = @env
+      ENV.delete('SSL_CERT_FILE') if @env.nil?
+    end
+
+    # 🔴 **本体。**設定に存在しないパスが入っていても、そのまま返さない。
+    def test_missing_configured_path_is_dropped
+      config[@key] = '/nonexistent/cacert.pem'
+
+      assert_nil(@listener.root_cert_file)
+    end
+
+    # 🔴 **本体その 2。**設定が無いときのフォールバック（env）も同じ扱い。
+    # ⚠ **これが #4586 の実害の入口**だった。
+    def test_missing_env_path_is_dropped
+      config[@key] = nil
+      assert_raises(Ginseng::ConfigError) {config[@key]}
+      ENV['SSL_CERT_FILE'] = '/nonexistent/cacert.pem'
+
+      assert_nil(@listener.root_cert_file)
+    end
+
+    # 実在するなら設定値をそのまま返す（機能を殺していないこと）。
+    def test_existing_configured_path_is_kept
+      config[@key] = __FILE__
+
+      assert_equal(__FILE__, @listener.root_cert_file)
+    end
+
+    # 設定が無くても env が実在すればそちらを使う。
+    def test_existing_env_path_is_kept
+      config[@key] = nil
+      ENV['SSL_CERT_FILE'] = __FILE__
+
+      assert_equal(__FILE__, @listener.root_cert_file)
+    end
+
+    # 設定も env も無ければ nil＝ OS の CA ストアに倒れる。⚠ `verify_peer` は効く。
+    def test_nil_without_config_and_env
+      config[@key] = nil
+      ENV.delete('SSL_CERT_FILE')
+
+      assert_nil(@listener.root_cert_file)
+    end
+
+    # 空文字は「未設定」と同じ扱い。File.exist?('') は false だが、
+    # ここを通す前に落として error ログを出さない。
+    def test_blank_is_not_an_error
+      config[@key] = nil
+      ENV['SSL_CERT_FILE'] = ''
+
+      assert_nil(@listener.root_cert_file)
+    end
+  end
+end


### PR DESCRIPTION
Refs #4586 — ⚠ 自動クローズしません（`ginseng-core#512` 側との順序があるため・下記）。

## ⚠ まず切り分け: **ⓑ が正解**でした（2026-09-09・shallu 本番で実測）

Issue が「**これが最初の仕事**」としていた ⓐ／ⓑ の判定です。

| | 実測値 |
| --- | --- |
| `Environment.cert_file` | `/home/mastodon/repos/mulukhiya-toot-proxy/cert/cacert.pem` |
| そのファイル | **存在しない** |
| `Mulukhiya::HTTP.new` 実行後の `ENV['SSL_CERT_FILE']` | **nil のまま** |
| listener プロセスの環境変数（`sudo procstat -e 93388`） | `SSL_CERT_FILE` **無し** |

⚠ **ⓐ（`verify_peer: true` なのに検証が期待どおりでない）ではありません。**
現行の `ginseng-core`（`b6e736db`）は `ENV['SSL_CERT_FILE']` を立てる前に
**`File.exist?(cert_file)` で守っています**（pooza/ginseng-core#512 / #548 で入った）。

```ruby
# ginseng-core: lib/ginseng/http.rb
if ENV.fetch('SSL_CERT_FILE', nil).nil? && File.exist?(cert_file)
  ENV['SSL_CERT_FILE'] = cert_file
  Ginseng.managed_cert_file = cert_file
end
```

**＝ 渡っているのは常に nil で、OS の CA ストアが使われ、`verify_peer: true` は正しく効いています。**

⚠⚠ **ただし潜在的な地雷であることは変わりません。**`rake cert:update` を打った瞬間に
この経路が生き、以後は「ファイルが消えた／ローテーションで入れ替わった」時点で落ちます。
`project_latent-landmine-fires-on-next-restart` の型です。

## 直した点

| | 内容 |
| --- | --- |
| 1 | **実在するパスだけを通す**（`File.exist?`）。nil なら OS の CA ストアに倒れる |
| 2 | ⚠ **落としたときは `logger.error` で必ず残す。**黙って nil に倒すと「検証しているつもりで OS のストアを見ている」状態が無音で続く。`source:`（`:config` / `:env`）も残す |
| 3 | ⚠ **裸の `rescue` を `Ginseng::ConfigError` だけに絞った。**未設定・typo・型違いを同じ穴に落として区別できなくしていた |

⚠ あわせて設定キーを `root_cert_file_key` に切り出しました（テストが同じ字面を二重に持たないため）。

## テスト（6 本・新規 `test/unit/lib/listener_root_cert.rb`）

| テスト | 何を押さえるか |
| --- | --- |
| `test_missing_configured_path_is_dropped` | 🔴 設定に存在しないパスが入っていても返さない |
| `test_missing_env_path_is_dropped` | 🔴 **#4586 の実害の入口。**env フォールバックも同じ扱い |
| `test_existing_configured_path_is_kept` | 実在するなら設定値を返す（機能を殺していない） |
| `test_existing_env_path_is_kept` | 設定が無くても env が実在すれば使う |
| `test_nil_without_config_and_env` | どちらも無ければ nil ＝ OS の CA ストア |
| `test_blank_is_not_an_error` | 空文字は「未設定」扱いで error ログを出さない |

⚠ `Listener#initialize` は実際に `Faye::WebSocket::Client` を張るので `allocate` で作っています。

## 検証

- `bundle exec rake lint` → ✅ **506 files / no offenses**、脆弱性 0
- `bundle exec rake test` → ✅ **1283 tests / 1832 assertions / 0 failures / 0 errors**

## ⚠ Issue を閉じない理由

Issue の完了条件のうち 4 つは満たしますが、**根は `pooza/ginseng-core#512` 側**（`cert` タスクの移植）
だと Issue 自身が書いています。⚠ **こちらだけ触っても根は残る**ので、そちらの状況を見てから閉じます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExMqJf1tfD174UoMBGVJNk