### PR TITLE
fix: ffmpeg の内側の締切をハンドラ締切から逆算する (#4696)

### DIFF
--- a/app/lib/mulukhiya/event.rb
+++ b/app/lib/mulukhiya/event.rb
@@ -16,6 +16,25 @@ module Mulukhiya
     # 諦めて先へ進む（従来の挙動に戻るだけで、悪化はしない）。
     HANDLER_KILL_WAIT = 5
 
+    # ハンドラの締切時刻を、そのハンドラのスレッドから引くためのキー (#4696)。
+    #
+    # ⚠⚠ **内側の締切を「同じ設定値の定数」で置いてはいけない。**
+    # `VideoFile#ffmpeg_timeout` は `/handler/video_format_convert/timeout` = 90 を
+    # 読んでいたが、**外側の `thread.join(handler.timeout)` が先に始まり、しかも
+    # transcode の前に `video_stream` のプローブ（`/ffmpeg/probe/timeout` = 30）が
+    # 挟まる**ので、内側の `Timeout.timeout(90)` は**構造的に一度も発火しなかった**。
+    # 発火しない Timeout は `log_ffmpeg_error` と `"ffmpeg failed: ..."` の経路ごと
+    # 殺し、残るのは `{message: 'timeout'}` 1 行だけになる。
+    #
+    # ⚠ **短い定数に置き換えるのも違う。**それでは今まで通っていた変換が落ちる。
+    # **締切そのものを配って残り時間から逆算させる**と、内側は必ず先に切れ、かつ
+    # 使える時間は縮まない。
+    HANDLER_DEADLINE_KEY = :mulukhiya_handler_deadline
+
+    # 内側の締切を外側より確実に手前へ置くための余白 (秒)。
+    # ⚠ 内側が `Timeout::Error` で正規に抜け、`ensure` の後始末が走りきるまでの分。
+    HANDLER_DEADLINE_MARGIN = 5
+
     attr_reader :label, :params
 
     def initialize(label, params = {})
@@ -102,8 +121,12 @@ module Mulukhiya
     # counter を渡すとハンドラのスレッドで HTTP が集計される (#4464)。
     # nil のときは計装なし＝従来どおりの挙動。
     def run_handler(handler, payload, counter)
+      deadline = Time.now + handler.timeout - HANDLER_DEADLINE_MARGIN
       thread = Thread.new do
         Thread.current[HandlerProfile::HTTP_KEY] = counter
+        # ⚠ **外側の `join` より手前で切れる締切を配る (#4696)。**時刻で配るので、
+        # ハンドラの中で何段ネストしても「残り」は一意に決まる。
+        Thread.current[HANDLER_DEADLINE_KEY] = deadline
         handler.send(method, payload, params)
       end
       return if thread.join(handler.timeout)

--- a/app/lib/mulukhiya/event.rb
+++ b/app/lib/mulukhiya/event.rb
@@ -33,6 +33,11 @@ module Mulukhiya
 
     # 内側の締切を外側より確実に手前へ置くための余白 (秒)。
     # ⚠ 内側が `Timeout::Error` で正規に抜け、`ensure` の後始末が走りきるまでの分。
+    #
+    # ⚠⚠ **そのまま引くのではなく「締切の半分」と短いほうを取る（PR #4706 の Codex P2）。**
+    # `timeout` に 1〜5 秒を設定した（schema 上は妥当な）ハンドラでは
+    # `now + timeout - 5` が**既に過ぎた時刻**になり、内側の取り分が下限へ張り付く。
+    # そうなると外側の `thread.join` が先に発火しうる＝**塞いだはずの穴が開く**。
     HANDLER_DEADLINE_MARGIN = 5
 
     attr_reader :label, :params
@@ -121,7 +126,7 @@ module Mulukhiya
     # counter を渡すとハンドラのスレッドで HTTP が集計される (#4464)。
     # nil のときは計装なし＝従来どおりの挙動。
     def run_handler(handler, payload, counter)
-      deadline = Time.now + handler.timeout - HANDLER_DEADLINE_MARGIN
+      deadline = handler_deadline(handler.timeout)
       thread = Thread.new do
         Thread.current[HandlerProfile::HTTP_KEY] = counter
         # ⚠ **外側の `join` より手前で切れる締切を配る (#4696)。**時刻で配るので、
@@ -142,6 +147,20 @@ module Mulukhiya
       # 最中に呼び出し側が dispatch / post へ進む（詳細は HANDLER_KILL_WAIT）。
       thread.join(HANDLER_KILL_WAIT)
       handler.errors.push(message: 'timeout', timeout: "#{handler.timeout}s")
+    end
+
+    # ハンドラ締切の絶対時刻。
+    #
+    # ⚠⚠ **単調時計で持つ（PR #4706 の Codex P2）。**`Thread#join` と
+    # `Timeout.timeout` はどちらも単調時計で数えるので、壁時計で持つと
+    # **NTP / VM の時刻補正で内外の物差しがずれる**。後ろへ飛べば内側の残りが
+    # 伸びて外側に追い越され、前へ飛べば正常な変換が途中で切られる。
+    #
+    # ⚠ 前倒し幅は「余白」と「締切の半分」の短いほう。`timeout` が余白より短い
+    # 設定でも、**内側の取り分が必ず正で残る**。
+    def handler_deadline(timeout)
+      lead = [HANDLER_DEADLINE_MARGIN, timeout / 2.0].min
+      return Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout - lead
     end
 
     def resolve_pipeline

--- a/app/lib/mulukhiya/file/video_file.rb
+++ b/app/lib/mulukhiya/file/video_file.rb
@@ -4,6 +4,12 @@ module Mulukhiya
     # ⚠ ハンドラの中では `Event::HANDLER_DEADLINE_KEY` の残りのほうが短くなる。
     DEFAULT_FFMPEG_TIMEOUT = 90
 
+    # 内側へ渡す下限 (秒)。⚠ **0 以下を渡さない** — `Timeout.timeout(0)` は
+    # 「制限なし」の意味になり、塞いだはずの穴がそのまま開く。
+    # ⚠ 1 秒ではなくこの値なのは、`timeout` に数秒を設定したハンドラで
+    # **下限が締切そのものを追い越さない**ようにするため（PR #4706 の Codex P2）。
+    MIN_FFMPEG_TIMEOUT = 0.1
+
     def values
       return {
         type:,
@@ -104,11 +110,15 @@ module Mulukhiya
       return [handler_deadline_remaining, ffmpeg_timeout_limit].compact.min
     end
 
-    # ハンドラ締切までの残り。⚠ **0 以下を渡さない** — `Timeout.timeout(0)` は
-    # 「制限なし」の意味になり、**塞いだはずの穴がそのまま開く**。
+    # ハンドラ締切までの残り。
+    #
+    # ⚠⚠ **単調時計で読む（PR #4706 の Codex P2）。**配る側（`Event#handler_deadline`）と
+    # 物差しを揃える。壁時計を混ぜると NTP / VM の時刻補正で内外がずれる。
+    # ⚠ 下限は `MIN_FFMPEG_TIMEOUT`。0 以下は `Timeout.timeout` が「制限なし」と読む。
     def handler_deadline_remaining
       return nil unless deadline = Thread.current[Event::HANDLER_DEADLINE_KEY]
-      return [deadline - Time.now, 1].max
+      remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      return [remaining, MIN_FFMPEG_TIMEOUT].max
     end
 
     def ffmpeg_timeout_limit

--- a/app/lib/mulukhiya/file/video_file.rb
+++ b/app/lib/mulukhiya/file/video_file.rb
@@ -1,5 +1,9 @@
 module Mulukhiya
   class VideoFile < MediaFile
+    # ハンドラの外（rake・CLI・テスト）で ffmpeg を回すときの上限 (秒)。
+    # ⚠ ハンドラの中では `Event::HANDLER_DEADLINE_KEY` の残りのほうが短くなる。
+    DEFAULT_FFMPEG_TIMEOUT = 90
+
     def values
       return {
         type:,
@@ -81,10 +85,38 @@ module Mulukhiya
 
     private
 
+    # ffmpeg 1 回あたりの締切 (秒)。
+    #
+    # ⚠⚠ **ハンドラ締切と同じキーを読んではいけない (#4696)。**以前は内外とも
+    # `/handler/video_format_convert/timeout` = 90 で、**外側の
+    # `Event#run_handler` の `thread.join` が先に始まり、さらに transcode の前に
+    # `video_stream` のプローブ（`/ffmpeg/probe/timeout` = 30）が挟まる**ため、
+    # 内側の `Timeout.timeout(90)` は**構造的に一度も発火しなかった**。
+    #
+    # ⚠ 発火しないと `log_ffmpeg_error` と `raise "ffmpeg failed: ..."` の経路ごと
+    # 死に、残るのは `{message: 'timeout'}` 1 行だけになる。さらに `Thread#kill` は
+    # ffmpeg にシグナルを送らないので、変換途中の `tmp/media/*.mp4` が残る。
+    #
+    # **ハンドラの締切から残りを逆算する**ので、内側が必ず先に切れ、かつ使える時間は
+    # 縮まない。⚠ ハンドラの外（rake・テスト・CLI）では締切が無いので、
+    # `/ffmpeg/timeout` の上限だけが効く。
     def ffmpeg_timeout
-      return Config.instance['/handler/video_format_convert/timeout']
-    rescue
-      return 90
+      return [handler_deadline_remaining, ffmpeg_timeout_limit].compact.min
+    end
+
+    # ハンドラ締切までの残り。⚠ **0 以下を渡さない** — `Timeout.timeout(0)` は
+    # 「制限なし」の意味になり、**塞いだはずの穴がそのまま開く**。
+    def handler_deadline_remaining
+      return nil unless deadline = Thread.current[Event::HANDLER_DEADLINE_KEY]
+      return [deadline - Time.now, 1].max
+    end
+
+    def ffmpeg_timeout_limit
+      return Config.instance['/ffmpeg/timeout']
+    rescue Ginseng::ConfigError
+      # 既定値は config/application.yaml にある。設定ファイルが古い環境でも
+      # 「制限なし」へ退行させないための定数フォールバック。
+      return DEFAULT_FFMPEG_TIMEOUT
     end
 
     def log_ffmpeg_error(command, phase)

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -73,6 +73,10 @@ ffmpeg:
   preset: veryfast
   probe:
     timeout: 30
+  # ffmpeg 1 回あたりの上限 (秒)。⚠ ハンドラの中では
+  # `/handler/video_format_convert/timeout` から逆算した残りのほうが短くなるので、
+  # これが効くのは rake・CLI・テストなど**ハンドラの外**だけ (#4696)。
+  timeout: 90
 firefish:
   capabilities:
     reaction: true

--- a/test/unit/lib/ffmpeg_timeout.rb
+++ b/test/unit/lib/ffmpeg_timeout.rb
@@ -1,0 +1,96 @@
+module Mulukhiya
+  # ffmpeg の内側の締切が、**ハンドラ締切より先に発火する**こと (#4696)。
+  #
+  # ⚠⚠ **直す前は内外とも `/handler/video_format_convert/timeout` = 90 を読んでいた。**
+  # 外側の `Event#run_handler` の `thread.join(handler.timeout)` が先に始まり、しかも
+  # transcode の前に `video_stream` のプローブ（`/ffmpeg/probe/timeout` = 30）が
+  # 挟まるので、**内側の `Timeout.timeout(90)` は構造的に一度も発火しなかった**。
+  # ⚠ 発火しないと `log_ffmpeg_error` と `raise "ffmpeg failed: ..."` の経路ごと死に、
+  # 残るのは `{message: 'timeout'}` 1 行だけになる。
+  class FFmpegTimeoutTest < TestCase
+    HANDLER_TIMEOUT = 90
+
+    def setup
+      @file = VideoFile.allocate
+      @deadline = Thread.current[Event::HANDLER_DEADLINE_KEY]
+    end
+
+    def teardown
+      Thread.current[Event::HANDLER_DEADLINE_KEY] = @deadline
+    end
+
+    # 🔴 **本体。**ハンドラ締切から逆算した残りが、**必ずハンドラ締切より短い**。
+    # ⚠ プローブに上限いっぱい掛かった最悪ケースでも内側が先に切れること。
+    def test_inner_deadline_always_precedes_the_handler
+      Thread.current[Event::HANDLER_DEADLINE_KEY] =
+        Time.now + HANDLER_TIMEOUT - Event::HANDLER_DEADLINE_MARGIN
+
+      assert_operator(timeout, :<, HANDLER_TIMEOUT)
+
+      # プローブが上限（30 秒）を使い切った後でも成り立つ。
+      Thread.current[Event::HANDLER_DEADLINE_KEY] =
+        Time.now + HANDLER_TIMEOUT - Event::HANDLER_DEADLINE_MARGIN - probe_timeout
+
+      assert_operator(timeout, :<, HANDLER_TIMEOUT - probe_timeout)
+    end
+
+    # 🔴 **`Timeout.timeout(0)` は「制限なし」**なので、0 以下を渡してはいけない。
+    # ⚠ 締切を過ぎていても穴が開かないこと。
+    def test_expired_deadline_never_disables_the_timeout
+      Thread.current[Event::HANDLER_DEADLINE_KEY] = Time.now - 3600
+
+      assert_operator(timeout, :>, 0)
+    end
+
+    # ハンドラの外（rake・CLI・テスト）では締切が無いので上限だけが効く。
+    def test_falls_back_to_the_limit_outside_a_handler
+      Thread.current[Event::HANDLER_DEADLINE_KEY] = nil
+
+      assert_equal(config['/ffmpeg/timeout'], timeout)
+    end
+
+    # ⚠ 締切が上限より遠くても、上限を超えない。
+    def test_limit_caps_a_distant_deadline
+      Thread.current[Event::HANDLER_DEADLINE_KEY] = Time.now + 100_000
+
+      assert_equal(config['/ffmpeg/timeout'], timeout)
+    end
+
+    # ⚠⚠ **ハンドラ締切と同じ設定値を読み戻していないこと。**ここが同じ値に戻ったら
+    # 「内側が発火しない」に逆戻りする。
+    def test_does_not_read_the_handler_timeout_key
+      Thread.current[Event::HANDLER_DEADLINE_KEY] = nil
+      config['/handler/video_format_convert/timeout'] = 12_345
+
+      assert_not_equal(12_345, timeout)
+    ensure
+      config['/handler/video_format_convert/timeout'] = HANDLER_TIMEOUT
+    end
+
+    # 🔴 `Event#run_handler` が実際に締切をスレッドへ配ること。
+    # ⚠ 配線が外れても VideoFile 側のテストだけでは緑のままになる（#4583 と同型）。
+    def test_run_handler_publishes_the_deadline
+      seen = nil
+      handler = Object.new
+      handler.define_singleton_method(:timeout) {HANDLER_TIMEOUT}
+      handler.define_singleton_method(:handle_pre_toot) do |_payload, _params|
+        seen = Thread.current[Event::HANDLER_DEADLINE_KEY]
+      end
+
+      Event.new(:pre_toot).send(:run_handler, handler, {}, nil)
+
+      assert_not_nil(seen, '締切がスレッドへ配られていない')
+      assert_operator(seen - Time.now, :<=, HANDLER_TIMEOUT - Event::HANDLER_DEADLINE_MARGIN)
+    end
+
+    private
+
+    def timeout
+      return @file.send(:ffmpeg_timeout)
+    end
+
+    def probe_timeout
+      return config['/ffmpeg/probe/timeout']
+    end
+  end
+end

--- a/test/unit/lib/ffmpeg_timeout.rb
+++ b/test/unit/lib/ffmpeg_timeout.rb
@@ -22,14 +22,12 @@ module Mulukhiya
     # 🔴 **本体。**ハンドラ締切から逆算した残りが、**必ずハンドラ締切より短い**。
     # ⚠ プローブに上限いっぱい掛かった最悪ケースでも内側が先に切れること。
     def test_inner_deadline_always_precedes_the_handler
-      Thread.current[Event::HANDLER_DEADLINE_KEY] =
-        Time.now + HANDLER_TIMEOUT - Event::HANDLER_DEADLINE_MARGIN
+      publish(HANDLER_TIMEOUT)
 
       assert_operator(timeout, :<, HANDLER_TIMEOUT)
 
       # プローブが上限（30 秒）を使い切った後でも成り立つ。
-      Thread.current[Event::HANDLER_DEADLINE_KEY] =
-        Time.now + HANDLER_TIMEOUT - Event::HANDLER_DEADLINE_MARGIN - probe_timeout
+      Thread.current[Event::HANDLER_DEADLINE_KEY] -= probe_timeout
 
       assert_operator(timeout, :<, HANDLER_TIMEOUT - probe_timeout)
     end
@@ -37,7 +35,7 @@ module Mulukhiya
     # 🔴 **`Timeout.timeout(0)` は「制限なし」**なので、0 以下を渡してはいけない。
     # ⚠ 締切を過ぎていても穴が開かないこと。
     def test_expired_deadline_never_disables_the_timeout
-      Thread.current[Event::HANDLER_DEADLINE_KEY] = Time.now - 3600
+      Thread.current[Event::HANDLER_DEADLINE_KEY] = monotonic - 3600
 
       assert_operator(timeout, :>, 0)
     end
@@ -51,7 +49,7 @@ module Mulukhiya
 
     # ⚠ 締切が上限より遠くても、上限を超えない。
     def test_limit_caps_a_distant_deadline
-      Thread.current[Event::HANDLER_DEADLINE_KEY] = Time.now + 100_000
+      Thread.current[Event::HANDLER_DEADLINE_KEY] = monotonic + 100_000
 
       assert_equal(config['/ffmpeg/timeout'], timeout)
     end
@@ -80,10 +78,43 @@ module Mulukhiya
       Event.new(:pre_toot).send(:run_handler, handler, {}, nil)
 
       assert_not_nil(seen, '締切がスレッドへ配られていない')
-      assert_operator(seen - Time.now, :<=, HANDLER_TIMEOUT - Event::HANDLER_DEADLINE_MARGIN)
+      assert_operator(seen - monotonic, :<=, HANDLER_TIMEOUT - Event::HANDLER_DEADLINE_MARGIN)
+    end
+
+    # 🔴 **短いハンドラ締切でも内側が先に切れる**（PR #4706 の Codex P2）。
+    # ⚠ 余白をそのまま引くと `timeout` が 1〜5 秒のとき締切が既に過ぎた時刻になり、
+    # 内側が下限へ張り付いて**外側が先に発火しうる**。
+    def test_short_handler_timeout_keeps_a_positive_lead
+      [1, 2, 5].each do |seconds|
+        publish(seconds)
+
+        assert_operator(timeout, :>, 0, "#{seconds}s: 0 以下は制限なしになる")
+        assert_operator(timeout, :<, seconds, "#{seconds}s: 内側が外側を追い越している")
+      end
+    end
+
+    # ⚠⚠ **単調時計で持つ**（PR #4706 の Codex P2）。壁時計だと NTP / VM の補正で
+    # 内外の物差しがずれ、後ろへ飛べば内側が外側に追い越される。
+    def test_deadline_is_monotonic
+      publish(HANDLER_TIMEOUT)
+      deadline = Thread.current[Event::HANDLER_DEADLINE_KEY]
+
+      # 壁時計基準なら epoch 秒（10^9 台）になる。単調時計は起動からの経過。
+      assert_in_delta(monotonic + HANDLER_TIMEOUT - Event::HANDLER_DEADLINE_MARGIN, deadline, 1)
+      assert_operator(deadline, :<, Time.now.to_f, '壁時計基準になっている')
     end
 
     private
+
+    def monotonic
+      return Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+
+    # `Event#run_handler` が配るのと同じ形で締切を置く。
+    def publish(handler_timeout)
+      Thread.current[Event::HANDLER_DEADLINE_KEY] =
+        Event.new(:pre_toot).send(:handler_deadline, handler_timeout)
+    end
 
     def timeout
       return @file.send(:ffmpeg_timeout)


### PR DESCRIPTION
Closes #4696

## 何が起きていたか

⚠⚠ **内外とも `/handler/video_format_convert/timeout` = 90 を読んでいました。**

外側の `Event#run_handler` の `thread.join(handler.timeout)` が先に始まり、しかも
transcode の前に `video_stream` のプローブ（`/ffmpeg/probe/timeout` = 30）が挟まるので、
🔴 **内側の `Timeout.timeout(90)` は構造的に一度も発火しませんでした。**

⚠ 発火しないと `log_ffmpeg_error` と `raise "ffmpeg failed: ..."` の経路ごと死に、
残るのは `{message: 'timeout'}` 1 行だけになります。#4657 が足した観測性の裏で、
**既存の観測性が消えていた**形です。さらに `Thread#kill` は ffmpeg にシグナルを送らないので、
変換途中の `tmp/media/<sha256>.mp4` が残ります。

## ⚠ 「短い定数を別キーで置く」ではなく「締切を配る」にしました

Issue の当ては「ffmpeg 側の締切を別キーにし、**ハンドラより短くする**」でしたが、
⚠ **短い定数だと今まで通っていた変換が落ちます。**

現状の実効上限は（外側が 90 秒で切るので）約 90 秒です。仮に別キーへ 25 秒を置くと、
**30〜85 秒かかる変換が新たに失敗します。**しかも `convert_type` は remux → transcode と
**2 回 exec しうる**ので、`probe(30) + 2T < 90` を満たす定数は 30 秒未満しか取れません。

そこで **ハンドラの締切時刻そのものをスレッドへ配り、残りから逆算する**形にしました。

| | 役割 |
| --- | --- |
| `Event::HANDLER_DEADLINE_KEY` | `run_handler` が `Time.now + handler.timeout - HANDLER_DEADLINE_MARGIN` を配る |
| `Event::HANDLER_DEADLINE_MARGIN` = 5 | 内側が `Timeout::Error` で正規に抜け、`ensure` が走りきるまでの余白 |
| `VideoFile#ffmpeg_timeout` | 残りと `/ffmpeg/timeout` の**短いほう** |
| `/ffmpeg/timeout` = 90 | ⚠ ハンドラの**外**（rake・CLI・テスト）用の上限。ハンドラ内では残りのほうが常に短い |

**内側は必ず先に切れて観測性が戻り、かつ使える時間は縮みません**（90 → 85）。
時刻で配るので、ハンドラの中で何段ネストしても「残り」は一意に決まります。

⚠ **0 以下を渡さないようにしています** — `Timeout.timeout(0)` は「制限なし」の意味になり、
**塞いだはずの穴がそのまま開きます。**

## テスト（6 本・新規 `test/unit/lib/ffmpeg_timeout.rb`）

| テスト | 何を押さえるか |
| --- | --- |
| `test_inner_deadline_always_precedes_the_handler` | 🔴 **本体。**プローブが上限を使い切った最悪ケースでも内側が先に切れる |
| `test_expired_deadline_never_disables_the_timeout` | 🔴 期限切れでも 0 を渡さない（`Timeout.timeout(0)` ＝ 制限なし） |
| `test_falls_back_to_the_limit_outside_a_handler` | ハンドラの外では `/ffmpeg/timeout` だけが効く |
| `test_limit_caps_a_distant_deadline` | 締切が遠くても上限を超えない |
| `test_does_not_read_the_handler_timeout_key` | ⚠⚠ **ハンドラ締切と同じ設定値を読み戻していない**（ここが戻ったら退行） |
| `test_run_handler_publishes_the_deadline` | 🔴 `run_handler` が実際に締切を配る。⚠ 配線が外れても VideoFile 側だけでは緑のままになる（#4583 と同型） |

## 検証

- `bundle exec rake lint` → ✅ **506 files / no offenses**、脆弱性 0
- `bundle exec rake test` → ✅ **1288 tests / 1845 assertions / 0 failures / 0 errors**

## ⚠ 積み残し（この PR では触っていません）

Issue の 2「`Thread#kill` は ffmpeg にシグナルを送らない」は**根本解決していません。**
内側が先に発火するようになったので `Open3.capture3` は正規の例外で抜け、実害はほぼ消えますが、
⚠ **`FFmpegCommandBuilder.transcode_video` に `-nostats` / `-loglevel quiet` を足すと
「stderr への書き込みで EPIPE → SIGPIPE」という偶然の保険が消えます。**
その変更を入れるときは、この点を思い出す必要があります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExMqJf1tfD174UoMBGVJNk