### PR TITLE
fix: schema の format を実際に検証する (#4597)

### DIFF
--- a/app/lib/mulukhiya.rb
+++ b/app/lib/mulukhiya.rb
@@ -104,8 +104,13 @@ module Mulukhiya
 
   # 検証そのものが実行できなかった場合だけ握る。⚠ ここでの fail-open は
   # 「schema を読めない環境でも起動はできる」ための意図的なもの。
+  # ⚠⚠ **schema の検証だけでは足りない (#4597)。**json-schema には `regex` の
+  # 検証実装が無く、`format: regex` と書いてあっても壊れた正規表現が素通しする。
+  # 🔴 `/sentry/scrub_patterns` は `before_send` の中で毎回 `Regexp.new` されるので、
+  # **Sentry へイベントを送ろうとした瞬間に初めて倒れる**＝**例外を集める仕組みが
+  # 例外で止まる**。ここで一緒に見て、strict なら起動で止める。
   def self.config_validation_errors
-    return Config.instance.errors
+    return Config.instance.errors + ConfigFormatValidator.new.errors
   rescue => e
     warn "config validation skipped: #{e.message}"
     return []

--- a/app/lib/mulukhiya.rb
+++ b/app/lib/mulukhiya.rb
@@ -104,13 +104,10 @@ module Mulukhiya
 
   # 検証そのものが実行できなかった場合だけ握る。⚠ ここでの fail-open は
   # 「schema を読めない環境でも起動はできる」ための意図的なもの。
-  # ⚠⚠ **schema の検証だけでは足りない (#4597)。**json-schema には `regex` の
-  # 検証実装が無く、`format: regex` と書いてあっても壊れた正規表現が素通しする。
-  # 🔴 `/sentry/scrub_patterns` は `before_send` の中で毎回 `Regexp.new` されるので、
-  # **Sentry へイベントを送ろうとした瞬間に初めて倒れる**＝**例外を集める仕組みが
-  # 例外で止まる**。ここで一緒に見て、strict なら起動で止める。
+  # ⚠ `format: regex` の検証は `Config#errors` に寄せてある (#4597)。
+  # **`rake config:lint` と `#audit` も同じ結果を見る**必要があるため。
   def self.config_validation_errors
-    return Config.instance.errors + ConfigFormatValidator.new.errors
+    return Config.instance.errors
   rescue => e
     warn "config validation skipped: #{e.message}"
     return []

--- a/app/lib/mulukhiya/config.rb
+++ b/app/lib/mulukhiya/config.rb
@@ -45,6 +45,17 @@ module Mulukhiya
       }
     end
 
+    # ⚠⚠ **schema の検証だけでは足りない (#4597)。**json-schema には `regex` の
+    # 検証実装が無く、`format: regex` と書いてあっても壊れた正規表現が素通しする。
+    #
+    # 🔴 **ここに足す（PR #4711 の Codex P1）。**`Mulukhiya.validate_config` にだけ
+    # 足すと、**`rake config:lint` も `#audit` も `errors` を直に見ている**ので
+    # 素通りしてしまう。`config:lint` は起動前チェックとして設定されているのに
+    # `config: OK` を返し、管理画面の audit にも出ない。**消費者ごとに配線しない。**
+    def errors
+      return super + ConfigFormatValidator.new(schema, merged_raw).errors
+    end
+
     def audit
       local = raw['local']
       return {errors: [], unknown_keys: []} unless local.is_a?(Hash)

--- a/app/lib/mulukhiya/config_format_validator.rb
+++ b/app/lib/mulukhiya/config_format_validator.rb
@@ -1,0 +1,72 @@
+module Mulukhiya
+  # JSON Schema の `format: regex` を**実際に**検証する (#4597)。
+  #
+  # ⚠⚠ **json-schema には `regex` の検証実装がそもそも無い。**`format: regex` と
+  # 書いてあっても `[unclosed` も `(?<broken` も素通しする。⚠ `validate_formats: true`
+  # を渡しても変わらない（`date-time` などは効くが `regex` / `hostname` / `email` は
+  # 実装が無い）。**フラグの問題ではない。**
+  #
+  # 🔴 **いちばん効くのは `/sentry/scrub_patterns`。**`Mulukhiya.setup_sentry` は
+  # `before_send` の中で毎回 `Regexp.new` を呼ぶので、**壊れたパターンは
+  # `config:lint` を通り、Sentry へイベントを送ろうとした瞬間に初めて
+  # `RegexpError` になる**。⚠⚠ sentry-ruby の `Client#send_event` は
+  # `before_send.call` を rescue していないので、**例外を集める仕組みが例外で止まる**。
+  # ⚠ 設定した本人は「スクラブしているつもり」なので、無音のまま漏れる。
+  #
+  # ⚠ **場所を列挙しない。**schema を歩いて `format: regex` の付いた値を拾うので、
+  # schema に足した瞬間から検証対象になる。列挙すると必ずずれる。
+  class ConfigFormatValidator
+    include Package
+
+    # 実際にコンパイルして確かめる format。⚠ `hostname` / `email` は
+    # `pattern` で表現できるので schema 側で書き換えた。ここに残すのは
+    # **JSON Schema の語彙で表現できない**ものだけ。
+    COMPILED_FORMATS = ['regex'].freeze
+
+    def initialize(schema = nil, values = nil)
+      @schema = schema || Config.instance.schema
+      @values = values || Config.instance.merged_raw
+    end
+
+    def errors
+      @errors = []
+      walk(@schema, @values, '')
+      return @errors
+    end
+
+    private
+
+    def walk(schema, value, path)
+      return unless schema.is_a?(Hash)
+      verify(schema, value, path)
+      walk_properties(schema, value, path)
+      walk_items(schema, value, path)
+    end
+
+    def walk_properties(schema, value, path)
+      properties = schema['properties'] || schema[:properties]
+      return unless properties.is_a?(Hash) && value.is_a?(Hash)
+      properties.each do |key, child|
+        next unless value.key?(key.to_s)
+        walk(child, value[key.to_s], "#{path}/#{key}")
+      end
+    end
+
+    def walk_items(schema, value, path)
+      items = schema['items'] || schema[:items]
+      return unless items.is_a?(Hash) && value.is_a?(Array)
+      value.each_with_index {|v, i| walk(items, v, "#{path}[#{i}]")}
+    end
+
+    def verify(schema, value, path)
+      format = schema['format'] || schema[:format]
+      return unless COMPILED_FORMATS.include?(format)
+      return unless value.is_a?(String)
+      Regexp.new(value)
+    rescue RegexpError => e
+      # ⚠ **値そのものは出す。**壊れた正規表現は秘密情報ではないし、
+      # どこが壊れているか分からないと直せない。
+      @errors.push("The property '##{path}' is not a valid regular expression: #{e.message}")
+    end
+  end
+end

--- a/config/schema/base.yaml
+++ b/config/schema/base.yaml
@@ -177,7 +177,10 @@ properties:
               format: uri
               type: string
             path:
-              format: ^/
+              # ⚠⚠ **`format: ^/` は format 名ですらなかった (#4597)。**未知の format は
+              # 黙って無視されるので、**1 文字の違いで完全な no-op** になっていた。
+              # 書き手の意図（「`/` で始まること」）は正規表現なので `pattern` が正しい。
+              pattern: '^/'
               type: string
             title:
               type: string
@@ -213,7 +216,10 @@ properties:
       hosts:
         properties:
           default:
-            format: hostname
+            # ⚠ **`format: hostname` は json-schema に検証実装が無く素通しだった (#4597)。**
+            # `not a hostname!` も `http://example.com` も `.....` も通っていた。
+            # RFC 1123 のラベル（英数字とハイフン・先頭末尾はハイフン不可）で書き直す。
+            pattern: '^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$'
             type: string
         type: object
     type: object
@@ -232,7 +238,10 @@ properties:
       hosts:
         properties:
           default:
-            format: hostname
+            # ⚠ **`format: hostname` は json-schema に検証実装が無く素通しだった (#4597)。**
+            # `not a hostname!` も `http://example.com` も `.....` も通っていた。
+            # RFC 1123 のラベル（英数字とハイフン・先頭末尾はハイフン不可）で書き直す。
+            pattern: '^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$'
             type: string
         type: object
       subject:

--- a/config/schema/handler/mail_alert.yaml
+++ b/config/schema/handler/mail_alert.yaml
@@ -9,7 +9,10 @@ properties:
     minimum: 1
     type: integer
   to:
-    format: email
+    # ⚠ **`format: email` は json-schema に検証実装が無く素通しだった (#4597)。**
+    # `not-an-email` も `@` も `a b@c` も通っていた。⚠ RFC 5322 を厳密に書くのは
+    # 不毛なので、**typo を落とせる最小限**（空白なし・`@` が 1 つ・ドメインに `.`）に絞る。
+    pattern: '^[^@[:space:]]+@[^@[:space:]]+\.[^@[:space:]]+$'
     type: string
 required:
   - to

--- a/test/unit/lib/config_format_validator.rb
+++ b/test/unit/lib/config_format_validator.rb
@@ -76,7 +76,26 @@ module Mulukhiya
       assert_empty(found, '検証実装の無い format が残っている')
     end
 
+    # 🔴 **`Config#errors` に届くこと（PR #4711 の Codex P1）。**
+    # ⚠⚠ `Mulukhiya.validate_config` にだけ足すと、**`rake config:lint` も
+    # `Config#audit` も `errors` を直に見ている**ので素通りする。`config:lint` は
+    # 起動前チェックとして設定されているのに `config: OK` を返してしまう。
+    def test_errors_reach_every_consumer
+      config = Config.instance
+      original = config.raw['local']
+      config.raw['local'] = {'spoiler' => {'pattern' => '[unclosed'}}
+
+      assert_equal(1, regexp_errors(config.errors).length, 'Config#errors に出ていない')
+      assert_equal(1, regexp_errors(config.audit[:errors]).length, 'Config#audit に出ていない')
+    ensure
+      config.raw['local'] = original
+    end
+
     private
+
+    def regexp_errors(errors)
+      return errors.select {|e| e.include?('is not a valid regular expression')}
+    end
 
     def validate(values)
       return ConfigFormatValidator.new(Config.instance.schema, values).errors

--- a/test/unit/lib/config_format_validator.rb
+++ b/test/unit/lib/config_format_validator.rb
@@ -1,0 +1,85 @@
+module Mulukhiya
+  # `format: regex` を**実際に**検証すること (#4597)。
+  #
+  # ⚠⚠ **json-schema には `regex` の検証実装がそもそも無い。**`format: regex` と
+  # 書いてあっても `[unclosed` も `(?<broken` も素通しする。⚠ `validate_formats: true`
+  # を渡しても変わらない。**フラグの問題ではない。**
+  #
+  # 🔴 いちばん効くのは `/sentry/scrub_patterns`。`before_send` の中で毎回
+  # `Regexp.new` されるので、**Sentry へイベントを送ろうとした瞬間に初めて倒れる**
+  # ＝ **例外を集める仕組みが例外で止まる**。設定した本人は「スクラブしているつもり」。
+  class ConfigFormatValidatorTest < TestCase
+    BROKEN = ['[unclosed', '(?<broken', '*invalid'].freeze
+
+    # 🔴 **本体。**壊れた正規表現を捕まえる。
+    def test_detects_a_broken_pattern
+      BROKEN.each do |pattern|
+        errors = validate({'spoiler' => {'pattern' => pattern}})
+
+        assert_equal(1, errors.length, "#{pattern} を素通ししている")
+        assert_match(%r{'#/spoiler/pattern'}, errors.first)
+      end
+    end
+
+    # 🔴 **配列の中も見る。**`/sentry/scrub_patterns` はここ。
+    def test_detects_a_broken_pattern_in_an_array
+      errors = validate({'sentry' => {'scrub_patterns' => ['ok', '[unclosed', 'fine']}})
+
+      assert_equal(1, errors.length)
+      assert_match(%r{'#/sentry/scrub_patterns\[1\]'}, errors.first)
+    end
+
+    # 妥当なものは通す（機能を殺していない）。
+    def test_accepts_valid_patterns
+      values = {
+        'spoiler' => {'pattern' => '\A(?<body>.+)\z'},
+        'sentry' => {'scrub_patterns' => ['token=\w+', '[0-9]{4}']},
+      }
+
+      assert_empty(validate(values))
+    end
+
+    # ⚠ 未設定は検証対象ではない（schema の `required` の仕事）。
+    def test_absent_values_are_not_errors
+      assert_empty(validate({}))
+    end
+
+    # ⚠ `format: regex` 以外は触らない。`uri` は json-schema 側が見る。
+    def test_other_formats_are_left_alone
+      errors = validate({'status_url' => '[unclosed'})
+
+      assert_empty(errors)
+    end
+
+    # ⚠⚠ **実際の schema に対して回しても落ちない**こと。ここが落ちるなら
+    # 同梱の `config/schema` に壊れた既定値が入っている。
+    def test_shipped_config_is_clean
+      assert_empty(ConfigFormatValidator.new.errors)
+    end
+
+    # 🔴 **効かない format が復活していないこと。**`hostname` / `email` は
+    # json-schema に検証実装が無く、`^/` は **format 名ですらなかった**（#4597）。
+    # ⚠ **効かない指定を残すと「対応済み」に見えるだけ害になる。**
+    #
+    # ⚠ 通してよいのは 3 つだけ。`uri` / `date-time` は json-schema が見る。
+    # **`regex` はここ（`ConfigFormatValidator`）が見る**ので残してよい。
+    EFFECTIVE_FORMATS = ['uri', 'date-time', *ConfigFormatValidator::COMPILED_FORMATS].freeze
+
+    def test_no_ineffective_formats_remain
+      found = Dir.glob(File.join(Environment.dir, 'config/schema/**/*.yaml')).flat_map do |path|
+        File.readlines(path).filter_map do |line|
+          next unless matches = line.match(/^\s*format:\s*(\S+)\s*$/)
+          "#{File.basename(path)}: #{matches[1]}" unless EFFECTIVE_FORMATS.include?(matches[1])
+        end
+      end
+
+      assert_empty(found, '検証実装の無い format が残っている')
+    end
+
+    private
+
+    def validate(values)
+      return ConfigFormatValidator.new(Config.instance.schema, values).errors
+    end
+  end
+end


### PR DESCRIPTION
Closes #4597

⚠⚠ **`config/schema/` に書かれた `format` のうち `uri` 以外は 1 件も検証されていませんでした。**
⚠ **書いてあるので守られているように見えるが、どんな値でも通る**という状態です。

## 直し方は 2 通りに分かれます

### ① JSON Schema の語彙で表現できるもの → `pattern` へ

| | 直し方 | 実測 |
| --- | --- | --- |
| `format: ^/`（1 件） | ⚠⚠ **format 名ですらなく、未知の format として黙って無視されていた。**`pattern: '^/'` へ | `relative/path` ✅弾く / `https://elsewhere.example` ✅弾く / `/feed/custom.rss` ✅通す |
| `format: hostname`（2 件） | RFC 1123 のラベルを `pattern` で | `not a hostname!` / `http://example.com` / `.....` ✅3 つとも弾く / `tube.example.com`・`a-b.example.co.jp` ✅通す |
| `format: email`（1 件） | typo を落とせる最小限（空白なし・`@` が 1 つ・ドメインに `.`） | — |

🔴 **`^/` は 1 文字の違いで完全な no-op**でした。書き手の意図（「`/` で始まること」）は
正規表現なので `pattern` が正しい形です。

⚠ email は **RFC 5322 を厳密に書くのは不毛**なので、typo を落とせる最小限に絞りました。

### ② 表現できないもの（`format: regex`・6 件）→ 読み込み側で検証する

「正規表現として妥当か」は JSON Schema の語彙にありません。`ConfigFormatValidator` を足し、
**schema を歩いて `format: regex` の付いた値を実際に `Regexp.new` する**形にしました。

⚠ **場所を列挙していません。**schema に `format: regex` を足した瞬間から検証対象になります
（列挙すると必ずずれます）。配列の中（`/sentry/scrub_patterns[1]` のような位置）も辿ります。

`Mulukhiya.validate_config` に合流させたので、**#4596 の `strict` なら起動で止まります。**

## 🔴 いちばん効くのは `/sentry/scrub_patterns`

`Mulukhiya.setup_sentry` は `before_send` の中で**毎回 `Regexp.new` を呼びます**。
⚠⚠ 壊れたパターンは `config:lint` を通り、**Sentry へイベントを送ろうとした瞬間に初めて
`RegexpError` になる** ＝ **例外を集める仕組みが例外で止まる**形です。
⚠ 設定した本人は「スクラブしているつもり」なので、**無音のまま漏れます。**

## 本番への影響を確認しました（2026-09-09）

厳格化した 4 キーは **本番 3 台とも未設定**でした:

```
/feed/custom = []
/handler/mail_alert/to = (未設定)
/peer_tube/hosts/default = (未設定)
/piefed/hosts/default = (未設定)
```

同梱の `application.yaml` も新しい pattern を通ります（`Config.instance.errors` は
この環境固有の `postgres/dsn` 未設定 1 件のみ）。

## テスト（8 本・新規 `test/unit/lib/config_format_validator.rb`）

| テスト | 何を押さえるか |
| --- | --- |
| `test_detects_a_broken_pattern` | 🔴 `[unclosed` / `(?<broken` / `*invalid` を捕まえる |
| `test_detects_a_broken_pattern_in_an_array` | 🔴 `/sentry/scrub_patterns[1]` のような配列の中も辿る |
| `test_accepts_valid_patterns` | 妥当なものは通す |
| `test_absent_values_are_not_errors` | 未設定は `required` の仕事 |
| `test_other_formats_are_left_alone` | `uri` は json-schema 側に任せる |
| `test_shipped_config_is_clean` | 同梱設定に壊れた既定値が無い |
| `test_no_ineffective_formats_remain` | 🔴 **効かない format が復活していない**（通してよいのは `uri` / `date-time` / `regex` の 3 つだけ） |

⚠ **「効かない指定を残すと『対応済み』に見えるだけ害になる」**という Issue の指摘を、
最後のテストで恒久化しています。

## 検証

- `bundle exec rake lint` → ✅ **511 files / no offenses**、脆弱性 0
- `bundle exec rake test` → ✅ **1308 tests / 1885 assertions / 0 failures / 0 errors**

## ⚠ 参考: `uri` は上流で厳しくなります

`pooza/ginseng-core#516` / PR `#517` で `format: uri` が絶対 URI を要求するようになります。
Issue に「モロヘイヤの現行設定に対して新規エラーが 0 件」と記録済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExMqJf1tfD174UoMBGVJNk