### PR TITLE
obs: report_error の alert 過不足 3 系統を塞ぐ (#4693)

### DIFF
--- a/app/lib/mulukhiya/controller.rb
+++ b/app/lib/mulukhiya/controller.rb
@@ -21,6 +21,12 @@ module Mulukhiya
     ALERT_THROTTLE_SECONDS = 300
     ALERT_THROTTLE_KEY_PREFIX = 'alert_throttle'.freeze
 
+    # ルートが決まる前に落ちたときの発生源 (#4693・PR #4712 の Codex P2)。
+    #
+    # ⚠⚠ **ここは 1 つのバケツにまとめる。**`before` は全リクエストで走り、
+    # **パスごとに分けると分けた数だけ鳴る**＝抑えたい相手そのものを取り逃がす。
+    BEFORE_ORIGIN = 'before'.freeze
+
     set :root, Environment.dir
     enable :method_override
 
@@ -271,12 +277,34 @@ module Mulukhiya
     # **抑えたいのは「全断中に毎リクエスト鳴る」**ほうなので、これで足りる。
     def throttled_alert(error)
       redis = Redis.new
-      key = "#{ALERT_THROTTLE_KEY_PREFIX}/#{error.class}"
+      key = alert_throttle_key(error)
       return error.log(throttled: true) if redis.key?(key)
       redis.setex(key, ALERT_THROTTLE_SECONDS, 1)
       error.alert
     rescue => e
       error.log(throttle_error: e.class.to_s)
+    end
+
+    # 抑止のバケツ。**型だけでは粗すぎる（PR #4712 の Codex P2）。**
+    #
+    # ⚠⚠ `report_error` は `before` だけでなく**各コントローラの rescue から
+    # 呼ばれる**ので、型だけで括ると **`RuntimeError` / `NoMethodError` のような
+    # 広い型で、あるルートの失敗が別ルートの本物のバグを 300 秒握り潰す。**
+    # 発生源（ルート）を混ぜて、**抑えたいのは「同じ場所の連打」だけ**にする。
+    #
+    # ⚠ `sinatra.route` は `"POST /api/v?/status/tags"` のような**パターン**なので、
+    # id を含まず安定している（実測）。ルートが決まる前＝ `before` の失敗では nil。
+    def alert_throttle_key(error)
+      return [ALERT_THROTTLE_KEY_PREFIX, error.class, alert_throttle_origin].join('/')
+    end
+
+    # ⚠ リクエストの外（rake・テスト）では `request` が nil。**黙って倒すが、
+    # 倒す先は「より強く抑える」側**なので、無音で緩むことにはならない。
+    def alert_throttle_origin
+      return BEFORE_ORIGIN unless request
+      return request.env['sinatra.route'].presence || BEFORE_ORIGIN
+    rescue StandardError
+      return BEFORE_ORIGIN
     end
 
     # ⚠ 見るのは `status`（モロヘイヤがクライアントへ返す値）。上流の

--- a/app/lib/mulukhiya/controller.rb
+++ b/app/lib/mulukhiya/controller.rb
@@ -15,6 +15,12 @@ module Mulukhiya
     # `X-Mulukhiya` まで混ざる。転送してよいものだけを 1 本の許可リストに置く。
     FORWARDED_HEADERS = ['Idempotency-Key'].freeze
 
+    # サーバー側の失敗を鳴らす間隔 (秒) と、その印を置く Redis キーの接頭辞 (#4693)。
+    # ⚠ 型ごとに独立して数える。`Sequel::DatabaseConnectionError` の連打を抑えている間に
+    # 別の型（本物のバグ）が出たら、そちらは 1 回目として鳴ってほしい。
+    ALERT_THROTTLE_SECONDS = 300
+    ALERT_THROTTLE_KEY_PREFIX = 'alert_throttle'.freeze
+
     set :root, Environment.dir
     enable :method_override
 
@@ -178,6 +184,23 @@ module Mulukhiya
       return @headers.to_h.slice(*FORWARDED_HEADERS)
     end
 
+    # トークンを暗号化する。⚠ **失敗はこちらの設定の問題 (#4693)。**
+    #
+    # ⚠⚠ `Ginseng::CryptError#status` は **403** なので、`report_error` の
+    # ステータス判定では「クライアントが悪い」側に落ちて **`log` 止め**になる。
+    # だが実体は `/crypt/password` の未設定・破損で、**全ユーザーのトークン発行が
+    # 403 になるのに Sentry には何も出ない**（`Crypt.password` が `rescue nil` で
+    # nil に落ち、`PKCS5.pbkdf2_hmac(nil, ...)` が `CryptError` に包まれる）。
+    #
+    # ⚠ **クライアントは何も悪くない**ので、ここで印を付けて必ず鳴らす。
+    # ⚠ `report_error` 側で例外クラスを列挙しないための形（#4603 / #4629 で
+    # 列挙は実際に取りこぼしている）。
+    def encrypt_token!(value)
+      return value.encrypt
+    rescue => e
+      raise NeverSilent.mark(e)
+    end
+
     def verify_token_integrity!
       expected = token
       return unless expected
@@ -188,7 +211,11 @@ module Mulukhiya
         actual: sns.token&.first(8),
         path: scrub_log_path(request.path),
       )
-      raise Ginseng::AuthError, 'Token integrity check failed'
+      # ⚠⚠ **これは「クライアントが悪い」ではない (#4693)。**リクエスト間で
+      # トークンが混線した＝**セキュリティ不変条件の破れ**で、2025-10 のトークン
+      # 汚染事故（`Gemfile` が rack / sinatra に上限を書いている理由そのもの）の
+      # 再発検知がここに掛かっている。401 なので既定では log 止めになる。
+      raise NeverSilent.mark(Ginseng::AuthError.new('Token integrity check failed'))
     end
 
     # クライアント起因の失敗を Sentry alert に上げない共通判定
@@ -214,7 +241,42 @@ module Mulukhiya
     # モロヘイヤ自身のバグを黙らせてはいけないので、これが正しい既定。
     # `respond_to?` のガードは refine が外れたときの保険で、通常は到達しない。
     def report_error(error)
-      client_error?(error) ? error.log : error.alert
+      # ⚠⚠ **① 印が付いていればステータスに依らず必ず鳴らす (#4693)。**
+      # 「403 だがこちらの設定が壊れている」型（`Ginseng::CryptError`）や
+      # 「401 だがセキュリティ不変条件の破れ」型（`token_mismatch`）が、
+      # ステータスだけの判定では丸ごと無音になっていた。
+      return error.alert if never_silent?(error)
+      # ② クライアント起因は従来どおり log 止め。
+      return error.log if client_error?(error)
+      # ⚠⚠ **③ サーバー側の失敗は鳴らすが、連続はデッドマンで抑える (#4693)。**
+      # `before` は**全リクエスト**（未認証・スキャナ由来を含む）で走り、失敗の
+      # 主因は Redis / Postgres 障害。素通しだと **DB 全断中にリクエスト 1 本ごとに
+      # Sentry イベント 1 件＋ slack / line / mail** が飛び、障害中に外向き HTTP を
+      # 増やす二次被害とレート制限になる。
+      return throttled_alert(error)
+    end
+
+    # 同じ型の失敗は窓のあいだ 1 回だけ鳴らす (#4693)。
+    #
+    # ⚠ `StartupNotificationWorker#notify_failure` と同じ「連続失敗の 1 回目だけ」の
+    # 考え方だが、**成功で解除する代わりに TTL で解除する。**`before` は毎リクエスト
+    # 走るので、成功のたびに Redis を書くと平常時のコストが乗る。
+    #
+    # ⚠⚠ **カウンタ自体が落ちたら log へ倒す。**ここへ来る主因が Redis 全断なので、
+    # 抑止できないからと鳴らす側へ倒すと**まさに避けたいスパムになる**。
+    # Redis の死は `/health` の redis 側で観測されるので、二重に鳴らす価値がない
+    # （`StartupNotificationWorker` と同じ判断）。
+    # ⚠ **厳密な排他ではない。**`Ginseng::Redis::Service#set` は `NX` を取らないので
+    # `key?` → `setex` の 2 段になる。同時に来た数本が二重に鳴ることはあるが、
+    # **抑えたいのは「全断中に毎リクエスト鳴る」**ほうなので、これで足りる。
+    def throttled_alert(error)
+      redis = Redis.new
+      key = "#{ALERT_THROTTLE_KEY_PREFIX}/#{error.class}"
+      return error.log(throttled: true) if redis.key?(key)
+      redis.setex(key, ALERT_THROTTLE_SECONDS, 1)
+      error.alert
+    rescue => e
+      error.log(throttle_error: e.class.to_s)
     end
 
     # ⚠ 見るのは `status`（モロヘイヤがクライアントへ返す値）。上流の

--- a/app/lib/mulukhiya/controller/api_controller.rb
+++ b/app/lib/mulukhiya/controller/api_controller.rb
@@ -134,7 +134,7 @@ module Mulukhiya
       else
         response = sns.auth(params[:code], params[:type])
         @renderer.message = response.parsed_response
-        @renderer.message['access_token_crypt'] = @renderer.message['access_token'].encrypt
+        @renderer.message['access_token_crypt'] = encrypt_token!(@renderer.message['access_token'])
       end
       return @renderer.to_s
     rescue => e
@@ -154,7 +154,7 @@ module Mulukhiya
         response = sns.auth(params[:code], params[:type])
         token = sns.create_access_token(response.parsed_response['accessToken'], params[:type])
         @renderer.message = response.parsed_response
-        @renderer.message['access_token_crypt'] = token.encrypt
+        @renderer.message['access_token_crypt'] = encrypt_token!(token)
       end
       return @renderer.to_s
     rescue => e

--- a/app/lib/mulukhiya/controller/ui_controller.rb
+++ b/app/lib/mulukhiya/controller/ui_controller.rb
@@ -32,10 +32,10 @@ module Mulukhiya
       access_token = parsed['access_token'] || parsed['accessToken']
       raise Ginseng::AuthError, 'No access token in response' unless access_token
       if info_bot_token?(access_token)
-        config.update_file(agent: {info: {token: access_token.encrypt}})
+        config.update_file(agent: {info: {token: encrypt_token!(access_token)}})
         config.reload
       end
-      token_crypt = access_token.encrypt
+      token_crypt = encrypt_token!(access_token)
       @renderer.status = 302
       redirect_url = "/mulukhiya/app/token_complete?token=#{Rack::Utils.escape(token_crypt)}"
       response['Location'] = redirect_url

--- a/app/lib/mulukhiya/never_silent.rb
+++ b/app/lib/mulukhiya/never_silent.rb
@@ -1,0 +1,26 @@
+module Mulukhiya
+  # ステータスに依らず**必ず Sentry へ上げる**印 (#4693)。
+  #
+  # ⚠⚠ **`report_error` はステータスだけで判断する。**`client_error?` が真なら
+  # `log` 止めなので、**「403 だがこちらの設定が壊れている」型が丸ごと無音になる**。
+  # #4654 の一本化で `Ginseng::CryptError`（403）が Sentry から消えたのがこれ。
+  #
+  # ⚠ **`report_error` の側で例外クラスを列挙しない。**列挙は #4603 / #4629 で
+  # 実際に取りこぼした形（`NotFoundError` / `AuthError` が `else` へ落ちた）。
+  # **「これはクライアント起因ではない」と知っているのは raise した場所だけ**なので、
+  # そこで印を付けて運ぶ。`WrappedGatewayError#never_silent?` と同じ軸。
+  #
+  #   raise NeverSilent.mark(Ginseng::AuthError.new('...'))
+  #
+  # ⚠ インスタンスに `extend` するので、**新しい例外クラスを増やさない**。
+  # 上流の型（`Ginseng::AuthError` など）をそのまま使え、`status` も変わらない。
+  module NeverSilent
+    def never_silent?
+      return true
+    end
+
+    def self.mark(error)
+      return error.extend(self)
+    end
+  end
+end

--- a/app/lib/mulukhiya/test_case.rb
+++ b/app/lib/mulukhiya/test_case.rb
@@ -63,6 +63,18 @@ module Mulukhiya
     # ⚠ **「実走の前に手で UNLINK する」を手順書に書くだけでは弱い (#4583)。**
     # タグ辞書は Redis に残り、テストの結果が「前に一度回したか」で変わっていた。
     # 人間が手順を踏み忘れても効くよう、スイートのロードに織り込む。
+    # `report_error` のデッドマン（#4693）の窓を開け直す。
+    #
+    # ⚠⚠ **抑止は型ごとに Redis へ残る。**同じ型を扱うテストが 2 本以上あると、
+    # **後のテストが「抑止されている」状態から始まって順序依存になる**。
+    # 「実際に alert すること」を見るテストは、必ずこれを通してから測る。
+    def clear_alert_throttle(*classes)
+      redis = Redis.new
+      classes.each {|klass| redis.unlink("#{Controller::ALERT_THROTTLE_KEY_PREFIX}/#{klass}")}
+    rescue Ginseng::Redis::Error
+      nil
+    end
+
     def self.invalidate_shared_caches
       TaggingDictionary.invalidate_cache
     rescue => e

--- a/app/lib/mulukhiya/test_case.rb
+++ b/app/lib/mulukhiya/test_case.rb
@@ -68,9 +68,14 @@ module Mulukhiya
     # ⚠⚠ **抑止は型ごとに Redis へ残る。**同じ型を扱うテストが 2 本以上あると、
     # **後のテストが「抑止されている」状態から始まって順序依存になる**。
     # 「実際に alert すること」を見るテストは、必ずこれを通してから測る。
+    # ⚠ キーは `<prefix>/<型>/<発生源>` (#4693・PR #4712 の Codex P2)。
+    # テストからは発生源を特定しにくいので、接頭辞で総なめする。
     def clear_alert_throttle(*classes)
       redis = Redis.new
-      classes.each {|klass| redis.unlink("#{Controller::ALERT_THROTTLE_KEY_PREFIX}/#{klass}")}
+      classes.each do |klass|
+        prefix = "#{Controller::ALERT_THROTTLE_KEY_PREFIX}/#{klass}"
+        redis.keys("#{prefix}*").each {|key| redis.unlink(key)}
+      end
     rescue Ginseng::Redis::Error
       nil
     end

--- a/test/unit/controller/client_error_alert.rb
+++ b/test/unit/controller/client_error_alert.rb
@@ -14,8 +14,8 @@ module Mulukhiya
         @calls = []
       end
 
-      def alert = @calls << :alert
-      def log = @calls << :log
+      def alert(*) = @calls << :alert
+      def log(*) = @calls << :log
     end
 
     # ⚠ status を持たない素の例外（NoMethodError 等）はモロヘイヤ自身のバグ。
@@ -23,12 +23,13 @@ module Mulukhiya
       attr_reader :calls
 
       def initialize = @calls = []
-      def alert = @calls << :alert
-      def log = @calls << :log
+      def alert(*) = @calls << :alert
+      def log(*) = @calls << :log
     end
 
     def setup
       @controller = MisskeyController.new!
+      clear_alert_throttle(ErrorDouble, StatuslessDouble)
     end
 
     def test_client_errors_are_logged_not_alerted
@@ -40,8 +41,13 @@ module Mulukhiya
       end
     end
 
+    # ⚠ **同じ型を続けて投げると 2 本目以降は抑止される (#4693)。**サーバー側の
+    # 失敗は「連続失敗の 1 回目だけ鳴らす」デッドマンに乗ったので、**窓を毎回
+    # 開け直してから**「1 回目は鳴る」を見る。抑止そのものは
+    # `ReportErrorGapsTest` が正面から確かめている。
     def test_server_errors_are_alerted
       [500, 502, 503].each do |status|
+        clear_alert_throttle(ErrorDouble)
         error = ErrorDouble.new(status)
         @controller.report_error(error)
 
@@ -51,6 +57,7 @@ module Mulukhiya
 
     # ⚠ 黙らせてよいのはステータスで「クライアント起因」と言えるものだけ。
     def test_statusless_error_is_alerted
+      clear_alert_throttle(StatuslessDouble)
       error = StatuslessDouble.new
       @controller.report_error(error)
 
@@ -82,12 +89,14 @@ module Mulukhiya
     end
 
     # ⚠ 上がってきた例外は `status` を持たないので、`report_error` は alert 側へ倒す。
+    # ⚠ 抑止の窓を開け直してから測る（#4693）。
     def test_lookup_failure_is_alerted
       error = LookupError.new('connection refused')
       calls = []
-      error.define_singleton_method(:alert) {calls << :alert}
-      error.define_singleton_method(:log) {calls << :log}
+      error.define_singleton_method(:alert) {|*| calls << :alert}
+      error.define_singleton_method(:log) {|*| calls << :log}
 
+      clear_alert_throttle(LookupError)
       MisskeyController.new!.report_error(error)
 
       assert_equal([:alert], calls)
@@ -140,6 +149,7 @@ module Mulukhiya
 
     # モロヘイヤ自身のバグは黙らせない。
     def test_server_error_is_alerted
+      clear_alert_throttle(Ginseng::GatewayError)
       error = spy(Ginseng::GatewayError.new('Bad response 502'))
       handle(error)
 
@@ -155,8 +165,8 @@ module Mulukhiya
     def spy(error)
       calls = []
       error.define_singleton_method(:mulukhiya_calls) {calls}
-      error.define_singleton_method(:alert) {calls << :alert}
-      error.define_singleton_method(:log) {calls << :log}
+      error.define_singleton_method(:alert) {|*| calls << :alert}
+      error.define_singleton_method(:log) {|*| calls << :log}
       return error
     end
   end

--- a/test/unit/controller/report_error_consolidation.rb
+++ b/test/unit/controller/report_error_consolidation.rb
@@ -51,7 +51,9 @@ module Mulukhiya
     end
 
     # モロヘイヤ自身のバグは黙らせない。
+    # ⚠ 抑止の窓を開け直してから測る（#4693 のデッドマン）。
     def test_server_error_reaching_top_level_is_alerted
+      clear_alert_throttle(Ginseng::GatewayError)
       error = probe(Ginseng::GatewayError.new('Bad response 502'))
 
       assert_equal([:alert], error.mulukhiya_calls)
@@ -68,8 +70,8 @@ module Mulukhiya
     def spy(error)
       calls = []
       error.define_singleton_method(:mulukhiya_calls) {calls}
-      error.define_singleton_method(:alert) {calls << :alert}
-      error.define_singleton_method(:log) {calls << :log}
+      error.define_singleton_method(:alert) {|*| calls << :alert}
+      error.define_singleton_method(:log) {|*| calls << :log}
       return error
     end
   end

--- a/test/unit/controller/report_error_gaps.rb
+++ b/test/unit/controller/report_error_gaps.rb
@@ -1,0 +1,93 @@
+module Mulukhiya
+  # `report_error` の過不足を塞いだこと (#4693)。
+  #
+  # ⚠⚠ **#4654 の一本化でステータスだけの判断になった。**その結果、
+  # **ステータスと重大さがずれる 3 系統**でおかしくなっていた。
+  class ReportErrorGapsTest < TestCase
+    THROTTLED_CLASSES = [
+      RuntimeError, ArgumentError, Ginseng::CryptError, Ginseng::AuthError
+    ].freeze
+
+    def setup
+      @controller = APIController.new!
+      clear_alert_throttle(*THROTTLED_CLASSES)
+    end
+
+    def teardown
+      clear_alert_throttle(*THROTTLED_CLASSES)
+    end
+
+    # 🔴 **① 印が付いていればステータスに依らず必ず鳴らす。**
+    # ⚠ `Ginseng::CryptError#status` は 403 なので、素だと `log` 止めになる。
+    def test_never_silent_marker_beats_the_status
+      error = NeverSilent.mark(Ginseng::CryptError.new('crypt broken'))
+
+      assert_equal(:alert, report(error))
+    end
+
+    # ⚠ 印が無ければ従来どおり。403 は log 止め。
+    def test_unmarked_client_error_stays_logged
+      assert_equal(:log, report(Ginseng::CryptError.new('crypt broken')))
+    end
+
+    # 🔴 **② `token_mismatch` は必ず鳴る。**セキュリティ不変条件の破れ。
+    def test_token_mismatch_is_never_silent
+      error = NeverSilent.mark(Ginseng::AuthError.new('Token integrity check failed'))
+
+      assert_equal(:alert, report(error))
+    end
+
+    # ⚠ 素の `AuthError`（トークン期限切れ等）は従来どおり log 止め。
+    def test_plain_auth_error_stays_logged
+      assert_equal(:log, report(Ginseng::AuthError.new('Unauthorized')))
+    end
+
+    # 🔴 **③ サーバー側の失敗は 1 回目だけ鳴る。**
+    # ⚠⚠ **`before` は全リクエストで走る。**素通しだと DB 全断中にリクエスト
+    # 1 本ごとに Sentry ＋ slack / line / mail が飛ぶ。
+    def test_server_error_alerts_once_then_throttles
+      error = RuntimeError.new('db is down')
+
+      assert_equal(:alert, report(error), '1 回目が鳴っていない')
+      assert_equal(:log, report(error), '2 回目が抑えられていない')
+      assert_equal(:log, report(error))
+    end
+
+    # ⚠ 型ごとに独立して数える。連打を抑えている間に別の型（本物のバグ）が
+    # 出たら、そちらは 1 回目として鳴ってほしい。
+    def test_throttle_is_per_error_class
+      assert_equal(:alert, report(RuntimeError.new('db is down')))
+
+      assert_equal(:alert, report(ArgumentError.new('a real bug')), '別の型まで抑えている')
+    end
+
+    # ⚠ 印が付いていれば抑止も掛からない（必ず鳴らす、が優先）。
+    def test_marked_errors_are_not_throttled
+      error = NeverSilent.mark(Ginseng::CryptError.new('crypt broken'))
+
+      assert_equal(:alert, report(error))
+      assert_equal(:alert, report(error), '印が付いているのに抑えられている')
+    end
+
+    # ⚠⚠ **抑止できないなら鳴らす側へ倒さない。**ここへ来る主因が Redis 全断な
+    # ので、倒すとまさに避けたいスパムになる。Redis の死は `/health` が見る。
+    def test_falls_back_to_log_when_redis_is_unavailable
+      Redis.define_singleton_method(:new) {raise Ginseng::Redis::Error, 'refused'}
+
+      assert_equal(:log, report(RuntimeError.new('db is down')))
+    ensure
+      Redis.singleton_class.remove_method(:new)
+    end
+
+    private
+
+    # `log` / `alert` のどちらが呼ばれたかだけを見る。
+    def report(error)
+      called = nil
+      error.define_singleton_method(:log) {|*| called = :log}
+      error.define_singleton_method(:alert) {|*| called = :alert}
+      @controller.report_error(error)
+      return called
+    end
+  end
+end

--- a/test/unit/controller/report_error_gaps.rb
+++ b/test/unit/controller/report_error_gaps.rb
@@ -69,6 +69,31 @@ module Mulukhiya
       assert_equal(:alert, report(error), '印が付いているのに抑えられている')
     end
 
+    # 🔴 **抑止は発生源ごと（PR #4712 の Codex P2）。**
+    # ⚠⚠ `report_error` は `before` だけでなく**各コントローラの rescue から
+    # 呼ばれる**ので、型だけで括ると **`RuntimeError` のような広い型で、あるルートの
+    # 失敗が別ルートの本物のバグを 300 秒握り潰す。**
+    def test_throttle_is_scoped_to_the_origin
+      error = RuntimeError.new('boom')
+
+      assert_equal(:alert, report_from(error, 'POST /api/v?/status/tags'))
+      assert_equal(:log, report_from(error, 'POST /api/v?/status/tags'), '同じルートが抑えられていない')
+      assert_equal(:alert, report_from(error, 'GET /api/v?/about'), '別ルートまで抑えている')
+    ensure
+      clear_alert_throttle(RuntimeError)
+    end
+
+    # ⚠ ルートが決まる前（`before`）は 1 つのバケツ。**パスごとに分けると
+    # 分けた数だけ鳴る**＝抑えたい相手そのものを取り逃がす。
+    def test_before_failures_share_one_bucket
+      error = RuntimeError.new('db is down')
+
+      assert_equal(:alert, report_from(error, nil))
+      assert_equal(:log, report_from(error, nil))
+    ensure
+      clear_alert_throttle(RuntimeError)
+    end
+
     # ⚠⚠ **抑止できないなら鳴らす側へ倒さない。**ここへ来る主因が Redis 全断な
     # ので、倒すとまさに避けたいスパムになる。Redis の死は `/health` が見る。
     def test_falls_back_to_log_when_redis_is_unavailable
@@ -80,6 +105,16 @@ module Mulukhiya
     end
 
     private
+
+    # 発生源（`sinatra.route`）を指定して呼ぶ。
+    def report_from(error, route)
+      env = route ? {'sinatra.route' => route} : {}
+      @controller.define_singleton_method(:request) do
+        @probe_request ||= {}
+        @probe_request[route] ||= Struct.new(:env).new(env)
+      end
+      return report(error)
+    end
 
     # `log` / `alert` のどちらが呼ばれたかだけを見る。
     def report(error)


### PR DESCRIPTION
Closes #4693

#4654 が `report_error` を `client_error?(error) ? error.log : error.alert` に一本化した結果、
**ステータスだけで判断する**ようになり、ステータスと重大さがずれる 3 系統でおかしくなっていました。

## 🔴 ① CryptError（403）の全滅が無音 / ② token_mismatch（401）も同じ

`NeverSilent` マーカーを足し、`report_error` が**ステータスより先に**見るようにしました。

```ruby
def report_error(error)
  return error.alert if never_silent?(error)   # ①②
  return error.log if client_error?(error)
  return throttled_alert(error)                # ③
end
```

⚠ **例外クラスの列挙にしていません。**列挙は #4603（`NotFoundError`）/ #4629（`AuthError` と
`NotFoundError`）で**実際に取りこぼした形**です。**「これはクライアント起因ではない」と
知っているのは raise した場所だけ**なので、そこで印を付けて運びます
（`WrappedGatewayError#never_silent?` と同じ軸）。

⚠ **インスタンスに `extend` する**ので、新しい例外クラスを増やしません。上流の型
（`Ginseng::AuthError` など）をそのまま使え、`status` も変わりません。

| 印を付けた場所 | なぜ |
| --- | --- |
| `encrypt_token!`（auth 3 経路を通した） | ⚠⚠ `/crypt/password` の未設定・破損で**全ユーザーのトークン発行が 403 になるのに Sentry には何も出ない**（`Crypt.password` が `rescue nil` で nil に落ち、`PKCS5.pbkdf2_hmac(nil, ...)` が `CryptError` に包まれる）。**クライアントは何も悪くない** |
| `verify_token_integrity!` | ⚠⚠ **セキュリティ不変条件の破れ。**2025-10 のトークン汚染事故（`Gemfile` が rack / sinatra に上限を書いている理由）の再発検知がここに掛かっている |

## ③ 逆向き — `before` と読み系が障害中に連打する

`Controller#before` は**全リクエスト**（未認証・スキャナ由来を含む）で走り、失敗の主因は
Redis / Postgres 障害です。⚠⚠ 素通しだと **DB 全断中にリクエスト 1 本ごとに Sentry イベント
1 件＋ slack / line / mail** が飛び、**障害中に外向き HTTP を増やす二次被害**とレート制限になります。

`StartupNotificationWorker#notify_failure` の「連続失敗の 1 回目だけ」にそのまま乗せました。

- ⚠ **成功で解除する代わりに TTL（300 秒）で解除**します。`before` は毎リクエスト走るので、
  成功のたびに Redis を書くと平常時のコストが乗ります
- ⚠ **型ごとに独立**して数えます。連打を抑えている間に別の型（本物のバグ）が出たら、
  そちらは 1 回目として鳴ってほしいためです
- ⚠ **厳密な排他ではありません。**`Ginseng::Redis::Service#set` は `NX` を取らないので
  `key?` → `setex` の 2 段です。同時に来た数本が二重に鳴ることはありますが、抑えたいのは
  「全断中に毎リクエスト鳴る」ほうなので足ります
- ⚠⚠ **カウンタ自体が落ちたら log へ倒します。**ここへ来る主因が Redis 全断なので、
  鳴らす側へ倒すと**まさに避けたいスパムになります**。Redis の死は `/health` が見ます
  （`StartupNotificationWorker` と同じ判断）

## テスト（8 本・新規 `test/unit/controller/report_error_gaps.rb`）

⚠ **修正を外すと 5 本が実際に落ちる**ことを確認済みです:

```
Failure: test_falls_back_to_log_when_redis_is_unavailable
Failure: test_marked_errors_are_not_throttled
Failure: test_never_silent_marker_beats_the_status
Failure: test_server_error_alerts_once_then_throttles
Failure: test_token_mismatch_is_never_silent
```

印が無い 403 / 401 が**従来どおり log 止め**であることも押さえています。

## ⚠ 既存テストの更新（4 箇所）

抑止は型ごとに Redis へ残るので、**「実際に alert すること」を見るテストは窓を開け直して
から測る**必要があります。`TestCase#clear_alert_throttle` を足して通しました。
⚠ 放置すると**後のテストが「抑止されている」状態から始まって順序依存になります。**

⚠ spy の `log` / `alert` は引数を取れるようにしました（本物の `Ginseng::Error#log` は
kwargs を取るので、ダブルの側が狭すぎました）。

## 検証

- `bundle exec rake lint` → ✅ **514 files / no offenses**、脆弱性 0
- `bundle exec rake test` → ✅ **1325 tests / 1918 assertions / 0 failures / 0 errors**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExMqJf1tfD174UoMBGVJNk