### PR TITLE
fix: FreeBSD の rc スクリプトが SSH 越しの restart で戻るようにする (#4478)

### DIFF
--- a/config/sample/freebsd/mulukhiya-listener
+++ b/config/sample/freebsd/mulukhiya-listener
@@ -23,6 +23,7 @@ export LC_ALL=ja_JP.UTF-8
 
 start_cmd=${name}_start
 stop_cmd=${name}_stop
+status_cmd=${name}_status
 
 # listener は proctitle が "ruby: bin/listener_daemon.rb start" のままなので、
 # パターンは daemon スクリプト名で足りる (#4675)。
@@ -31,7 +32,19 @@ mulukhiya_listener_kill_wait=20
 
 mulukhiya_listener_start() {
   cd $mulukhiya_path
-  sudo -u $mulukhiya_user /usr/sbin/daemon \
+  # ⚠⚠ **`-f` を付けないと SSH 越しの restart が戻ってこない (#4478)。**
+  # `daemon(8)` は既定で標準入出力・標準エラーを**そのまま子へ引き継ぐ**ため、
+  # プロセスがデーモン化しても **fd の持ち主が残っている限り ssh は待ち続ける**。
+  # 2026-07-23 の lbock ではこれで **3 サービスのうち sidekiq だけ再起動された
+  # 混在状態**になった（ループの 1 周目で止まり、puma / listener は旧プロセスのまま）。
+  #
+  # ⚠⚠ **`-f` 単独にしないこと。**`-f` は 3 本とも /dev/null へ捨てるので、
+  # **FreeBSD で Sidekiq のログを no-reader pipe へ捨てていた #4362 と同じ轍**になる。
+  # `-S -T mulukhiya-toot-proxy` を併用すると、fd を切り離したうえで stdout / stderr を
+  # syslog へ流せる。タグは chubo2 の rsyslog 設定
+  # （`:programname, isequal, "mulukhiya-toot-proxy"`）が拾い、既存の
+  # `/var/log/mulukhiya-toot-proxy.log` に入る。
+  sudo -u $mulukhiya_user /usr/sbin/daemon -f -S -T mulukhiya-toot-proxy \
     /usr/local/bin/bash -lc "cd ${mulukhiya_path} && bundle exec bin/listener_daemon.rb start"
 }
 
@@ -50,6 +63,20 @@ mulukhiya_listener_stop() {
   done
   pkill -9 -u $mulukhiya_user -f "$mulukhiya_listener_pattern" 2>/dev/null
   sleep 2
+}
+
+# `service mulukhiya-listener status` が `unknown directive` にならないようにする (#4478)。
+# ⚠ **`daemon -p` の pidfile は使えない。**`bin/*_daemon.rb start` 自身が fork して
+# デーモン化するので、`daemon` が見ている子はすぐ終わる＝ pid が死んだ値になる。
+# 停止判定と同じ pattern で見るのが唯一の一貫した物差し。
+mulukhiya_listener_status() {
+  _pids=`pgrep -u $mulukhiya_user -f "$mulukhiya_listener_pattern" 2>/dev/null | tr '\n' ' '`
+  if [ -n "$_pids" ]; then
+    echo "mulukhiya-listener is running as pid ${_pids}."
+    return 0
+  fi
+  echo "mulukhiya-listener is not running."
+  return 1
 }
 
 run_rc_command "$1"

--- a/config/sample/freebsd/mulukhiya-puma
+++ b/config/sample/freebsd/mulukhiya-puma
@@ -23,6 +23,7 @@ export LC_ALL=ja_JP.UTF-8
 
 start_cmd=${name}_start
 stop_cmd=${name}_stop
+status_cmd=${name}_status
 
 # ⚠ puma も proctitle を "ruby: puma <version> (tcp://...) [mulukhiya-toot-proxy]"
 # へ書き換えるので、'puma_daemon.rb' だけでは一致しない (#4675)。cluster 時の
@@ -34,7 +35,19 @@ mulukhiya_puma_kill_wait=20
 
 mulukhiya_puma_start() {
   cd $mulukhiya_path
-  sudo -u $mulukhiya_user /usr/sbin/daemon \
+  # ⚠⚠ **`-f` を付けないと SSH 越しの restart が戻ってこない (#4478)。**
+  # `daemon(8)` は既定で標準入出力・標準エラーを**そのまま子へ引き継ぐ**ため、
+  # プロセスがデーモン化しても **fd の持ち主が残っている限り ssh は待ち続ける**。
+  # 2026-07-23 の lbock ではこれで **3 サービスのうち sidekiq だけ再起動された
+  # 混在状態**になった（ループの 1 周目で止まり、puma / listener は旧プロセスのまま）。
+  #
+  # ⚠⚠ **`-f` 単独にしないこと。**`-f` は 3 本とも /dev/null へ捨てるので、
+  # **FreeBSD で Sidekiq のログを no-reader pipe へ捨てていた #4362 と同じ轍**になる。
+  # `-S -T mulukhiya-toot-proxy` を併用すると、fd を切り離したうえで stdout / stderr を
+  # syslog へ流せる。タグは chubo2 の rsyslog 設定
+  # （`:programname, isequal, "mulukhiya-toot-proxy"`）が拾い、既存の
+  # `/var/log/mulukhiya-toot-proxy.log` に入る。
+  sudo -u $mulukhiya_user /usr/sbin/daemon -f -S -T mulukhiya-toot-proxy \
     /usr/local/bin/bash -lc "cd ${mulukhiya_path} && RACK_ENV=production bundle exec bin/puma_daemon.rb start"
 }
 
@@ -53,6 +66,20 @@ mulukhiya_puma_stop() {
   done
   pkill -9 -u $mulukhiya_user -f "$mulukhiya_puma_pattern" 2>/dev/null
   sleep 2
+}
+
+# `service mulukhiya-puma status` が `unknown directive` にならないようにする (#4478)。
+# ⚠ **`daemon -p` の pidfile は使えない。**`bin/*_daemon.rb start` 自身が fork して
+# デーモン化するので、`daemon` が見ている子はすぐ終わる＝ pid が死んだ値になる。
+# 停止判定と同じ pattern で見るのが唯一の一貫した物差し。
+mulukhiya_puma_status() {
+  _pids=`pgrep -u $mulukhiya_user -f "$mulukhiya_puma_pattern" 2>/dev/null | tr '\n' ' '`
+  if [ -n "$_pids" ]; then
+    echo "mulukhiya-puma is running as pid ${_pids}."
+    return 0
+  fi
+  echo "mulukhiya-puma is not running."
+  return 1
 }
 
 run_rc_command "$1"

--- a/config/sample/freebsd/mulukhiya-sidekiq
+++ b/config/sample/freebsd/mulukhiya-sidekiq
@@ -23,6 +23,7 @@ export LC_ALL=ja_JP.UTF-8
 
 start_cmd=${name}_start
 stop_cmd=${name}_stop
+status_cmd=${name}_status
 
 # ⚠ sidekiq は proctitle を "ruby: sidekiq <version> mulukhiya-toot-proxy ..." へ
 # 書き換えるので、'sidekiq_daemon.rb' だけでは一致しない。この保険は導入以来ずっと
@@ -41,7 +42,19 @@ mulukhiya_sidekiq_kill_wait=30
 
 mulukhiya_sidekiq_start() {
   cd $mulukhiya_path
-  sudo -u $mulukhiya_user /usr/sbin/daemon \
+  # ⚠⚠ **`-f` を付けないと SSH 越しの restart が戻ってこない (#4478)。**
+  # `daemon(8)` は既定で標準入出力・標準エラーを**そのまま子へ引き継ぐ**ため、
+  # プロセスがデーモン化しても **fd の持ち主が残っている限り ssh は待ち続ける**。
+  # 2026-07-23 の lbock ではこれで **3 サービスのうち sidekiq だけ再起動された
+  # 混在状態**になった（ループの 1 周目で止まり、puma / listener は旧プロセスのまま）。
+  #
+  # ⚠⚠ **`-f` 単独にしないこと。**`-f` は 3 本とも /dev/null へ捨てるので、
+  # **FreeBSD で Sidekiq のログを no-reader pipe へ捨てていた #4362 と同じ轍**になる。
+  # `-S -T mulukhiya-toot-proxy` を併用すると、fd を切り離したうえで stdout / stderr を
+  # syslog へ流せる。タグは chubo2 の rsyslog 設定
+  # （`:programname, isequal, "mulukhiya-toot-proxy"`）が拾い、既存の
+  # `/var/log/mulukhiya-toot-proxy.log` に入る。
+  sudo -u $mulukhiya_user /usr/sbin/daemon -f -S -T mulukhiya-toot-proxy \
     /usr/local/bin/bash -lc "cd ${mulukhiya_path} && bundle exec bin/sidekiq_daemon.rb start"
 }
 
@@ -60,6 +73,20 @@ mulukhiya_sidekiq_stop() {
   done
   pkill -9 -u $mulukhiya_user -f "$mulukhiya_sidekiq_pattern" 2>/dev/null
   sleep 2
+}
+
+# `service mulukhiya-sidekiq status` が `unknown directive` にならないようにする (#4478)。
+# ⚠ **`daemon -p` の pidfile は使えない。**`bin/*_daemon.rb start` 自身が fork して
+# デーモン化するので、`daemon` が見ている子はすぐ終わる＝ pid が死んだ値になる。
+# 停止判定と同じ pattern で見るのが唯一の一貫した物差し。
+mulukhiya_sidekiq_status() {
+  _pids=`pgrep -u $mulukhiya_user -f "$mulukhiya_sidekiq_pattern" 2>/dev/null | tr '\n' ' '`
+  if [ -n "$_pids" ]; then
+    echo "mulukhiya-sidekiq is running as pid ${_pids}."
+    return 0
+  fi
+  echo "mulukhiya-sidekiq is not running."
+  return 1
 }
 
 run_rc_command "$1"


### PR DESCRIPTION
Refs #4478 — ⚠ **配布が手作業なので、実機へ入るまでクローズしません**（下記）。

## 何が起きていたか

⚠⚠ **`daemon(8)` は既定で標準入出力・標準エラーをそのまま子へ引き継ぎます。**
プロセスがデーモン化しても **fd の持ち主が残っている限り ssh は待ち続けます。**

2026-07-23 の lbock ではこれで 🔴 **3 サービスのうち sidekiq だけ再起動された混在状態**に
なりました（ループの 1 周目で止まり、puma / listener は旧プロセスのまま）。

## 🔴 実機で両方の前提を確認しました（2026-09-09・shallu 本番）

### ① `-f` は本当に効くのか

`sleep 8` を抱えた daemon を SSH 越しに叩いて、コマンドが戻るまでを計りました。

| | ssh が戻るまで |
| --- | ---: |
| `daemon`（現行） | **8.48 秒** ← 子が終わるまで待っている |
| `daemon -f -S -T mulukhiya-toot-proxy` | **0.25 秒** |

### ② `-S -T` で出力が捨てられないか（#4362 の轍）

```
2026-09-09T08:03:34.799779+09:00 shallu.b-shock.co.jp mulukhiya-toot-proxy[22564] rc-d-probe-4478
```

✅ **`/var/log/mulukhiya-toot-proxy.log` に入りました。**タグは chubo2 の rsyslog 設定
（`:programname, isequal, "mulukhiya-toot-proxy"`）が拾っています。

⚠⚠ **`-f` 単独にしないこと。**3 本とも /dev/null へ捨てるので、**FreeBSD で Sidekiq の
ログを no-reader pipe へ捨てていた #4362 と同じ轍**になります。

## あわせて `status` を足しました

`service mulukhiya-puma status` が `unknown directive` になっていました。

⚠ **`daemon -p` の pidfile は使えません。**`bin/*_daemon.rb start` 自身が fork して
デーモン化するので、`daemon` が見ている子はすぐ終わる＝ **pid が死んだ値になります。**
停止判定と同じ pattern で見るのが唯一の一貫した物差しです。本番 3 サービスとも
この pattern で pid が引けることを確認しました:

```
pattern=[puma_daemon\.rb|puma[ :].*mulukhiya-toot-proxy] -> pids=[93267 ]
pattern=[sidekiq_daemon\.rb|sidekiq .*mulukhiya-toot-proxy] -> pids=[93166 ]
pattern=[listener_daemon\.rb] -> pids=[93388 ]
```

## Issue の「ついでに見直したいもの」の状況

| | 状態 |
| --- | --- |
| `stop` の `pkill` パターンが広い | ✅ **#4675 で対処済み**（`mulukhiya-toot-proxy` まで含めて絞る形に） |
| graceful stop の待ちが無い | ✅ **対処済み**（`kill_wait` のループが入っている） |
| `status` ディレクティブが無い | ✅ **この PR** |

## 対象

`mulukhiya-puma` / `mulukhiya-sidekiq` / `mulukhiya-listener` の 3 本。
⚠ Ubuntu 側（vulcan）は systemd unit なので影響しません。3 本とも `sh -n` で構文確認済み。

## ⚠⚠ 配布は手作業です

🔴 **rc.d は cookbook 管理外で、5.36.0 のデプロイ時に 6 ヶ月ぶん乖離していました**
（shallu は 2026-03-03、zugoga は 2026-03-02 の内容のまま）。

**上書きの前に必ず実機と diff を取り、`cat sample > 対象` で書いてください**
（`mv` はモードと所有者を壊します）。⚠ **この変更は次の再起動でしか効かない**ので、
5.37.0 のデプロイ手順に組み込むまで #4478 は open のままにします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExMqJf1tfD174UoMBGVJNk