### PR TITLE
fix: webhook 応答の穴 4 件を塞ぐ (#4694)

### DIFF
--- a/app/lib/mulukhiya/controller/webhook_controller.rb
+++ b/app/lib/mulukhiya/controller/webhook_controller.rb
@@ -143,10 +143,15 @@ module Mulukhiya
         next unless error.is_a?(Hash)
         attachment = error[:attachment] || error['attachment']
         next unless attachment.is_a?(Hash)
-        {
-          'url' => attachment['image_url'],
-          'message' => error[:message] || error['message'],
-        }
+        # ⚠ **`url` が nil になる回がある (#4694)。**`SlackWebhookPayload` は
+        # `blocks` の `type: image` を `image_url` の有無を見ずに images へ積むので、
+        # `image_url` を持たない image ブロックがここまで来る。
+        # `docs/api.md` は `url` を string と書いているので、**キーごと落とす**
+        # （null を返して契約を破らない）。
+        entry = {'message' => error[:message] || error['message']}
+        url = attachment['image_url']
+        entry['url'] = url if url.is_a?(String) && url.present?
+        entry
       end
     end
 

--- a/app/lib/mulukhiya/handler/webhook_image_handler.rb
+++ b/app/lib/mulukhiya/handler/webhook_image_handler.rb
@@ -6,6 +6,11 @@ module Mulukhiya
     # 運用側の切り分けは失われない。
     GENERIC_DROP_MESSAGE = 'attachment could not be processed'.freeze
 
+    # 殺したワーカーが `ensure` を走り終えるのを待つ上限 (秒) (#4694)。
+    # ⚠ 待たないと、**処理中だった添付を「落ちた」と報告した直後にワーカーが
+    # 成功で消す**（あるいはその逆の）競合が残る。
+    WORKER_KILL_WAIT = 1
+
     def disable?
       return true unless controller_class.webhook?
       return true unless sns.account&.webhook
@@ -37,9 +42,15 @@ module Mulukhiya
       queue = Queue.new
       (payload['attachments'] || []).each {|v| queue.push(v)}
       slots = create_slots(payload)
-      run_workers(queue, payload, slots)
+      # ⚠⚠ **取り出し済みで処理中の添付も控える（PR #4713 の Codex P1）。**
+      # `pop_attachment` はキューから**取り除いてから**アップロードに入るので、
+      # その最中に殺されると 🔴 **キューにも残らず `rescue` も通らない**
+      # （`Thread#kill` は `rescue => e` を通さない）。**添付 1 枚 = ワーカー 1 本**
+      # という最も普通の形でキューが空になり、`drain` だけでは何も残らなかった。
+      inflight = Concurrent::Array.new
+      run_workers(queue, payload, slots, inflight)
     ensure
-      drain(queue) if queue
+      drain(queue, inflight) if queue
     end
 
     private
@@ -53,18 +64,22 @@ module Mulukhiya
     # 2. **ワーカーの後始末**。`Parallel.each(in_threads:)` は `ensure` で
     #    `threads.each(&:kill)` していた。無いと、join が例外で打ち切られたときに
     #    走り続けたスレッドが**応答を組み立てた後**に `push` して孤児メディアを作る
-    def run_workers(queue, payload, slots)
+    def run_workers(queue, payload, slots, inflight)
       counter = Thread.current[HandlerProfile::HTTP_KEY]
       workers = [Parallel.processor_count, queue.size].min
       threads = Array.new(workers) do
         Thread.new do
           Thread.current[HandlerProfile::HTTP_KEY] = counter if counter
-          consume(queue, payload, slots)
+          consume(queue, payload, slots, inflight)
         end
       end
       threads.each(&:join)
     ensure
       threads&.each(&:kill)
+      # ⚠ **殺した後に待つ (#4694)。**待たないと、外側の `drain` が読む `inflight` が
+      # ワーカーの `ensure` と競合する。⚠ 待ちきれなくても先へ進む（ここは既に
+      # 劣化した経路なので、投稿経路ごと止めない）。
+      threads&.each {|thread| thread.join(WORKER_KILL_WAIT)}
     end
 
     # ⚠⚠ **枠を取ってから候補を取り出す。**逆順（取り出してから枠を取る）だと、
@@ -75,27 +90,41 @@ module Mulukhiya
     #
     # ⚠ 候補を「配る」形（`Parallel.each`）に戻さないこと。枠切れで skip した候補が
     # 二度と戻らず、空いた枠が使われないまま有効な添付が落ちる (#4633・Codex P2)。
-    def consume(queue, payload, slots)
+    def consume(queue, payload, slots, inflight)
       loop do
         break unless reserve_slot(slots)
         unless attachment = pop_attachment(queue)
           slots.increment
           break
         end
+        # ⚠ **取り出したら控える。**外した瞬間から `ensure` で外すまでの間に
+        # 殺されると、この添付はどこからも辿れなくなる（PR #4713 の Codex P1）。
+        inflight.push(attachment)
         unless uri = parse_image_uri(attachment)
           slots.increment
+          inflight.delete(attachment)
           next
         end
         upload_attachment(payload, uri, slots, attachment)
+        # ⚠⚠ **`ensure` で外さない。**`Thread#kill` でも `ensure` は走るので、
+        # **殺された添付まで「片付いた」ことにしてしまう**（それでは元の穴のまま）。
+        # ⚠ `upload_attachment` は自前の `rescue` で失敗を記録して**正常に返る**ので、
+        # ここへ来たら成否によらず「処理は終わった」と言える。
+        inflight.delete(attachment)
       end
     end
 
     # ⚠ **枠切れで残った候補も「落ちた」として残す (#4633)。**従来は完全に無音で、
     # 6 枚送って 4 枚しか付かなくても送信側にも運用者にも何も出なかった。
     # 取得失敗と上限超過だけ記録して枠切れを黙らせるのは、この Issue の趣旨に反する。
-    def drain(queue)
+    # ⚠ `inflight` は**取り出し済みで処理中だった**もの（PR #4713 の Codex P1）。
+    # 枠切れ（キューに残った）とは理由が違うので、別の `class` で残す。
+    def drain(queue, inflight = nil)
       while attachment = pop_attachment(queue)
         record_drop('SlotExhausted', 'max media attachments exceeded', attachment)
+      end
+      inflight&.each do |attachment|
+        record_drop('Timeout', 'handler timed out while uploading', attachment)
       end
     end
 

--- a/app/lib/mulukhiya/handler/webhook_image_handler.rb
+++ b/app/lib/mulukhiya/handler/webhook_image_handler.rb
@@ -2,6 +2,10 @@ module Mulukhiya
   class WebhookImageHandler < Handler
     include LogScrubber
 
+    # 内部例外を丸めて返すときの文言 (#4694)。⚠ **原文は syslog に残す**ので、
+    # 運用側の切り分けは失われない。
+    GENERIC_DROP_MESSAGE = 'attachment could not be processed'.freeze
+
     def disable?
       return true unless controller_class.webhook?
       return true unless sns.account&.webhook
@@ -16,6 +20,17 @@ module Mulukhiya
       return RemoteHost.validator
     end
 
+    # ⚠⚠ **`drain` は `ensure` に置く (#4694)。**#4657 の `thread.kill` は
+    # `run_workers` の `threads.each(&:join)` を途中で切るので、素直に後ろへ
+    # 書くと**タイムアウト経路でだけ実行されない**。`drain` は「枠切れ・未処理で
+    # 残った添付」を `record_drop` する**唯一の経路**なので、走らないと
+    # 🔴 **キューに残った添付が syslog にも応答にも 1 行も残らない。**
+    #
+    # ⚠ 5.35.0 までは殺されなかったので、応答には間に合わないものの syslog には
+    # 残っていた。**#4633 で塞いだ穴が、タイムアウト経路でだけ開き直していた。**
+    #
+    # ⚠ `Thread#kill` は殺されるスレッドの `ensure` を走らせる。この
+    # `handle_pre_webhook` 自身が殺される側なので、ここに置けば必ず通る。
     def handle_pre_webhook(payload, params = {})
       payload.deep_stringify_keys!
       payload[attachment_field] = Concurrent::Array.new(payload[attachment_field] || [])
@@ -23,7 +38,8 @@ module Mulukhiya
       (payload['attachments'] || []).each {|v| queue.push(v)}
       slots = create_slots(payload)
       run_workers(queue, payload, slots)
-      drain(queue)
+    ensure
+      drain(queue) if queue
     end
 
     private
@@ -102,7 +118,25 @@ module Mulukhiya
     # 自体は正しいが、上限超過 (`/media/download/max_bytes`) も取得失敗も
     # **200 と作成済み投稿 ID が返るだけ**で、送信側は成功と区別できなかった。
     def drop_attachment(error, attachment)
-      record_drop(error.class.to_s, error.message, attachment)
+      record_drop(error.class.to_s, client_message(error), attachment, detail: error.message)
+    end
+
+    # 送信側へ返してよいメッセージ (#4694)。
+    #
+    # ⚠⚠ **`upload_attachment` の rescue は全例外を拾う。**素通しすると
+    # `Errno::EACCES - /home/mulukhiya/.../tmp/media/xxxx.jpg`（**サーバー内の
+    # 絶対パス**）や `PG::ConnectionBad: connection to server at "127.0.0.1",
+    # port 6432 failed`（**内部ホスト・ポート**）がそのまま第三者へ返る。
+    # ⚠ webhook は第三者システムへ配るものなので、digest を持つ相手に限られる
+    # ことは緩和材料にならない。
+    #
+    # ⚠ **`InternalGatewayError#client_message` と同じ方針**（内部メソッド名と
+    # 上流ステータスを外へ出さない）。あちらと非対称なままにしない。
+    # ⚠ **原文は syslog には残す。**外に出さないことと、こちらが見られなくなる
+    # ことは別（`record_drop` の `detail:`）。
+    def client_message(error)
+      return error.message if error.is_a?(Ginseng::Error)
+      return GENERIC_DROP_MESSAGE
     end
 
     # ⚠⚠ **添付を丸ごと出さない (#4630)。**Slack legacy attachments の
@@ -112,9 +146,16 @@ module Mulukhiya
     # 値しか伏せないので、`image_url` 全体も本文も素通しする。
     # ⚠ `errors` 側も同じものを通す。`Reporter` が `summary` 経由で `logger.info`
     # へ流すため、片方だけ伏せても意味がない。
-    def record_drop(reason, message, attachment)
+    # ⚠ `detail:` は **syslog にだけ**出す原文 (#4694)。送信側へ返すのは
+    # `message`（丸めた側）。
+    def record_drop(reason, message, attachment, detail: nil)
       scrubbed = scrub_log_params(attachment)
-      logger.error(error: 'webhook attachment dropped', reason:, attachment: scrubbed)
+      logger.error(
+        error: 'webhook attachment dropped',
+        reason:,
+        message: detail || message,
+        attachment: scrubbed,
+      )
       errors.push(class: reason, message:, attachment: scrubbed)
     end
 

--- a/app/lib/mulukhiya/handler/webhook_image_handler.rb
+++ b/app/lib/mulukhiya/handler/webhook_image_handler.rb
@@ -47,7 +47,12 @@ module Mulukhiya
       # その最中に殺されると 🔴 **キューにも残らず `rescue` も通らない**
       # （`Thread#kill` は `rescue => e` を通さない）。**添付 1 枚 = ワーカー 1 本**
       # という最も普通の形でキューが空になり、`drain` だけでは何も残らなかった。
-      inflight = Concurrent::Array.new
+      # ⚠⚠ **`Concurrent::Array` ではなく Hash（PR #4713 の Codex P1）。**
+      # `Array#delete` は**値の等価**で消すので、**同じ内容の添付が 2 枚あると、
+      # 先に終わったワーカーがまだ走っている別ワーカーの分まで消す**。
+      # そのワーカーが締切で殺されると、キューにも `inflight` にも残らず
+      # **また無音で落ちる**。**同一性**で 1 件ずつ独立に扱う。
+      inflight = Concurrent::Hash.new.tap(&:compare_by_identity)
       run_workers(queue, payload, slots, inflight)
     ensure
       drain(queue, inflight) if queue
@@ -99,7 +104,7 @@ module Mulukhiya
         end
         # ⚠ **取り出したら控える。**外した瞬間から `ensure` で外すまでの間に
         # 殺されると、この添付はどこからも辿れなくなる（PR #4713 の Codex P1）。
-        inflight.push(attachment)
+        inflight[attachment] = attachment
         unless uri = parse_image_uri(attachment)
           slots.increment
           inflight.delete(attachment)
@@ -123,7 +128,7 @@ module Mulukhiya
       while attachment = pop_attachment(queue)
         record_drop('SlotExhausted', 'max media attachments exceeded', attachment)
       end
-      inflight&.each do |attachment|
+      inflight&.each_value do |attachment|
         record_drop('Timeout', 'handler timed out while uploading', attachment)
       end
     end

--- a/docs/api.md
+++ b/docs/api.md
@@ -1579,12 +1579,22 @@ Slack 互換のペイロードを投稿に変換する。`text` / `blocks` / `at
 
 | キー | 型 | 説明 |
 |------|-----|------|
-| `mulukhiya.attachment_errors[].url` | string | 落ちた添付の `image_url`（送信側が送った URL そのまま） |
-| `mulukhiya.attachment_errors[].message` | string | 落ちた理由。⚠ **人間向けの文言で、機械判定用の安定した識別子ではない** |
+| `mulukhiya.attachment_errors[].url` | string | 落ちた添付の `image_url`（送信側が送った URL そのまま）。⚠ **`image_url` を持たない添付では、このキーごと付かない**（5.37.0 / #4694。それ以前は `null` が入りうる） |
+| `mulukhiya.attachment_errors[].message` | string | 落ちた理由。⚠ **人間向けの文言で、機械判定用の安定した識別子ではない**。⚠⚠ **5.37.0 (#4694) から、モロヘイヤ内部の例外は `attachment could not be processed` に丸める**（サーバー内の絶対パスや内部ホスト・ポートが混ざっていた）。原文は syslog にだけ残る |
 | `mulukhiya.missing_attachments` | integer | **上流へ渡したのに、返ってきた投稿に載っていない添付の本数**。下記 |
 
 ⚠ **どちらのキーも、該当が無ければ付かない。**`mulukhiya` キー自体も同様なので、
 `response["mulukhiya"]` の有無だけで「全部通った / 何かおかしい」を判定できる。
+
+⚠⚠ **ただし「`mulukhiya` があれば投稿が成立している」とは読まないこと (#4694)。**
+`mulukhiya` は**上流の応答が Hash でありさえすれば足される**ので、上流が
+`{"error": "Validation failed: ..."}` を返した回（422 等）にもエラー本文と同居する。
+**投稿の成否は HTTP ステータスで見ること。**
+
+⚠ **5.36.0 以前には、ハンドラのタイムアウトで落ちた添付が `attachment_errors` にも
+syslog にも残らない穴があった**（#4694 の 1・5.37.0 で是正）。⚠⚠ **その回は
+`mulukhiya` キー自体が付かないので、送信側は「全部通った」と読む。**
+5.36.0 以前を相手にするクライアントは、この経路があることを前提にすること。
 
 🔴 **`missing_attachments` は主に `Idempotency-Key` の再送で出る。**添付の取得に
 失敗した投稿を、送信側が**同じ `Idempotency-Key`** で送り直すと、

--- a/test/unit/controller/webhook_attachment_errors.rb
+++ b/test/unit/controller/webhook_attachment_errors.rb
@@ -96,7 +96,9 @@ module Mulukhiya
 
       entry = body(reporter).dig('mulukhiya', 'attachment_errors').first
 
-      assert_equal(['url', 'message'], entry.keys)
+      # ⚠ **順序は `message` → `url`（#4694）。**`url` は「あるときだけ足す」形に
+      # なったので後ろに来る。`image_url` を持たない添付では**キーごと付かない**。
+      assert_equal(['message', 'url'], entry.keys)
     end
 
     # ⚠⚠ **`Idempotency-Key` の再送（PR #4684 の Codex P1）。**上流は初回の

--- a/test/unit/handler/webhook_attachment_slots.rb
+++ b/test/unit/handler/webhook_attachment_slots.rb
@@ -160,7 +160,9 @@ module Mulukhiya
         return uri.to_s
       end
 
-      def record_drop(reason, _message, attachment)
+      # ⚠ `detail:` は syslog 専用の原文 (#4694)。ここでは使わないが、
+      # 本体と同じ signature にしておかないと呼び出しで落ちる。
+      def record_drop(reason, _message, attachment, detail: nil)
         @dropped.push(reason:, attachment: scrub_log_params(attachment))
       end
     end

--- a/test/unit/handler/webhook_attachment_slots.rb
+++ b/test/unit/handler/webhook_attachment_slots.rb
@@ -104,8 +104,13 @@ module Mulukhiya
       queue = Queue.new
       6.times {|i| queue.push({'image_url' => "https://example.com/#{i}.png"})}
 
-      handler.send(:run_workers, queue, payload, Concurrent::AtomicFixnum.new(4))
-      handler.send(:drain, queue)
+      # ⚠ 第 4 引数は処理中の添付を控える置き場 (#4694)。ここは正常完了する
+      # ケースなので、走り終えた時点で空になっている。
+      inflight = Concurrent::Array.new
+      handler.send(:run_workers, queue, payload, Concurrent::AtomicFixnum.new(4), inflight)
+      handler.send(:drain, queue, inflight)
+
+      assert_empty(inflight, '正常完了なのに処理中の控えが残っている')
 
       assert_equal(4, payload['media'].count)
       assert_equal(2, handler.dropped.count)
@@ -182,7 +187,10 @@ module Mulukhiya
     # 「全ワーカーが枠を持っている間に skip が起きる」条件を作れない。
     def drive(handler, queue, payload, slots)
       atomic = Concurrent::AtomicFixnum.new(slots)
-      run_concurrently(WORKERS) {handler.send(:consume, queue, payload, atomic)}
+      # ⚠ 第 4 引数は処理中の添付を控える置き場 (#4694)。ここでは枠の勘定だけを
+      # 見るので中身は使わないが、スレッド安全な実体を渡す必要がある。
+      inflight = Concurrent::Array.new
+      run_concurrently(WORKERS) {handler.send(:consume, queue, payload, atomic, inflight)}
     end
 
     # 本体と同じ実装を呼ぶ (private なので send)。

--- a/test/unit/handler/webhook_attachment_slots.rb
+++ b/test/unit/handler/webhook_attachment_slots.rb
@@ -106,7 +106,7 @@ module Mulukhiya
 
       # ⚠ 第 4 引数は処理中の添付を控える置き場 (#4694)。ここは正常完了する
       # ケースなので、走り終えた時点で空になっている。
-      inflight = Concurrent::Array.new
+      inflight = Concurrent::Hash.new.tap(&:compare_by_identity)
       handler.send(:run_workers, queue, payload, Concurrent::AtomicFixnum.new(4), inflight)
       handler.send(:drain, queue, inflight)
 
@@ -189,7 +189,7 @@ module Mulukhiya
       atomic = Concurrent::AtomicFixnum.new(slots)
       # ⚠ 第 4 引数は処理中の添付を控える置き場 (#4694)。ここでは枠の勘定だけを
       # 見るので中身は使わないが、スレッド安全な実体を渡す必要がある。
-      inflight = Concurrent::Array.new
+      inflight = Concurrent::Hash.new.tap(&:compare_by_identity)
       run_concurrently(WORKERS) {handler.send(:consume, queue, payload, atomic, inflight)}
     end
 

--- a/test/unit/handler/webhook_response_gaps.rb
+++ b/test/unit/handler/webhook_response_gaps.rb
@@ -66,6 +66,32 @@ module Mulukhiya
       assert_equal('Timeout', @handler.errors.first[:class])
     end
 
+    # 🔴 **①-c 同じ内容の添付が 2 枚あっても取りこぼさない（PR #4713 の Codex P1）。**
+    #
+    # ⚠⚠ `Concurrent::Array#delete` は**値の等価**で消すので、**先に終わった
+    # ワーカーがまだ走っている別ワーカーの分まで消して**しまう。そのワーカーが
+    # 締切で殺されると、キューにも控えにも残らず**また無音で落ちる**。
+    def test_duplicate_attachments_are_tracked_independently
+      attachment = {'image_url' => 'https://example.com/same.png'}
+      # ⚠ **両方が控えに載ってから、片方だけが先に終わる**形を作る。
+      # 素直に「1 枚目は即終わり」にすると、**2 枚目が控えに載る前に 1 枚目が
+      # 終わってしまい競合が起きない**（実際に false negative を踏んだ）。
+      calls = Concurrent::AtomicFixnum.new(0)
+      @handler.define_singleton_method(:create_slots) {|*| Concurrent::AtomicFixnum.new(4)}
+      @handler.define_singleton_method(:upload_attachment) do |*|
+        sleep(calls.increment == 1 ? 0.3 : 10)
+      end
+      payload = {'attachments' => [attachment.dup, attachment.dup]}
+
+      thread = Thread.new {@handler.handle_pre_webhook(payload)}
+      sleep(1.0)
+      thread.kill
+      thread.join(5)
+
+      assert_equal(1, @handler.errors.length, '重複した添付が取りこぼされている')
+      assert_equal('Timeout', @handler.errors.first[:class])
+    end
+
     # 🔴 **② 内部例外の生メッセージを送信側へ返さない。**
     # ⚠⚠ 素通しすると **サーバー内の絶対パス**や**内部ホスト・ポート**が第三者へ返る。
     def test_internal_exception_message_is_not_leaked

--- a/test/unit/handler/webhook_response_gaps.rb
+++ b/test/unit/handler/webhook_response_gaps.rb
@@ -43,6 +43,29 @@ module Mulukhiya
       assert(@handler.errors.all? {|e| e[:class] == 'SlotExhausted'})
     end
 
+    # 🔴 **①-b 取り出し済みで処理中だった添付も残る（PR #4713 の Codex P1）。**
+    #
+    # ⚠⚠ `pop_attachment` はキューから**取り除いてから**アップロードに入るので、
+    # その最中に殺されると **キューにも残らず `rescue` も通らない**
+    # （`Thread#kill` は `rescue => e` を通さない）。⚠ **添付 1 枚 = ワーカー 1 本**
+    # という最も普通の形でキューが空になり、`drain` だけでは何も残らなかった。
+    def test_inflight_attachments_are_recorded_when_killed
+      # アップロードで固まるワーカーを作る。⚠ `parse_image_uri` は通す。
+      # ⚠ setup の `create_slots` は 0 枠なので、ここだけ枠を開ける
+      # （0 枠だとキューから取り出されず `SlotExhausted` の側になる）。
+      @handler.define_singleton_method(:create_slots) {|*| Concurrent::AtomicFixnum.new(4)}
+      @handler.define_singleton_method(:upload_attachment) {|*| sleep(10)}
+      payload = {'attachments' => [{'image_url' => 'https://example.com/a.png'}]}
+
+      thread = Thread.new {@handler.handle_pre_webhook(payload)}
+      sleep(0.3)
+      thread.kill
+      thread.join(5)
+
+      assert_equal(1, @handler.errors.length, '処理中だった添付が残っていない')
+      assert_equal('Timeout', @handler.errors.first[:class])
+    end
+
     # 🔴 **② 内部例外の生メッセージを送信側へ返さない。**
     # ⚠⚠ 素通しすると **サーバー内の絶対パス**や**内部ホスト・ポート**が第三者へ返る。
     def test_internal_exception_message_is_not_leaked

--- a/test/unit/handler/webhook_response_gaps.rb
+++ b/test/unit/handler/webhook_response_gaps.rb
@@ -1,0 +1,101 @@
+module Mulukhiya
+  # webhook 応答の穴 4 件 (#4694)。
+  #
+  # ⚠⚠ **#4657 の `thread.kill` は `handle_pre_webhook` を途中で切る。**素直に
+  # `run_workers` の後ろへ `drain` を書くと、**タイムアウト経路でだけ実行されない**。
+  # `drain` は「枠切れ・未処理で残った添付」を `record_drop` する**唯一の経路**なので、
+  # 🔴 走らないとキューに残った添付が syslog にも応答にも 1 行も残らない。
+  class WebhookResponseGapsTest < TestCase
+    # ⚠ `WebhookImageHandler.new` は `Ginseng::Fediverse::Service` を作るので
+    # **DB 接続が要る**（`Environment.account_class` が Sequel モデル）。
+    # ここで見たいのは `drain` の走行と文言の丸めだけなので `allocate` で作り、
+    # 必要な内部状態だけ与える。
+    def setup
+      @handler = WebhookImageHandler.allocate
+      # ⚠ `TestCase#teardown` が `@handler.clear` を呼ぶので、そこが触る
+      # ivar は揃えておく（allocate では initialize が走らない）。
+      @handler.instance_variable_set(:@errors, Concurrent::Array.new)
+      @handler.instance_variable_set(:@result, Concurrent::Array.new)
+      @handler.instance_variable_set(:@reporter, Reporter.new)
+      @handler.instance_variable_set(:@break, false)
+      @handler.define_singleton_method(:attachment_field) {'media_ids'}
+      @handler.define_singleton_method(:create_slots) {|*| Concurrent::AtomicFixnum.new(0)}
+    end
+
+    # 🔴 **① スレッドを殺されても `drain` が走る。**
+    # ⚠ `Thread#kill` は殺されるスレッドの `ensure` を走らせるので、
+    # `handle_pre_webhook` 自身の `ensure` に置けば必ず通る。
+    def test_drain_runs_even_when_the_thread_is_killed
+      # `run_workers` が返らないまま殺される状況を作る。⚠ 実際のタイムアウトは
+      # `Event#run_handler` の `thread.kill` なので、形は同じ。
+      @handler.define_singleton_method(:run_workers) {|*| sleep(10)}
+      payload = {'attachments' => [
+        {'image_url' => 'https://example.com/a.png'},
+        {'image_url' => 'https://example.com/b.png'},
+      ]}
+
+      thread = Thread.new {@handler.handle_pre_webhook(payload)}
+      sleep(0.1)
+      thread.kill
+      thread.join(3)
+
+      assert_equal(2, @handler.errors.length, '殺された後に drain が走っていない')
+      assert(@handler.errors.all? {|e| e[:class] == 'SlotExhausted'})
+    end
+
+    # 🔴 **② 内部例外の生メッセージを送信側へ返さない。**
+    # ⚠⚠ 素通しすると **サーバー内の絶対パス**や**内部ホスト・ポート**が第三者へ返る。
+    def test_internal_exception_message_is_not_leaked
+      error = Errno::EACCES.new('/home/mulukhiya/repos/x/tmp/media/secret.jpg')
+
+      assert_equal(
+        WebhookImageHandler::GENERIC_DROP_MESSAGE,
+        @handler.send(:client_message, error),
+      )
+    end
+
+    # ⚠ `Ginseng::Error` 系は送信側が対処できる情報なので通す
+    # （上限超過・取得失敗の理由）。
+    def test_ginseng_error_message_is_passed_through
+      error = Ginseng::TooLargeError.new('too large')
+
+      assert_equal('too large', @handler.send(:client_message, error))
+    end
+
+    # ⚠⚠ **原文は syslog に残す。**外に出さないことと、こちらが見られなくなる
+    # ことは別。
+    def test_original_message_still_reaches_syslog
+      logged = []
+      double = Object.new
+      double.define_singleton_method(:error) {|payload| logged.push(payload)}
+      double.define_singleton_method(:info) {|*| nil}
+      @handler.define_singleton_method(:logger) {double}
+
+      @handler.send(:drop_attachment, Errno::EACCES.new('/home/secret/path.jpg'), {})
+
+      assert_match(%r{/home/secret/path\.jpg}, logged.first[:message].to_s)
+      assert_equal(WebhookImageHandler::GENERIC_DROP_MESSAGE, @handler.errors.first[:message])
+    end
+
+    # 🔴 **③ `url` が nil にならない。**`docs/api.md` は string と書いている。
+    def test_url_key_is_omitted_when_absent
+      entries = attachment_errors([
+        {attachment: {'image_url' => 'https://example.com/a.png'}, message: 'x'},
+        {attachment: {'text' => 'no image_url here'}, message: 'y'},
+      ])
+
+      assert_equal('https://example.com/a.png', entries[0]['url'])
+      refute(entries[1].key?('url'), 'url が null で載っている')
+      assert_equal('y', entries[1]['message'])
+    end
+
+    private
+
+    def attachment_errors(errors)
+      reporter = Reporter.new
+      errors.each {|e| reporter.errors.push(e)}
+      controller = WebhookController.allocate
+      return controller.send(:attachment_errors, reporter)
+    end
+  end
+end


### PR DESCRIPTION
Closes #4694

## 🔴 1. タイムアウト経路で、落ちた添付が応答にも syslog にも残らない

#4657 の `thread.kill` は `run_workers` の `threads.each(&:join)` を途中で切ります。
そのため `drain(queue)` を素直に後ろへ書くと ⚠⚠ **タイムアウト経路でだけ実行されません。**

`drain` は「枠切れ・未処理で残った添付」を `record_drop` する**唯一の経路**なので、
走らないと 🔴 **キューに残った添付が syslog にも `handler.errors` にも 1 行も残りません。**
さらに `reporter.temp[:attachment_count]` は kill 後に取るので `sent == returned` となり
`missing_attachments` も 0 ＝ **`mulukhiya` キー自体が付かず、送信側は「全部通った」と読みます。**

⚠ **5.35.0 までは殺されなかった**ので、応答には間に合わないものの syslog には残っていました。
**#4633 で塞いだ観測性の穴が、タイムアウト経路でだけ開き直していた**形です。

`handle_pre_webhook` 自身の `ensure` へ移しました。⚠ `Thread#kill` は**殺されるスレッドの
`ensure` を走らせる**ので、この位置なら必ず通ります。

## 2. `attachment_errors[].message` が内部例外の生メッセージを返していた

`upload_attachment` の rescue は `rescue => e` で**全例外**を拾うので、こういうものが
そのまま第三者システムへ返りえました:

- `Errno::EACCES - /home/mulukhiya/.../tmp/media/xxxx.jpg`（**サーバー内の絶対パス**）
- `PG::ConnectionBad: connection to server at "127.0.0.1", port 6432 failed`（**内部ホスト・ポート**）

`Ginseng::Error` 系だけ `message` を通し、それ以外は `attachment could not be processed` に
丸めました。⚠ **`InternalGatewayError#client_message` と同じ方針**（内部メソッド名と上流
ステータスを外へ出さない）で、非対称を解消しています。

⚠ **原文は syslog には残します**（`record_drop` の `detail:`）。**外に出さないことと、
こちらが見られなくなることは別**なので、運用側の切り分けは失われません。

## 3. `attachment_errors[].url` が `null` になりうる

`SlackWebhookPayload` は `blocks` の `type: image` を `image_url` の有無を見ずに images へ
積むので、`image_url` を持たない image ブロックで nil が載っていました。`docs/api.md` は
`url` を string と書いているので、**キーごと落とす**形にしました（null を返して契約を破らない）。

## 4. 上流が 4xx / 5xx を返した回にも `mulukhiya` キーが付く

Issue のとおり `docs/api.md` に注記で対応しました。

> ⚠⚠ **「`mulukhiya` があれば投稿が成立している」とは読まないこと。**
> **投稿の成否は HTTP ステータスで見ること。**

あわせて **5.36.0 以前のタイムアウト経路の穴**も、5.36.0 以前を相手にするクライアント向けに
明記しています。

## テスト（5 本・新規 `test/unit/handler/webhook_response_gaps.rb`）

⚠ **修正を外すと 5 本とも落ちる**ことを確認済みです:

```
Failure: test_drain_runs_even_when_the_thread_is_killed
Error:   test_ginseng_error_message_is_passed_through (client_message が無い)
Error:   test_internal_exception_message_is_not_leaked (GENERIC_DROP_MESSAGE が無い)
Failure: test_original_message_still_reaches_syslog
Failure: test_url_key_is_omitted_when_absent
```

⚠ 1 のテストは `run_workers` を返らないように差し替えてから `Thread#kill` します
（実際のタイムアウトは `Event#run_handler` の `thread.kill` なので、形は同じ）。
⚠ `WebhookImageHandler.new` は `Ginseng::Fediverse::Service` を作るので **DB 接続が要ります**。
`allocate` で作り、`TestCase#teardown` の `clear` が触る ivar だけ与えています。

## ⚠ 既存テストの更新（2 箇所）

- `record_drop` に `detail:` が増えたので、`WebhookAttachmentSlotsTest` のダブルを追随
- `attachment_errors` のキー順が `message` → `url` になった（`url` は「あるときだけ足す」形に
  なったので後ろ）。`WebhookAttachmentErrorsTest#test_only_url_and_message_are_returned` を更新

## 検証

- `bundle exec rake lint` → ✅ **513 files / no offenses**、脆弱性 0
- `bundle exec rake test` → ✅ **1322 tests / 1915 assertions / 0 failures / 0 errors**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExMqJf1tfD174UoMBGVJNk