### PR TITLE
fix: 辞書ソースの間欠 404 を再送する (#4689)

### DIFF
--- a/app/lib/mulukhiya/dictionary_http.rb
+++ b/app/lib/mulukhiya/dictionary_http.rb
@@ -1,0 +1,63 @@
+module Mulukhiya
+  # 辞書ソース取得専用の HTTP クライアント (#4689)。
+  #
+  # ⚠⚠ **404 を再送対象にするのはここだけ。**`Mulukhiya::HTTP` 全体でやると、
+  # 投稿経路や API クライアントまで巻き込んで **恒久的な 404 を retry_limit 倍
+  # 叩き直すだけ**になる。上流（`Ginseng::HTTP::RetryMethods#retryable?`）が
+  # 404 を外しているのは**意図的な設計**で、「401 / 403 / 422 を投げ直しても
+  # 結果は同じ」という一般論としては正しい。
+  #
+  # ⚠ **404 が一時的なのは GAS という相手の事情**であって一般には成り立たないので、
+  # 上流を変えにいく話ではない。`retryable?` は「方針を変えたいアプリは override する」
+  # と明記されている面（pooza/tomato-shrieker の `retry_not_found` に前例がある）。
+  class DictionaryHTTP < HTTP
+    # 辞書取得での再送回数の既定 (#4689)。
+    #
+    # ⚠⚠ **時間の見積もりを先に置く。**#4659 の実測で **404 になった回は遅い**
+    # （`seconds: 33.47`）。`/http/timeout/seconds: 30` と `/http/retry/seconds: 1` の
+    # もとでは、1 ソースあたりの最悪が
+    #
+    #   limit × timeout + (limit - 1) × retry_seconds
+    #
+    # になる。**limit 2 で 61 秒 / limit 3 で 92 秒。**`TaggingDictionaryUpdateWorker` は
+    # `every: 10m`（600 秒）で、⚠ **ソースは `Parallel.each` で並列に引く**ので
+    # 壁時計はソース数倍にはならない（スレッド数を超えない限り）。
+    #
+    # ⚠ **既定を 2（＝再送 1 回）にしたのは上流負荷とのつり合い。**間欠 404 は
+    # gomander で 1 日 38% の回に出るので、1 回の再送で取りこぼしは 38% → 約 14% に
+    # 落ちる。⚠⚠ **再送は #4690（取得回数を減らす）とちょうど逆に効く**ので、
+    # 増やすなら総リクエスト数で見ること。
+    DEFAULT_RETRY_LIMIT = 2
+
+    # 辞書取得で再送する 4xx。⚠ **GAS の間欠 404 のためだけに開けている。**
+    RETRYABLE_CLIENT_STATUSES = [404].freeze
+
+    # ⚠ **`retry_limit` の reader を潰さない。**`Ginseng::HTTP` は
+    # `attr_accessor :retry_limit` を持ち、呼び出し側が `http.retry_limit = 1` で
+    # 絞る使い方がある（`rss20_feed_renderer` / `media_metadata_storage`）。
+    # メソッドで上書きすると**その代入が黙って効かなくなる**ので、
+    # `@retry_limit` を差し替える形にする。
+    def initialize
+      super
+      @retry_limit = configured_retry_limit
+    end
+
+    private
+
+    def configured_retry_limit
+      return config['/handler/dictionary_tag/retry/limit']
+    rescue Ginseng::ConfigError
+      # 既定値は config/application.yaml にある。設定ファイルが古い環境でも
+      # 再送回数が未定義にならないための定数フォールバック。
+      return DEFAULT_RETRY_LIMIT
+    end
+
+    # ⚠ **`super` を先に通す。**pinning / 上限超過 / 5xx / 接続断の判定は上流のまま。
+    # ここで足すのは 404 だけ。
+    def retryable?(error)
+      return true if super
+      return false unless error.is_a?(Ginseng::GatewayError)
+      return RETRYABLE_CLIENT_STATUSES.include?(error.source_status)
+    end
+  end
+end

--- a/app/lib/mulukhiya/dictionary_http.rb
+++ b/app/lib/mulukhiya/dictionary_http.rb
@@ -54,9 +54,19 @@ module Mulukhiya
 
     # ⚠ **`super` を先に通す。**pinning / 上限超過 / 5xx / 接続断の判定は上流のまま。
     # ここで足すのは 404 だけ。
+    #
+    # ⚠⚠ **`instance_of?` で見る（PR #4710 の Codex P1）。**上流が明示的に落として
+    # いる `PinningError` / `TooLargeError` は **`GatewayError` のサブクラス**なので、
+    # `is_a?` で拾うと **`source_status` がたまたま 404 のときに上流のガードを
+    # すり抜ける**。pinning は設定の問題で試行の間に変わらず、上限超過は同じ場所で
+    # 超えるだけなので、再送してはいけない。
+    #
+    # ⚠ **サブクラスを列挙しない**のは、上流がガードを増やしたときに自動で追随する
+    # ため。上流のレスポンス由来の 404 は `GatewayError.new("Bad response 404")`
+    # ＝ **素の `GatewayError`** なので、これで過不足なく拾える。
     def retryable?(error)
       return true if super
-      return false unless error.is_a?(Ginseng::GatewayError)
+      return false unless error.instance_of?(Ginseng::GatewayError)
       return RETRYABLE_CLIENT_STATUSES.include?(error.source_status)
     end
   end

--- a/app/lib/mulukhiya/remote_dictionary.rb
+++ b/app/lib/mulukhiya/remote_dictionary.rb
@@ -145,11 +145,10 @@ module Mulukhiya
 
     def initialize(params)
       @params = params.key_flatten
-      @http = HTTP.new
-    end
-
-    def retry_limit
-      return config['/http/retry/limit'] rescue 5
+      # ⚠ **辞書だけ 404 を再送する (#4689)。**GAS の間欠 404 は「取れなかった」
+      # ではなく相手側の一過性なので、last-good で埋める前に引き直す。
+      # ⚠⚠ **`Mulukhiya::HTTP` 全体では開けない**（恒久的な 404 を 3 倍叩くだけ）。
+      @http = DictionaryHTTP.new
     end
   end
 end

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -101,6 +101,13 @@ handler:
       - https://pf.korako.me/plugins/community-hashtag-map.json
     cache_ttl: 3600
   dictionary_tag:
+    # 辞書ソース取得の再送回数 (#4689)。⚠ **404 を再送するのは辞書だけ**
+    # （GAS の間欠 404 のため）。⚠⚠ 1 ソースあたりの最悪は
+    # `limit × /http/timeout/seconds + (limit - 1) × /http/retry/seconds`
+    # ＝ **2 なら 61 秒 / 3 なら 92 秒**。worker は 10 分周期なので 2 で余裕を残す。
+    # ⚠ 増やすと #4690（取得回数を減らす）と逆に効くので、総リクエスト数で見ること。
+    retry:
+      limit: 2
     cache:
       ttl: 3600
       # ソース単位の last-good キャッシュの TTL (#4659)。⚠ 本体の ttl より長く持つ

--- a/config/autoload.yaml
+++ b/config/autoload.yaml
@@ -3,6 +3,7 @@ inflections:
   amazon_url_handler: AmazonURLHandler
   api_controller: APIController
   css_renderer: CSSRenderer
+  dictionary_http: DictionaryHTTP
   ffmpeg_command_builder: FFmpegCommandBuilder
   http: HTTP
   http_status: HTTPStatus

--- a/config/schema/handler/dictionary_tag.yaml
+++ b/config/schema/handler/dictionary_tag.yaml
@@ -41,6 +41,14 @@ properties:
     type: array
   disabled:
     type: boolean
+  retry:
+    properties:
+      limit:
+        minimum: 1
+        type: integer
+    required:
+      - limit
+    type: object
   timeout:
     minimum: 1
     type: integer

--- a/test/unit/lib/dictionary_http.rb
+++ b/test/unit/lib/dictionary_http.rb
@@ -1,0 +1,89 @@
+module Mulukhiya
+  # 辞書ソース取得だけが 404 を再送すること (#4689)。
+  #
+  # ⚠⚠ **`Mulukhiya::HTTP` 全体で 404 を retryable にしてはいけない。**投稿経路や
+  # API クライアントまで巻き込むと、**恒久的な 404 を retry_limit 倍叩き直すだけ**に
+  # なる。上流（`Ginseng::HTTP::RetryMethods#retryable?`）が 404 を外しているのは
+  # 意図的な設計で、一般論としては正しい。404 が一時的なのは **GAS という相手の事情**。
+  class DictionaryHTTPTest < TestCase
+    RETRY_KEY = '/handler/dictionary_tag/retry/limit'.freeze
+
+    def setup
+      @dic = DictionaryHTTP.new
+      @plain = HTTP.new
+      @limit = config[RETRY_KEY] rescue nil
+    end
+
+    def teardown
+      config[RETRY_KEY] = @limit
+    end
+
+    # 🔴 **本体。**辞書用クライアントは 404 を再送する。
+    def test_dictionary_retries_not_found
+      assert(retryable?(@dic, 404), '辞書が 404 を再送しない')
+    end
+
+    # 🔴 **本体その 2。**⚠ 素の `Mulukhiya::HTTP` は巻き込まない。
+    # ここが true になったら、恒久的な 404 を全経路で叩き直している。
+    def test_plain_http_does_not_retry_not_found
+      refute(retryable?(@plain, 404), '投稿経路まで 404 を再送している')
+    end
+
+    # ⚠ 開けたのは 404 だけ。他の恒久的な 4xx は上流の判定のまま。
+    def test_other_client_errors_stay_permanent
+      [400, 401, 403, 410, 422].each do |status|
+        refute(retryable?(@dic, status), "#{status} まで再送対象になっている")
+      end
+    end
+
+    # ⚠ **上流の判定を殺していない。**5xx と一時的な 4xx は従来どおり再送する。
+    def test_upstream_policy_is_preserved
+      [408, 425, 429, 500, 502, 503].each do |status|
+        assert(retryable?(@dic, status), "#{status} が再送されなくなっている")
+      end
+    end
+
+    # ⚠ **`retry_limit` の reader を潰していない。**呼び出し側の
+    # `http.retry_limit = 1` が効かなくなると、絞ったつもりの経路が黙って戻る。
+    def test_retry_limit_stays_assignable
+      @dic.retry_limit = 1
+
+      assert_equal(1, @dic.retry_limit)
+    end
+
+    # 既定は設定から引く。⚠ 死にコードだった `RemoteDictionary#retry_limit` は
+    # `rescue 5` という**別の既定値**を持っていて「辞書だけ 5 回」に見えていた。
+    def test_default_comes_from_config
+      config[RETRY_KEY] = 4
+
+      assert_equal(4, DictionaryHTTP.new.retry_limit)
+    end
+
+    # 設定が無い環境でも「制限なし」や nil に退行しない。
+    def test_falls_back_to_the_constant
+      config[RETRY_KEY] = nil
+      assert_raises(Ginseng::ConfigError) {config[RETRY_KEY]}
+
+      assert_equal(DictionaryHTTP::DEFAULT_RETRY_LIMIT, DictionaryHTTP.new.retry_limit)
+    end
+
+    # 🔴 **死にコードが復活していないこと。**`RemoteDictionary#retry_limit` は
+    # `rescue 5` の別既定を持つ未使用メソッドだった（#4689 で削除）。
+    def test_remote_dictionary_has_no_stale_retry_limit
+      refute(RemoteDictionary.method_defined?(:retry_limit, false))
+    end
+
+    private
+
+    # `retryable?` は private なので送る。error は source_status だけ見られる。
+    def retryable?(http, status)
+      return http.send(:retryable?, gateway_error(status))
+    end
+
+    def gateway_error(status)
+      error = Ginseng::GatewayError.new("Bad response #{status}")
+      error.define_singleton_method(:source_status) {status}
+      return error
+    end
+  end
+end

--- a/test/unit/lib/dictionary_http.rb
+++ b/test/unit/lib/dictionary_http.rb
@@ -43,6 +43,27 @@ module Mulukhiya
       end
     end
 
+    # 🔴 **上流のガードをすり抜けない**（PR #4710 の Codex P1）。
+    # ⚠⚠ `PinningError` / `TooLargeError` は **`GatewayError` のサブクラス**なので、
+    # `is_a?` で拾うと **`source_status` がたまたま 404 のときに再送してしまう**。
+    # pinning は設定の問題で試行の間に変わらず、上限超過は同じ場所で超えるだけ。
+    def test_upstream_guards_are_not_bypassed
+      [Ginseng::PinningError, Ginseng::TooLargeError].each do |klass|
+        error = klass.new('boom')
+        error.define_singleton_method(:source_status) {404}
+
+        refute(@dic.send(:retryable?, error), "#{klass} が 404 で再送対象になっている")
+      end
+    end
+
+    # ⚠ ガードは `GatewayError` のサブクラスとして足される。列挙せず
+    # `instance_of?` で見ているので、上流が増やしても自動で追随する。
+    def test_guards_are_gateway_error_subclasses
+      [Ginseng::PinningError, Ginseng::TooLargeError].each do |klass|
+        assert_operator(klass, :<, Ginseng::GatewayError)
+      end
+    end
+
     # ⚠ **`retry_limit` の reader を潰していない。**呼び出し側の
     # `http.retry_limit = 1` が効かなくなると、絞ったつもりの経路が黙って戻る。
     def test_retry_limit_stays_assignable


### PR DESCRIPTION
Closes #4689

## 何を直したか

GAS の間欠 404 がそのまま 1 回の欠けになっていました。`RemoteDictionary#fetch` は
404 を「取れなかった」として扱うだけで再送しません。

⚠ **上流（`Ginseng::HTTP::RetryMethods#retryable?`）が 404 を外しているのは意図的な設計**で、
「401 / 403 / 422 を投げ直しても結果は同じ」という一般論としては正しいものです。
**404 が一時的なのは GAS という相手の事情**なので、上流を変えにいく話ではありません。

## 辞書だけに閉じました

`DictionaryHTTP < HTTP` を作り、`retryable?` を override して 404 を足しました。

⚠⚠ **`Mulukhiya::HTTP` 全体では開けません。**投稿経路や API クライアントまで巻き込むと、
**恒久的な 404 を retry_limit 倍叩き直すだけ**になります。

⚠ **`super` を先に通す**ので、pinning / 上限超過 / 5xx / 接続断の判定は上流のままです。

## ⚠⚠ 時間の見積もり（Issue が「**先に決める**」としていた項目）

1 ソースあたりの最悪は `limit × timeout + (limit - 1) × retry_seconds`。
`/http/timeout/seconds: 30` / `/http/retry/seconds: 1` のもとで:

| limit | 1 ソースあたり最悪 |
| ---: | ---: |
| 2 | **61 秒** |
| 3 | 92 秒 |

⚠ **ソースは `Parallel.each`（`in_threads: processor_count * 2`）で並列に引く**ので、
壁時計はソース数倍にはなりません（スレッド数を超えない限り）。worker は `every: 10m`（600 秒）。

**既定は 2（＝再送 1 回）**にしました。間欠 404 は gomander で 1 日 38% の回に出るので、
1 回の再送で取りこぼしは **38% → 約 14%** に落ちます。⚠ **再送は #4690（取得回数を減らす）と
ちょうど逆に効く**ので、増やすなら総リクエスト数で見てください。
`/handler/dictionary_tag/retry/limit` で変えられます（`config/schema` にも宣言済み）。

## 🔴 死にコードを消しました

`RemoteDictionary#retry_limit` はどこからも呼ばれておらず、⚠ **`rescue 5` という別の既定値**を
持っていたので「辞書だけ 5 回再送している」ように読めました。

⚠ **`retry_limit` の reader は潰していません。**`Ginseng::HTTP` は `attr_accessor :retry_limit` を
持ち、`http.retry_limit = 1` で絞る使い方があります（`rss20_feed_renderer` /
`media_metadata_storage`）。メソッドで上書きすると**その代入が黙って効かなくなる**ので、
`initialize` で `@retry_limit` を差し替える形にしました。

## テスト（8 本・新規 `test/unit/lib/dictionary_http.rb`）

| テスト | 何を押さえるか |
| --- | --- |
| `test_dictionary_retries_not_found` | 🔴 辞書は 404 を再送する |
| `test_plain_http_does_not_retry_not_found` | 🔴 **素の `Mulukhiya::HTTP` は巻き込まない** |
| `test_other_client_errors_stay_permanent` | 400 / 401 / 403 / 410 / 422 は恒久のまま |
| `test_upstream_policy_is_preserved` | 408 / 425 / 429 / 5xx は従来どおり再送 |
| `test_retry_limit_stays_assignable` | ⚠ reader を潰していない |
| `test_default_comes_from_config` / `test_falls_back_to_the_constant` | 既定値の出どころ |
| `test_remote_dictionary_has_no_stale_retry_limit` | 🔴 死にコードが復活していない |

## 効きの測り方（Issue より）

② で入った syslog の `substituted_sources` が **0 より大きい回が減れば**効いています
（last-good で埋めに回らずに済んだ、ということ）。⚠ **上流の 404 そのものはゼロにできない**
ので、指標は「埋める回数が減ったか」に取ります。

## 検証

- `bundle exec rake lint` → ✅ **511 files / no offenses**、脆弱性 0
- `bundle exec rake test` → ✅ **1309 tests / 1890 assertions / 0 failures / 0 errors**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExMqJf1tfD174UoMBGVJNk