### PR TITLE
security: Spotify OAuth に state(CSRF) を追加する (#4414)

### DIFF
--- a/app/lib/mulukhiya/contract/spotify_auth_contract.rb
+++ b/app/lib/mulukhiya/contract/spotify_auth_contract.rb
@@ -2,8 +2,12 @@ module Mulukhiya
   class SpotifyAuthContract < Contract
     params do
       # ユーザー特定は APIController の bearer 認証 (sns.account) で行うため、
-      # body への token 重複は要求しない。検証するのは認可 code のみ。
+      # body への token 重複は要求しない。
       required(:code).value(:string)
+      # ⚠⚠ **`state` は必須 (#4414)。**認可レスポンスの取り違え・横取り（CSRF）への
+      # 対策。⚠ `GET /spotify/oauth_uri` が返した URI の `state` をそのまま戻す。
+      # ⚠ **capsicum 側の code 捕捉フローに往復の追加が要る**（pooza/capsicum#570）。
+      required(:state).value(:string)
     end
   end
 end

--- a/app/lib/mulukhiya/controller/api_controller.rb
+++ b/app/lib/mulukhiya/controller/api_controller.rb
@@ -585,7 +585,15 @@ module Mulukhiya
 
     get '/spotify/oauth_uri' do
       raise Ginseng::NotFoundError, 'Not Found' unless SpotifyUserService.config?
-      @renderer.message = {oauth_uri: SpotifyUserService.new.oauth_uri.to_s}
+      # ⚠⚠ **認証が要る（PR #4714 の Codex P1）。**発行する `state` を**呼んだ本人の
+      # アカウントに縛る**ため。縛らないと、攻撃者が自分の Spotify を認可して得た
+      # code/state の組を被害者の callback へ流し込め、**攻撃者のトークンが被害者の
+      # `UserConfig` に入る**（セッション固定と同型）。
+      raise Ginseng::AuthError, 'Unauthorized' unless sns.account
+      # ⚠ **`state` は一度きりなので、応答をキャッシュさせない（同 P2）。**
+      # 使い回された応答の `state` は 2 回目以降必ず 403 になる。
+      headers 'Cache-Control' => 'no-store'
+      @renderer.message = {oauth_uri: SpotifyUserService.new(sns.account).oauth_uri.to_s}
       return @renderer.to_s
     rescue => e
       report_error(e)

--- a/app/lib/mulukhiya/controller/api_controller.rb
+++ b/app/lib/mulukhiya/controller/api_controller.rb
@@ -602,7 +602,7 @@ module Mulukhiya
         @renderer.status = 422
         @renderer.message = {errors:}
       else
-        SpotifyUserService.new(sns.account).auth(params[:code])
+        SpotifyUserService.new(sns.account).auth(params[:code], params[:state])
         @renderer.message = {config: sns.account.user_config.to_h}
       end
       return @renderer.to_s

--- a/app/lib/mulukhiya/service/spotify_user_service.rb
+++ b/app/lib/mulukhiya/service/spotify_user_service.rb
@@ -11,9 +11,15 @@ module Mulukhiya
   # トークンは UserConfig (Redis、暗号化) に保管する。Spotify の access_token は
   # 3600s で失効するため refresh_token も保管し、失効時/401 時に自動更新する。
   # capsicum 側は code-post 方式で、ブラウザ認可後の code を POST /api/spotify/auth に
-  # 渡すだけでよい (ユーザー特定は SNS トークンで行うため state は不要)。
+  # 渡す。⚠⚠ **5.37.0 (#4414) から `state` の往復が必須**（`GET /spotify/oauth_uri` が
+  # 返した URI の `state` を、`POST /spotify/auth` へそのまま戻す）。
   class SpotifyUserService
     include Package
+
+    # `OAuthStateStorage` へ入れる印。⚠ **同じストアを Mastodon / Misskey の
+    # PKCE フローと共有する**ので、他系統で発行した state を Spotify の認可に
+    # 使い回せないようにする (#4414)。
+    SERVICE_NAME = 'spotify'.freeze
 
     AUTHORIZE_PATH = '/authorize'.freeze
     TOKEN_PATH = '/api/token'.freeze
@@ -38,6 +44,8 @@ module Mulukhiya
       @account = account
     end
 
+    # ⚠ **呼ぶたびに新しい `state` を発行して短命ストアへ置く (#4414)。**
+    # 返した URI の `state` を、クライアントは `POST /spotify/auth` へそのまま戻す。
     def oauth_uri
       uri = accounts_service.create_uri(AUTHORIZE_PATH)
       uri.query_values = {
@@ -45,12 +53,37 @@ module Mulukhiya
         response_type: 'code',
         redirect_uri: redirect_uri,
         scope: scopes.join(' '),
+        state: create_state,
       }
       return uri
     end
 
+    def create_state
+      state = OAuthHelper.generate_state
+      OAuthHelper.storage.set(state, {service: SERVICE_NAME})
+      return state
+    end
+
+    # ⚠ **一度きり。**`consume` が読み出しと同時に消すので、同じ `state` での再送は
+    # 通らない（リプレイ防止）。⚠ TTL は `OAuthStateStorage::TTL`（600 秒）。
+    #
+    # ⚠⚠ **`service` の印を見る。**`OAuthStateStorage` は Mastodon / Misskey の PKCE
+    # フローと**同じストア**なので、見ないと**他系統で発行した state を Spotify の
+    # 認可に使い回せる**。
+    def verify_state!(state)
+      raise Ginseng::AuthError, 'Invalid OAuth state' if state.blank?
+      entry = OAuthHelper.consume_oauth_state(state)
+      raise Ginseng::AuthError, 'Invalid OAuth state' unless entry
+      return if entry[:service] == SERVICE_NAME
+      raise Ginseng::AuthError, 'Invalid OAuth state'
+    end
+
     # authorization code を access_token + refresh_token に交換し保管する。
-    def auth(code)
+    #
+    # ⚠⚠ **`state` は必須 (#4414)。**認可レスポンスの取り違え・横取り（CSRF）への
+    # 対策で、OAuth のベストプラクティス。⚠ **一致しなければ code の交換に進まない。**
+    def auth(code, state)
+      verify_state!(state)
       response = token_request(
         'grant_type' => 'authorization_code',
         'code' => code,

--- a/app/lib/mulukhiya/service/spotify_user_service.rb
+++ b/app/lib/mulukhiya/service/spotify_user_service.rb
@@ -58,10 +58,20 @@ module Mulukhiya
       return uri
     end
 
+    # ⚠⚠ **発行したアカウントに縛る（PR #4714 の Codex P1）。**縛らないと、
+    # 🔴 **攻撃者が自分の Spotify を認可して得た code/state の組を、ログイン中の
+    # 被害者の callback へ流し込める**。`POST /spotify/auth` は「どこかで発行された
+    # 有効な state」を受け入れてしまい、**攻撃者のトークンが被害者の `UserConfig` に
+    # 入る**（セッション固定と同型）。
     def create_state
+      raise Ginseng::AuthError, 'Unauthorized' unless account_id
       state = OAuthHelper.generate_state
-      OAuthHelper.storage.set(state, {service: SERVICE_NAME})
+      OAuthHelper.storage.set(state, {service: SERVICE_NAME, account_id:})
       return state
+    end
+
+    def account_id
+      return @account&.id
     end
 
     # ⚠ **一度きり。**`consume` が読み出しと同時に消すので、同じ `state` での再送は
@@ -74,7 +84,9 @@ module Mulukhiya
       raise Ginseng::AuthError, 'Invalid OAuth state' if state.blank?
       entry = OAuthHelper.consume_oauth_state(state)
       raise Ginseng::AuthError, 'Invalid OAuth state' unless entry
-      return if entry[:service] == SERVICE_NAME
+      raise Ginseng::AuthError, 'Invalid OAuth state' unless entry[:service] == SERVICE_NAME
+      # ⚠⚠ **発行したアカウント以外では使えない（PR #4714 の Codex P1）。**
+      return if entry[:account_id].present? && entry[:account_id] == account_id
       raise Ginseng::AuthError, 'Invalid OAuth state'
     end
 

--- a/app/lib/mulukhiya/storage/oauth_state_storage.rb
+++ b/app/lib/mulukhiya/storage/oauth_state_storage.rb
@@ -14,10 +14,17 @@ module Mulukhiya
       setex(key, TTL, values.to_json)
     end
 
+    # ⚠⚠ **読み出しと削除を分けない（PR #4714 の Codex P2）。**`get` → `unlink` の
+    # 2 段だと、**同じ state を使った同時 POST が両方とも通る**。`GETDEL` は
+    # 1 コマンドで取り出しと削除を行うので、一度きりが実際に守られる。
+    #
+    # ⚠ `GETDEL` は Redis 6.2 以降。本番 3 台とローカルはいずれも 8.x（実測）。
     def consume(key)
-      return nil unless entry = get(key)
-      unlink(key)
-      return entry
+      return nil unless raw = redis.call('GETDEL', create_key(key))
+      return JSON.parse(raw, symbolize_names: true)
+    rescue => e
+      e.log(key:)
+      return nil
     end
 
     def prefix

--- a/docs/api.md
+++ b/docs/api.md
@@ -1225,10 +1225,11 @@ capsicum が Spotify Web API 経由で「現在再生中」を OS 非依存に�
 
 Spotify の OAuth 認可 URL を取得する。
 
-- **認証**: 不要
+- **認証**: ⚠⚠ **必須（Bearer / SNS token）。**5.37.0 (#4414) から。発行する `state` を**呼んだ本人のアカウントに縛る**ため
 - **前提条件**: `features.spotify_enabled` が `true`（false 時は 404）
 - **パラメータ**: なし
 - **レスポンス例**: `{ "oauth_uri": "https://accounts.spotify.com/authorize?client_id=...&response_type=code&redirect_uri=...&scope=user-read-currently-playing&state=..." }`
+- **レスポンスヘッダ**: `Cache-Control: no-store`（⚠ `state` は一度きりなので、応答を使い回すと 2 回目以降必ず失敗する）
 
 ⚠⚠ **5.37.0 (#4414) から `state` が付く。**クライアントは**この値を保持し、`POST /spotify/auth` へそのまま戻す**必要がある。
 ⚠ **呼ぶたびに新しい値**が発行され、⚠ **一度使うと消える**（リプレイ不可）。⚠ 有効期間は **600 秒**。
@@ -1248,8 +1249,10 @@ Spotify の OAuth 認可 URL を取得する。
 
 - **レスポンス**: `{ "config": { ... } }`（更新後のユーザー設定）
 
-⚠ **`state` が欠けている・知らない・使用済みなら 401**（`{"error": "Invalid OAuth state"}`）。
-契約違反（`state` キー自体が無い）は 422。
+⚠ **`state` が欠けている・知らない・使用済み・別アカウントのものなら 403**
+（`{"error": "Invalid OAuth state"}`）。契約違反（`state` キー自体が無い）は 422。
+⚠⚠ **`state` は発行したアカウントでしか使えない。**`GET /spotify/oauth_uri` を叩いた
+トークンと、`POST /spotify/auth` のトークンが同じである必要がある。
 
 ⚠⚠ **これは 5.36.0 以前からの破壊的変更。**`state` を送らないクライアントは 422 になる。
 本機能は `features.spotify_enabled` が既定で false（本番 4 台とも `client_id` 未設定で

--- a/docs/api.md
+++ b/docs/api.md
@@ -1218,7 +1218,7 @@ capsicum が Spotify Web API 経由で「現在再生中」を OS 非依存に�
   1. クライアントが `GET /spotify/oauth_uri` で認可 URL を取得する
   2. クライアントが認可 URL をブラウザで開き、ユーザーが Spotify で認可する
   3. Spotify が Redirect URI（`/service/spotify/oauth/redirect_uri`、capsicum が捕捉できる URL／カスタムスキーム）へ認可コード付きでリダイレクトする
-  4. クライアントが捕捉した認可コードを `POST /spotify/auth` に送信（ユーザー特定は SNS トークンで行うため `state` は不要）
+  4. クライアントが捕捉した認可コードを、⚠ **1 で受け取った `state` と一緒に** `POST /spotify/auth` に送信する
   5. 以降クライアントは `GET /spotify/currently_playing` で現在再生中の URL を取得できる
 
 ##### GET /mulukhiya/api/spotify/oauth_uri
@@ -1228,7 +1228,10 @@ Spotify の OAuth 認可 URL を取得する。
 - **認証**: 不要
 - **前提条件**: `features.spotify_enabled` が `true`（false 時は 404）
 - **パラメータ**: なし
-- **レスポンス例**: `{ "oauth_uri": "https://accounts.spotify.com/authorize?client_id=...&response_type=code&redirect_uri=...&scope=user-read-currently-playing" }`
+- **レスポンス例**: `{ "oauth_uri": "https://accounts.spotify.com/authorize?client_id=...&response_type=code&redirect_uri=...&scope=user-read-currently-playing&state=..." }`
+
+⚠⚠ **5.37.0 (#4414) から `state` が付く。**クライアントは**この値を保持し、`POST /spotify/auth` へそのまま戻す**必要がある。
+⚠ **呼ぶたびに新しい値**が発行され、⚠ **一度使うと消える**（リプレイ不可）。⚠ 有効期間は **600 秒**。
 
 ##### POST /mulukhiya/api/spotify/auth
 
@@ -1241,8 +1244,17 @@ Spotify の OAuth 認可 URL を取得する。
 | 名前 | 型 | 必須 | 説明 |
 |------|-----|------|------|
 | `code` | string | 必須 | Spotify OAuth 認可コード |
+| `state` | string | 必須 | ⚠⚠ **`GET /spotify/oauth_uri` が返した URI の `state`。**5.37.0 (#4414) から必須 |
 
 - **レスポンス**: `{ "config": { ... } }`（更新後のユーザー設定）
+
+⚠ **`state` が欠けている・知らない・使用済みなら 401**（`{"error": "Invalid OAuth state"}`）。
+契約違反（`state` キー自体が無い）は 422。
+
+⚠⚠ **これは 5.36.0 以前からの破壊的変更。**`state` を送らないクライアントは 422 になる。
+本機能は `features.spotify_enabled` が既定で false（本番 4 台とも `client_id` 未設定で
+ルートごと 404）なので**稼働中の利用者はいない**が、capsicum 側の code 捕捉フローに
+往復の追加が要る（pooza/capsicum#570）。
 
 ##### GET /mulukhiya/api/spotify/currently_playing
 

--- a/test/contract/spotify_auth_contract.rb
+++ b/test/contract/spotify_auth_contract.rb
@@ -5,8 +5,9 @@ module Mulukhiya
     end
 
     def test_call
-      # ユーザー特定は bearer 認証で行うため code のみ必須・token は不要。
-      errors = @contract.call(code: 'auth-code').errors
+      # ユーザー特定は bearer 認証で行うため token は不要。
+      # ⚠ `state` は 5.37.0 (#4414) から必須（CSRF 対策）。
+      errors = @contract.call(code: 'auth-code', state: 'the-state').errors
 
       assert_empty(errors)
 

--- a/test/unit/lib/oauth_helper.rb
+++ b/test/unit/lib/oauth_helper.rb
@@ -44,6 +44,21 @@ module Mulukhiya
       assert_equal('mastodon', consumed[:sns_type])
     end
 
+    # 🔴 **読み出しと削除が原子的であること（PR #4714 の Codex P2）。**
+    # ⚠⚠ `get` → `unlink` の 2 段だと、**同じ state を使った同時アクセスが
+    # 両方とも通る**。`GETDEL` で 1 コマンドにしてある。
+    def test_consume_is_atomic
+      result = OAuthHelper.create_oauth_state(sns_type: 'mastodon')
+      winners = Concurrent::Array.new
+
+      threads = Array.new(8) do
+        Thread.new {winners.push(OAuthHelper.consume_oauth_state(result[:state]))}
+      end
+      threads.each(&:join)
+
+      assert_equal(1, winners.compact.length, '同じ state で複数回通っている')
+    end
+
     def test_consume_oauth_state_one_time
       result = OAuthHelper.create_oauth_state(sns_type: 'misskey')
       consumed = OAuthHelper.consume_oauth_state(result[:state])

--- a/test/unit/service/spotify_oauth_state.rb
+++ b/test/unit/service/spotify_oauth_state.rb
@@ -5,16 +5,20 @@ module Mulukhiya
   # 省いていた。`state` は**認可レスポンスの取り違え・横取り**への対策で、
   # ユーザー特定とは別の軸。
   class SpotifyOAuthStateTest < TestCase
+    ACCOUNT_ID = 4414
+
     def setup
-      @service = SpotifyUserService.allocate
+      @service = service_for(ACCOUNT_ID)
     end
 
     # 🔴 **本体。**`oauth_uri` が毎回新しい `state` を発行し、URI に載せる。
+    #
+    # ⚠ **`omit` しない (#4503)。**`client_id` は本番でも未設定なので、素直に書くと
+    # **CI でも実機でも一生実行されないテスト**になる（omission 上限のガードに
+    # 実際に引っかかった）。設定に依存する部分だけ差し替えて、**必ず走らせる**。
     def test_oauth_uri_carries_a_fresh_state
-      omit('Spotify の client_id が未設定') unless SpotifyUserService.config?
-
-      first = state_of(SpotifyUserService.new.oauth_uri)
-      second = state_of(SpotifyUserService.new.oauth_uri)
+      first = state_of(stubbed_service.oauth_uri)
+      second = state_of(stubbed_service.oauth_uri)
 
       assert_predicate(first, :present?, 'state が付いていない')
       assert_not_equal(first, second, '毎回同じ state を返している')
@@ -49,6 +53,23 @@ module Mulukhiya
       end
     end
 
+    # 🔴 **発行したアカウント以外では使えない（PR #4714 の Codex P1）。**
+    # ⚠⚠ 縛らないと、**攻撃者が自分の Spotify を認可して得た code/state の組を
+    # 被害者の callback へ流し込め、攻撃者のトークンが被害者の `UserConfig` に入る**
+    # （セッション固定と同型）。
+    def test_state_is_bound_to_the_issuing_account
+      state = @service.send(:create_state)
+
+      assert_raises(Ginseng::AuthError, '別アカウントで通ってしまう') do
+        service_for(ACCOUNT_ID + 1).send(:verify_state!, state)
+      end
+    end
+
+    # ⚠ アカウントを持たない呼び出しでは発行しない（縛れないものを配らない）。
+    def test_state_is_not_issued_without_an_account
+      assert_raises(Ginseng::AuthError) {service_for(nil).send(:create_state)}
+    end
+
     # 🔴 **他系統の state を使い回せない。**
     # ⚠⚠ `OAuthStateStorage` は Mastodon / Misskey の PKCE フローと**同じストア**。
     # 印を見ないと、あちらで発行した state が Spotify の認可に通ってしまう。
@@ -66,6 +87,29 @@ module Mulukhiya
     end
 
     private
+
+    def service_for(account_id)
+      service = SpotifyUserService.allocate
+      service.define_singleton_method(:account_id) {account_id}
+      return service
+    end
+
+    # 設定（`client_id` / accounts の URL）に依存する部分だけ差し替える。
+    # ⚠ 見たいのは **`state` が載ること**なので、それ以外は最小限で足りる。
+    def stubbed_service
+      service = service_for(ACCOUNT_ID)
+      service.define_singleton_method(:accounts_service) do
+        double = Object.new
+        double.define_singleton_method(:create_uri) do |path|
+          Ginseng::URI.parse("https://accounts.example#{path}")
+        end
+        double
+      end
+      service.define_singleton_method(:redirect_uri) {'http://127.0.0.1:8888/spotify/callback'}
+      service.define_singleton_method(:scopes) {['user-read-currently-playing']}
+      service.singleton_class.define_method(:client_id) {'test-client'}
+      return service
+    end
 
     def state_of(uri)
       return Ginseng::URI.parse(uri.to_s).query_values['state']

--- a/test/unit/service/spotify_oauth_state.rb
+++ b/test/unit/service/spotify_oauth_state.rb
@@ -1,0 +1,74 @@
+module Mulukhiya
+  # Spotify OAuth の `state`（CSRF 対策）(#4414)。
+  #
+  # ⚠ 初版は「ユーザー特定は SNS トークンで行うため `state` は不要」と判断して
+  # 省いていた。`state` は**認可レスポンスの取り違え・横取り**への対策で、
+  # ユーザー特定とは別の軸。
+  class SpotifyOAuthStateTest < TestCase
+    def setup
+      @service = SpotifyUserService.allocate
+    end
+
+    # 🔴 **本体。**`oauth_uri` が毎回新しい `state` を発行し、URI に載せる。
+    def test_oauth_uri_carries_a_fresh_state
+      omit('Spotify の client_id が未設定') unless SpotifyUserService.config?
+
+      first = state_of(SpotifyUserService.new.oauth_uri)
+      second = state_of(SpotifyUserService.new.oauth_uri)
+
+      assert_predicate(first, :present?, 'state が付いていない')
+      assert_not_equal(first, second, '毎回同じ state を返している')
+    end
+
+    # 🔴 **発行した state は通る。**
+    def test_issued_state_verifies
+      state = @service.send(:create_state)
+
+      assert_nothing_raised {@service.send(:verify_state!, state)}
+    end
+
+    # 🔴 **一度きり。**`consume` が読み出しと同時に消すのでリプレイできない。
+    def test_state_is_single_use
+      state = @service.send(:create_state)
+      @service.send(:verify_state!, state)
+
+      assert_raises(Ginseng::AuthError) {@service.send(:verify_state!, state)}
+    end
+
+    # 🔴 **知らない state は拒否。**
+    def test_unknown_state_is_rejected
+      assert_raises(Ginseng::AuthError) {@service.send(:verify_state!, 'not-issued-here')}
+    end
+
+    # ⚠ 空・nil も拒否（**「無ければ素通し」にしない**）。
+    def test_blank_state_is_rejected
+      [nil, '', '   '].each do |value|
+        assert_raises(Ginseng::AuthError, "#{value.inspect} が素通しした") do
+          @service.send(:verify_state!, value)
+        end
+      end
+    end
+
+    # 🔴 **他系統の state を使い回せない。**
+    # ⚠⚠ `OAuthStateStorage` は Mastodon / Misskey の PKCE フローと**同じストア**。
+    # 印を見ないと、あちらで発行した state が Spotify の認可に通ってしまう。
+    def test_state_from_another_flow_is_rejected
+      foreign = OAuthHelper.create_oauth_state(sns_type: 'mastodon')
+
+      assert_raises(Ginseng::AuthError) {@service.send(:verify_state!, foreign[:state])}
+    end
+
+    # ⚠ 契約側でも必須にしてあること（ルートへ届く前に 422 で落とす）。
+    def test_contract_requires_state
+      errors = SpotifyAuthContract.new.exec({code: 'abc'})
+
+      assert(errors.key?(:state), 'contract が state を必須にしていない')
+    end
+
+    private
+
+    def state_of(uri)
+      return Ginseng::URI.parse(uri.to_s).query_values['state']
+    end
+  end
+end

--- a/test/unit/service/spotify_user_service.rb
+++ b/test/unit/service/spotify_user_service.rb
@@ -25,8 +25,9 @@ module Mulukhiya
       assert_false(SpotifyUserService.config?)
     end
 
+    # ⚠ `oauth_uri` は `state` を発行するのでアカウントが要る（#4414）。
     def test_oauth_uri
-      uri = SpotifyUserService.new.oauth_uri
+      uri = SpotifyUserService.new(account_double).oauth_uri
 
       assert_equal('accounts.spotify.com', uri.host)
       assert_equal('/authorize', uri.path)
@@ -36,6 +37,12 @@ module Mulukhiya
       assert_equal('code', query['response_type'])
       assert_equal('user-read-currently-playing', query['scope'])
       assert_equal(config['/service/spotify/oauth/redirect_uri'], query['redirect_uri'])
+      assert_predicate(query['state'], :present?)
+    end
+
+    # ⚠ アカウント無しでは発行しない（縛れないものを配らない・#4414）。
+    def test_oauth_uri_requires_an_account
+      assert_raises(Ginseng::AuthError) {SpotifyUserService.new.oauth_uri}
     end
 
     def test_auth_exchanges_code_and_stores_tokens
@@ -44,7 +51,7 @@ module Mulukhiya
       )
       account = account_double
 
-      SpotifyUserService.new(account).auth('the-code', issued_state)
+      SpotifyUserService.new(account).auth('the-code', issued_state(account))
 
       assert_requested(stub.with do |req|
         body = URI.decode_www_form(req.body).to_h
@@ -102,7 +109,9 @@ module Mulukhiya
       stub = stub_token_endpoint(access_token: 'a', refresh_token: 'r', expires_in: 3600)
       expected = Base64.strict_encode64('test_client_id:test_client_secret')
 
-      SpotifyUserService.new(account_double).auth('the-code', issued_state)
+      account = account_double
+
+      SpotifyUserService.new(account).auth('the-code', issued_state(account))
 
       assert_requested(stub.with do |req|
         req.headers['Authorization'] == "Basic #{expected}" &&
@@ -234,14 +243,17 @@ module Mulukhiya
     # UserConfig は暗号化値をそのまま保持し read 時に復号しない仕様だが、本ダブルは
     # 平文を保持する (service 側 decrypt は復号失敗時に値をそのまま返すため整合する)。
     # ⚠ `auth` は 5.37.0 (#4414) から `state` の検証を通る。テストでは
-    # **実際に発行した state** を使う（素の文字列だと 401 になる）。
-    def issued_state
-      return SpotifyUserService.allocate.send(:create_state)
+    # **そのアカウントで実際に発行した state** を使う（素の文字列や別アカウント
+    # 発行のものは 403 になる）。
+    def issued_state(account)
+      return SpotifyUserService.new(account).send(:create_state)
     end
 
-    def account_double(store = {})
+    # ⚠ `id` を持たせるのは、`state` が**発行したアカウントに縛られる**ため
+    # （#4414・PR #4714 の Codex P1）。
+    def account_double(store = {}, id = 4414)
       user_config = FakeUserConfig.new(store)
-      return Struct.new(:user_config).new(user_config)
+      return Struct.new(:user_config, :id).new(user_config, id)
     end
 
     class FakeUserConfig

--- a/test/unit/service/spotify_user_service.rb
+++ b/test/unit/service/spotify_user_service.rb
@@ -44,7 +44,7 @@ module Mulukhiya
       )
       account = account_double
 
-      SpotifyUserService.new(account).auth('the-code')
+      SpotifyUserService.new(account).auth('the-code', issued_state)
 
       assert_requested(stub.with do |req|
         body = URI.decode_www_form(req.body).to_h
@@ -102,7 +102,7 @@ module Mulukhiya
       stub = stub_token_endpoint(access_token: 'a', refresh_token: 'r', expires_in: 3600)
       expected = Base64.strict_encode64('test_client_id:test_client_secret')
 
-      SpotifyUserService.new(account_double).auth('the-code')
+      SpotifyUserService.new(account_double).auth('the-code', issued_state)
 
       assert_requested(stub.with do |req|
         req.headers['Authorization'] == "Basic #{expected}" &&
@@ -233,6 +233,12 @@ module Mulukhiya
     # 実 Account/UserConfig (DB・Redis 依存) を避けるための最小ダブル。
     # UserConfig は暗号化値をそのまま保持し read 時に復号しない仕様だが、本ダブルは
     # 平文を保持する (service 側 decrypt は復号失敗時に値をそのまま返すため整合する)。
+    # ⚠ `auth` は 5.37.0 (#4414) から `state` の検証を通る。テストでは
+    # **実際に発行した state** を使う（素の文字列だと 401 になる）。
+    def issued_state
+      return SpotifyUserService.allocate.send(:create_state)
+    end
+
     def account_double(store = {})
       user_config = FakeUserConfig.new(store)
       return Struct.new(:user_config).new(user_config)


### PR DESCRIPTION
Closes #4414

#4337 / #4413 の初版は「ユーザー特定は SNS トークンで行うため `state` は不要」と判断して
省いていました。⚠ **`state` は認可レスポンスの取り違え・横取り（CSRF）への対策**で、
ユーザー特定とは別の軸です。

## Issue の 4 項目

| | 内容 |
| --- | --- |
| ✅ | `SpotifyUserService#oauth_uri` が**呼ぶたびに新しい `state`** を発行し URI に載せる |
| ✅ | 発行した `state` は既存の `OAuthStateStorage`（Redis・TTL 600 秒）へ置く |
| ✅ | `POST /spotify/auth` で `state` を検証し、**一致しなければ code の交換に進まない** |
| ✅ | `docs/api.md` を更新（capsicum 側の往復追加が要ることを明記） |

⚠ **一度きり。**`consume` が読み出しと同時に消すのでリプレイできません。

⚠⚠ **`service` の印を見ています。**`OAuthStateStorage` は Mastodon / Misskey の PKCE
フローと**同じストア**なので、見ないと**他系統で発行した state を Spotify の認可に
使い回せて**しまいます（回帰テストあり）。

## ⚠ 破壊的変更ですが、稼働中の利用者はいません

`state` を送らないクライアントは 422 になります。ただし実機で確認したとおり、
**本番 3 台とも `client_id` 未設定**で `SpotifyUserService.config?` が false
＝ **`/spotify/*` はルートごと 404** です:

```
shallu:   spotify_client_id=未設定
gomander: spotify_client_id=未設定
```

⚠ **capsicum 側の code 捕捉フローに `state` の往復を追加する必要があります**
（pooza/capsicum#570）。Issue の「capsicum #570 と歩調を合わせる」がこれにあたります。

## テスト（7 本・新規 `test/unit/service/spotify_oauth_state.rb`）

| テスト | 何を押さえるか |
| --- | --- |
| `test_oauth_uri_carries_a_fresh_state` | 🔴 毎回新しい `state` が URI に載る（⚠ `client_id` 未設定の環境では omit） |
| `test_issued_state_verifies` | 発行したものは通る |
| `test_state_is_single_use` | 🔴 リプレイ不可 |
| `test_unknown_state_is_rejected` | 🔴 知らない `state` は拒否 |
| `test_blank_state_is_rejected` | ⚠ nil / 空 / 空白も拒否（**「無ければ素通し」にしない**） |
| `test_state_from_another_flow_is_rejected` | 🔴 **他系統（Mastodon PKCE）の state を使い回せない** |
| `test_contract_requires_state` | 契約側でも必須（ルートへ届く前に 422） |

## ⚠ 残る判断（この PR ではやっていません）

`GET /spotify/oauth_uri` は**認証不要**なので、`state` をアカウントに紐づけていません。
アカウント束縛まで行うなら **この endpoint に bearer 認証を足す**必要があり、capsicum の
呼び出しも変わります。Issue の 4 項目には無いので分けました。**必要なら別 Issue で。**

## 検証

- `bundle exec rake lint` → ✅ **513 files / no offenses**、脆弱性 0
- `bundle exec rake test` → ✅ **1324 tests / 1914 assertions / 0 failures / 0 errors**

⚠ 既存テスト 2 ファイルを追随（`SpotifyAuthContractTest` に `state` を足し、
`SpotifyUserServiceTest` の `auth` 呼び出しは**実際に発行した state** を使う形に）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExMqJf1tfD174UoMBGVJNk