### PR TITLE
test: webhook 投稿経路をインプロセスで検証する (#4428)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,11 +13,16 @@ jobs:
         # テストは実行されず omission になる。この件数が黙って増えると
         # 「守れているつもりの緑」が広がるので、超えたら CI を落とす (#4503)。
         # 意図してテストを増やしたときは、この数値を実測に合わせて更新する。
+        #
+        # 2026-09-09 (#4428): webhook 投稿経路のインプロセス検証を足したので +4。
+        # ⚠ これらは **harness（実インスタンス）が要る**テストで、CI では走らない。
+        # 実測は CI と同じ config（`controller` + ダミーの url/password）を置いて
+        # `rake test` を回した値: mastodon 326 / misskey 315。
         include:
           - controller: mastodon
-            omission_baseline: 322
+            omission_baseline: 326
           - controller: misskey
-            omission_baseline: 311
+            omission_baseline: 315
     services:
       redis:
         image: redis:7

--- a/docs/test-harness.md
+++ b/docs/test-harness.md
@@ -172,6 +172,43 @@ tests / failures / errors / omissions の 4 つで見る。
 記録先: [harness-verified-versions.yaml](harness-verified-versions.yaml)。上流バージョンの
 `verified` 昇格を伴う実走は、この台帳に日付つきで残す。
 
+## webhook 投稿経路の検証（#4428）
+
+**`WebhookInprocessTest`** が `/mulukhiya/webhook/<digest>` の受信 → `pre_toot`
+パイプライン → `sns.post` で upstream へ実投稿、までを **1 プロセスで**通す。
+
+⚠ **puma を別に立てない。**`include Rack::Test::Methods` + `def app = WebhookController`
+で Sinatra を直接叩く。harness には前段の mulukhiya が居ないので、curl 方式
+（`WebhookTest#test_command`）は**構造的に検証できない**（あちらは従来どおり omit）。
+
+### ⚠⚠ harness 側に provisioning が要る（pooza/chubo2#232）
+
+**mulukhiya の webhook 引き当ては、アプリ名で候補を絞る**:
+
+```sql
+AND (apps.name LIKE 'mulukhiya%')   -- Mastodon / Misskey とも同じ
+```
+
+そのため harness 側に **`mulukhiya` で始まる名前のアプリ**と、それに紐づく
+アクセストークンが要る。**無いと `oauth_access_tokens` / `access_token` に行があっても
+候補が 0 件になり、`/mulukhiya/webhook/<digest>` は必ず 404 になる。**
+
+| | harness が作るもの | 必要な追加 |
+| --- | --- | --- |
+| Mastodon | Doorkeeper アプリ `fedi-test-harness` | **名前を `mulukhiya (fedi-test-harness)` へ** |
+| Misskey | ⚠ **`app` / `access_token` の行を作らない**（signup が返すのはネイティブトークン） | **両方の行を作る** |
+
+⚠ **Misskey は `hash` 列が実トークン。**mulukhiya の `Misskey::AccessToken` は
+`to_s` が `values[:hash]`、`get(token:)` が `first(hash: token)` なので、
+`hash` に `.env.test` のトークンを入れる（`token` 列は使われない）。
+
+### ⚠ テストは webhook トークンを自分で用意する
+
+harness のアカウントは webhook トークンを持たないので、`WebhookInprocessTest#setup` が
+`account.user_config.token` を入れてから `account.webhook` を取る。
+⚠ **入れてから取る**（`Webhook#initialize` がそのとき `@sns.token` を固定するため）。
+⚠ teardown で必ず戻す（他のテストが同じアカウントを見る）。
+
 ## 後片付け
 
 ```sh

--- a/test/unit/controller/webhook_inprocess.rb
+++ b/test/unit/controller/webhook_inprocess.rb
@@ -46,8 +46,17 @@ module Mulukhiya
     def teardown
       super
       return if disable?
-      # ⚠ 他のテストが同じアカウントを見るので、必ず戻す。
-      account.user_config.token = @original_token if @original_token
+      # ⚠⚠ **無かったなら「無い」に戻す（PR #4715 の Codex P2）。**
+      # harness のアカウントは**トークンを持たないのが通常の状態**なので、
+      # `if @original_token` を付けると 🔴 **最初の 1 本が webhook を有効にしたまま
+      # 共有アカウントを汚染し、後続のテストや次回の harness 実行がその設定を見る**。
+      # ⚠ `UserConfig#token=` は nil を受けられない（`nil.encrypt` で落ちる）ので、
+      # 消す側は `update` を直に使う。
+      if @original_token
+        account.user_config.token = @original_token
+      else
+        account.user_config.update(mulukhiya: {token: nil}, webhook: {token: nil})
+      end
     end
 
     # 🔴 **本体。**受信からパイプラインを通って upstream へ実投稿されること。

--- a/test/unit/controller/webhook_inprocess.rb
+++ b/test/unit/controller/webhook_inprocess.rb
@@ -1,0 +1,106 @@
+require 'rack/test'
+
+module Mulukhiya
+  # webhook 投稿の full path をインプロセスで検証する (#4428)。
+  #
+  # ⚠⚠ **harness には前段の mulukhiya が居ない。**`Webhook#uri` は
+  # `sns.create_uri("/mulukhiya/webhook/<digest>")` ＝ **プロキシ自身のパス**を
+  # 組み立てるので、`WebhookTest#test_command` の curl は**バニラ upstream を
+  # 直接叩いて**しまう（Mastodon は nginx の HTML、Misskey は Fastify の 404 JSON）。
+  # そのため **webhook だけが harness の検証盲点**になっていた（chubo2#63）。
+  #
+  # 🔴 **puma を別に立てず、受信コントローラをインプロセスで駆動する。**
+  # `/mulukhiya/webhook/<digest>` の受信 → `pre_toot` パイプライン →
+  # `sns.post` で upstream へ実投稿、までを 1 プロセスで通す。
+  #
+  # ⚠ `Webhook#command`（curl スニペット）は tomato-shrieker 連携で使うので
+  # **変更しない**。テスト側の検証手段だけをインプロセス化する。
+  class WebhookInprocessTest < TestCase
+    include Rack::Test::Methods
+
+    def disable?
+      return true unless Environment.dbms_class&.config?
+      return true unless controller_class.webhook?
+      return true unless account&.webhook
+      return super
+    rescue StandardError
+      return true
+    end
+
+    # ⚠ `Rack::URLMap` の外で直接叩くので、パスは**マウント相対**（`/<digest>`）。
+    def app = WebhookController
+
+    def setup
+      return if disable?
+      # ⚠⚠ **harness のアカウントは webhook トークンを持たない。**`Webhook#digest` は
+      # トークン未設定で `ConfigError` を投げる（#4487 で入れた、幽霊 webhook URL を
+      # 作らせないためのガード）ので、**実際に webhook を有効化した状態を作る**。
+      # ⚠ ここは harness の provisioning が用意しない部分（chubo2#63）。
+      @original_token = account.user_config.token
+      account.user_config.token = account_class.test_token
+      # ⚠ **トークンを入れてから取る。**`Webhook#initialize` が `@sns.token` を
+      # そのとき固定するので、先に取ると空のまま握ることになる。
+      @hook = account.webhook
+    end
+
+    def teardown
+      super
+      return if disable?
+      # ⚠ 他のテストが同じアカウントを見るので、必ず戻す。
+      account.user_config.token = @original_token if @original_token
+    end
+
+    # 🔴 **本体。**受信からパイプラインを通って upstream へ実投稿されること。
+    def test_post_reaches_upstream
+      post_webhook({'text' => "#{Package.name} webhook inprocess test"})
+
+      assert_equal(200, last_response.status, last_response.body.to_s[0, 200])
+      body = JSON.parse(last_response.body)
+      # ⚠ Mastodon は `id` / `account`、Misskey は `createdNote`。
+      assert_includes(['id', 'account', 'createdNote'], body.keys.first)
+    end
+
+    # ⚠ **GET は疎通確認だけ。**投稿はしない。
+    def test_get_is_a_liveness_check
+      get("/#{@hook.digest}", {}, rack_env)
+
+      assert_equal(200, last_response.status)
+      assert_equal('OK', JSON.parse(last_response.body)['message'])
+    end
+
+    # 🔴 **知らない digest は 404。**⚠ 本文の形も押さえる（#4520 で
+    # `not_found` がルート由来のボディを潰さなくなった）。
+    def test_unknown_digest_is_not_found
+      post("/#{'0' * 64}", '{"text":"x"}', rack_env)
+
+      assert_equal(404, last_response.status)
+      assert_predicate(JSON.parse(last_response.body), :present?)
+    end
+
+    # ⚠ 契約違反は 422。`text` も `blocks` も無いペイロード。
+    def test_invalid_payload_is_unprocessable
+      post_webhook({'unknown_key' => 'x'})
+
+      assert_equal(422, last_response.status)
+    end
+
+    private
+
+    def post_webhook(payload)
+      body = payload.to_json
+      post("/#{@hook.digest}", body, rack_env(body))
+    end
+
+    # ⚠ **`CONTENT_TYPE` を明示しないと body が届かない。**form-urlencoded だと
+    # Rack が params 解釈で `rack.input` を読み切ってしまい、`before` の
+    # `request.body.read` が空文字を返す（本番の Puma では起きないテスト固有の事情）。
+    # ⚠ Sinatra のホスト認可で 403 になるので `HTTP_HOST` も要る。
+    def rack_env(body = '')
+      return {
+        'HTTP_HOST' => 'localhost',
+        'CONTENT_TYPE' => 'application/json',
+        'rack.input' => StringIO.new(body),
+      }
+    end
+  end
+end


### PR DESCRIPTION
Closes #4428
Depends on pooza/chubo2#232（harness の provisioning）

## 何が盲点だったか

⚠⚠ **harness には前段の mulukhiya が居ません。**`Webhook#uri` は
`sns.create_uri("/mulukhiya/webhook/<digest>")` ＝ **プロキシ自身のパス**を組み立てるので、
`WebhookTest#test_command` の curl は**バニラ upstream を直接叩いて**しまいます
（Mastodon は nginx の HTML、Misskey は Fastify の 404 JSON）。
**webhook だけが harness の検証盲点**でした。

## 方針どおり puma は立てていません

```ruby
include Rack::Test::Methods
def app = WebhookController      # ⚠ Rack::URLMap の外なのでパスはマウント相対
```

`/mulukhiya/webhook/<digest>` の受信 → `pre_toot` パイプライン → `sns.post` で
upstream へ**実投稿**、までを 1 プロセスで通します。
⚠ `Webhook#command`（curl スニペット）は tomato-shrieker 連携で使うので**変更していません**。

## 🔴 詰まっていたのは mulukhiya 側ではなく harness の provisioning でした

webhook 引き当ては **両系とも `apps.name LIKE 'mulukhiya%'`** でアプリ名を見ます:

```sql
-- Mastodon: app/query/mastodon/webhook_tokens.sql.erb
INNER JOIN oauth_applications AS apps ON tokens.application_id = apps.id
AND (apps.name LIKE 'mulukhiya%')
```

| | 実態 | 必要だったもの |
| --- | --- | --- |
| Mastodon | Doorkeeper アプリが `fedi-test-harness` | 名前を `mulukhiya (fedi-test-harness)` へ |
| Misskey | ⚠ **`app` / `access_token` の行が 1 つも無い**（signup が返すのはネイティブトークン） | 両方の行を作る |

実測（修正前・Mastodon）:

```
digest=40aaefde8d47...
webhook_tokens 行数=0
create! => NilClass
```

⚠⚠ **Misskey は `hash` 列が実トークン**です（`Misskey::AccessToken#to_s` が
`values[:hash]`、`get(token:)` が `first(hash: token)`）。取り違えると永久に引き当てられません。

harness 側の変更は **pooza/chubo2#232**。⚠ Misskey は harness を実際に作り直して
**冪等に効くこと**を確認しています。

## 実測（両系とも harness 実走）

| | 結果 |
| --- | --- |
| `webhook_inprocess`（Mastodon） | ✅ **6 tests / 7 assertions / 0 failures / 0 errors / 0 omissions** |
| `webhook_inprocess`（Misskey） | ✅ **6 tests / 7 assertions / 0 failures / 0 errors / 0 omissions** |
| 全スイート（Mastodon harness） | ✅ **1411 tests / 2707 assertions / 0 failures / 0 errors / 159 omissions** |
| 全スイート（Misskey harness） | ✅ **1414 tests / 2761 assertions / 0 failures / 0 errors / 145 omissions** |

## ⚠ テストは webhook トークンを自分で用意します

harness のアカウントは webhook トークンを持たず、`Webhook#digest` は未設定で
`ConfigError` を投げます（#4487 の、幽霊 webhook URL を作らせないガード）。
setup で `account.user_config.token` を入れ、teardown で戻します。

⚠ **入れてから `account.webhook` を取ります**（`Webhook#initialize` がそのとき
`@sns.token` を固定するので、先に取ると空のまま握ります。実際に一度踏みました）。

## ⚠ CI の omission 上限を更新しました

harness が要るテストなので CI では走りません。#4503 のガードの設計
（「意図してテストを増やしたときは、この数値を実測に合わせて更新する」）に従い:

| | 変更前 | 変更後 |
| --- | ---: | ---: |
| mastodon | 322 | **326** |
| misskey | 311 | **315** |

⚠ 実測は CI と同じ config（`controller` + ダミーの url/password）を置いて `rake test` を
回した値です。理由と実測方法をワークフローのコメントに残しました。

## docs

`docs/test-harness.md` に「webhook 投稿経路の検証」節を追加しました
（provisioning の要件・Misskey の `hash` 列の罠・トークンの用意の順序）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExMqJf1tfD174UoMBGVJNk