### PR TITLE
deps: dependabot に version update の受け皿を作る (#4702)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,8 @@
 version: 2
 updates:
+# ⚠⚠ **v4 系は据え置き（limit 0 ＝ version update 無効）。**
+# 保守は「必要なものだけバックポート」の方針なので、日次で PR が出ても捌けない。
+# ⚠ security update は limit 0 でも動くので、脆弱性の通知は止まらない。
 - package-ecosystem: bundler
   directory: '/'
   schedule:
@@ -9,12 +12,36 @@ updates:
   open-pull-requests-limit: 0
   target-branch: v4
   versioning-strategy: lockfile-only
+# ⚠⚠ **develop は version update を開ける (#4702)。**
+# #4701 で `ginseng-*` をタグ固定したが、**limit 0 のままだと版を上げる経路が
+# どこにも無く、7 本が凍結する**（PR #4701 の Codex P2）。⚠ 固定の目的は
+# 「破綻の受け皿を `bundle update` の中から版上げ PR の CI へ移す」ことなので、
+# **その PR が出ないと固定した意味が無い。**
+#
+# ⚠ `allow:` で `ginseng-*` に絞ってはいけない。`allow` は **security update にも効く**
+# ので、他の gem の脆弱性 PR まで止まる（limit 0 でも生きている唯一の安全弁を壊す）。
+# ⚠ dependabot は同一 `(ecosystem, directory, target-branch)` の重複を許さないので、
+# 「ginseng 専用のもう 1 エントリ」も足せない。**groups で束ねて本数を抑える。**
 - package-ecosystem: bundler
   directory: '/'
   schedule:
     interval: daily
     time: '03:00'
     timezone: 'Asia/Tokyo'
-  open-pull-requests-limit: 0
+  # ⚠ グループ 2 つぶん。1 日に出る PR は最大 2 本。
+  open-pull-requests-limit: 2
   target-branch: develop
   versioning-strategy: lockfile-only
+  groups:
+    # ⚠ 自作 gem。タグ固定したので `bump ginseng-core from v1.23.7 to ...` と
+    # **版として読める**タイトルになる（#4701 が狙っていた効果）。
+    ginseng:
+      patterns:
+        - 'ginseng-*'
+    # それ以外はまとめて 1 本。⚠ `versioning-strategy: lockfile-only` なので
+    # `Gemfile` の制約は動かず、`Gemfile.lock` だけが上がる。
+    others:
+      patterns:
+        - '*'
+      exclude-patterns:
+        - 'ginseng-*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,15 +31,46 @@ updates:
   # ⚠ グループ 2 つぶん。1 日に出る PR は最大 2 本。
   open-pull-requests-limit: 2
   target-branch: develop
-  versioning-strategy: lockfile-only
+  # ⚠⚠ **`lockfile-only` では ginseng の版が上がらない（PR #4716 の Codex P1）。**
+  # `tag: 'v1.23.7'` を新しいタグへ上げるには **`Gemfile` の書き換えが要る**が、
+  # `lockfile-only` は「manifest の変更が要る版は無視する」ので、**ginseng グループから
+  # PR が 1 本も出ない**（= この設定を足した目的そのものが成立しない）。
+  #
+  # `increase-if-necessary` は **今の制約を満たさない版のときだけ** manifest を動かす。
+  # ⚠ ただしそれでは、**意図して上限を置いている gem まで制約を広げる PR が出る**。
+  # そこで下の `ignore` で、上限の外へ出る版上げだけを止める（据え置きの判断は Issue で行う）。
+  # ⚠ `ignore` は version update にだけ効き、**security update は止めない**。
+  versioning-strategy: increase-if-necessary
+  # ⚠⚠ **`Gemfile` の `~>` と対にしてある。**上限を足した・外したら、ここも直す
+  # （`test/unit/lib/dependabot_config.rb` がずれを捕まえる）。
+  #   `~> X.Y`   → 上限の外は major       → major を止める
+  #   `~> X.Y.Z` → 上限の外は minor 以上  → minor と major を止める
+  ignore:
+    # #4699: json 3.0 はリリース翌日のメジャー。harness ＋ステージングで実走してから上げる
+    - dependency-name: json
+      update-types: ['version-update:semver-major']
+    # #4663 / #4678: 2026-02 の同時アクセステストを通った版。上げる判断は実測で行う
+    - dependency-name: rack
+      update-types: ['version-update:semver-major', 'version-update:semver-minor']
+    # 🔴 事故版は 4.2.0。4.2.1 は本番 4 台で無事故（#4508）
+    - dependency-name: sinatra
+      update-types: ['version-update:semver-major', 'version-update:semver-minor']
+    - dependency-name: sidekiq-scheduler
+      update-types: ['version-update:semver-major', 'version-update:semver-minor']
+    - dependency-name: parallel
+      update-types: ['version-update:semver-major']
+    - dependency-name: puma
+      update-types: ['version-update:semver-major']
+    - dependency-name: sidekiq
+      update-types: ['version-update:semver-major']
   groups:
     # ⚠ 自作 gem。タグ固定したので `bump ginseng-core from v1.23.7 to ...` と
     # **版として読める**タイトルになる（#4701 が狙っていた効果）。
     ginseng:
       patterns:
         - 'ginseng-*'
-    # それ以外はまとめて 1 本。⚠ `versioning-strategy: lockfile-only` なので
-    # `Gemfile` の制約は動かず、`Gemfile.lock` だけが上がる。
+    # それ以外はまとめて 1 本。⚠ 上の `ignore` があるので、**上限を置いた gem の
+    # 制約は動かない**（上限の内側の版上げは `Gemfile.lock` だけが上がる）。
     others:
       patterns:
         - '*'

--- a/test/unit/lib/dependabot_config.rb
+++ b/test/unit/lib/dependabot_config.rb
@@ -1,0 +1,64 @@
+module Mulukhiya
+  # `.github/dependabot.yml` の `ignore` が `Gemfile` の上限と対になっていること (#4702)。
+  #
+  # ⚠⚠ **`versioning-strategy: increase-if-necessary` は、上限の外の版で manifest を動かす。**
+  # `lockfile-only` のままでは ginseng の `tag:` が上がらない（PR #4716 の Codex P1）ので
+  # 切り替えたが、そのままでは **json 3.0 / rack 3.3 / sinatra 4.3 のような、意図して
+  # 据え置いている gem まで制約を広げる PR が出る**。`ignore` で止めている。
+  #
+  # 🔴 **`Gemfile` に上限を足したのに `ignore` を足し忘れると、据え置きの判断が黙って
+  # 崩れる。**逆に上限を外したのに `ignore` が残ると、版上げが黙って止まる。
+  # どちらも CI では気付けないので、ここで対を固定する。
+  class DependabotConfigTest < TestCase
+    MAJOR = 'version-update:semver-major'.freeze
+    MINOR = 'version-update:semver-minor'.freeze
+
+    def setup
+      @config = YAML.load_file(File.join(Environment.dir, '.github/dependabot.yml'))
+      @develop = @config['updates'].find {|u| u['target-branch'] == 'develop'}
+      @ignores = Array(@develop['ignore']).to_h {|v| [v['dependency-name'], v['update-types']]}
+    end
+
+    # 🔴 **本体。**`~>` で上限を置いた gem には、上限の外へ出る版上げを止める `ignore` がある。
+    #   `~> X.Y`   → 上限の外は major       → major を止める
+    #   `~> X.Y.Z` → 上限の外は minor 以上  → minor と major を止める
+    def test_every_capped_gem_is_ignored_beyond_its_cap
+      capped_gems.each do |name, segments|
+        types = @ignores[name]
+
+        assert(types, "#{name} に上限があるのに ignore が無い（据え置きが崩れる）")
+        assert_includes(types, MAJOR, "#{name} の major を止めていない")
+        assert_includes(types, MINOR, "#{name} は ~> X.Y.Z なので minor も止める必要がある") if segments == 3
+      end
+    end
+
+    # ⚠ 逆向き。上限を外したのに `ignore` が残っていると、版上げが黙って止まる。
+    def test_no_stale_ignores
+      stale = @ignores.keys - capped_gems.keys
+
+      assert_empty(stale, "Gemfile に上限が無いのに ignore が残っている: #{stale.join(', ')}")
+    end
+
+    # ⚠⚠ **ginseng の `tag:` が上がる設定であること。**`lockfile-only` に戻ると、
+    # ginseng グループから PR が 1 本も出なくなる（PR #4716 の Codex P1）。
+    def test_strategy_permits_manifest_updates
+      assert_not_equal('lockfile-only', @develop['versioning-strategy'])
+    end
+
+    # ⚠ ginseng を止めていないこと（ここを止めると #4701 の固定が凍結に変わる）。
+    def test_ginseng_is_not_ignored
+      assert(@ignores.keys.none? {|name| name.start_with?('ginseng')}, 'ginseng を ignore している')
+    end
+
+    private
+
+    # `Gemfile` の `gem 'name', '~> X.Y[.Z]'` を拾う。ginseng（`tag:`）は対象外。
+    def capped_gems
+      path = File.join(Environment.dir, 'Gemfile')
+      return File.readlines(path).filter_map do |line|
+        next unless matches = line.match(/^\s*gem '([^']+)', *'~> *([0-9.]+)'/)
+        [matches[1], matches[2].split('.').size]
+      end.to_h
+    end
+  end
+end


### PR DESCRIPTION
Closes #4702

#4701 で `ginseng-*` をタグ固定しましたが、⚠⚠ **`.github/dependabot.yml` は Bundler の
2 エントリとも `open-pull-requests-limit: 0`** で **version update が丸ごと無効**でした。
**版を上げる経路がどこにも無く、7 本が凍結します。**

⚠ 固定の目的は「破綻の受け皿を `bundle update` の中（無関係な PR）から**版上げ PR の CI**へ
移す」ことなので、**その PR が出ないと固定した意味がありません。**

## develop だけ開けます

⚠ **`allow:` で `ginseng-*` に絞ってはいけません。**`allow` は **security update にも効く**ので、
他の gem の脆弱性 PR まで止まります（limit 0 でも生きている**唯一の安全弁**を壊す）。
⚠ dependabot は同一 `(ecosystem, directory, target-branch)` の重複を許さないので、
「ginseng 専用のもう 1 エントリ」も足せません。

そこで **`groups` で束ねて本数を抑えます**:

| グループ | 中身 | 効果 |
| --- | --- | --- |
| `ginseng` | `ginseng-*` | タグ固定したので `bump ginseng-core from v1.23.7 to ...` と**版として読める**タイトルに（#4701 が狙っていた効果） |
| `others` | それ以外まとめて 1 本 | ⚠ `versioning-strategy: lockfile-only` なので `Gemfile` の制約は動かず `Gemfile.lock` だけ上がる |

**1 日に出る PR は最大 2 本**（`open-pull-requests-limit: 2`）。

## v4 は据え置きます

保守は「必要なものだけバックポート」の方針なので、日次で PR が出ても捌けません。
⚠ **security update は limit 0 でも動く**ので、脆弱性の通知は止まりません。

## ⚠ 効き始めるのは develop がこれを持ってから

dependabot は**対象ブランチ上の設定**を読むので、マージ後の最初のスケジュール
（03:00 JST）から動き出します。⚠ **初回は溜まっていたぶんが 2 本まとめて出ます。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExMqJf1tfD174UoMBGVJNk