### PR TITLE
fix: /feed/media の item から pubDate が消えていた (#4639 の手順 3 で発覚)

### DIFF
--- a/app/lib/mulukhiya/model/attachment_methods.rb
+++ b/app/lib/mulukhiya/model/attachment_methods.rb
@@ -116,12 +116,24 @@ module Mulukhiya
       return size
     end
 
+    # RSS 2.0 の item に**そのまま渡す**ハッシュ (#4639)。
+    #
+    # ⚠⚠ **キーはすべて `RSS::Maker` の item のセッターとして送られる。**
+    # `Ginseng::Web::RSS20FeedRenderer` は `entry.each {|k, v| item.send(:"#{k}=", v)}`
+    # なので、**item に無いキーを 1 つでも混ぜると例外になり、その後ろのキーが全部捨てられる。**
+    #
+    # 🔴 以前は `created_at:` を持っていた。`created_at=` は item に無いので、
+    # **`/feed/media` の全 item から `<pubDate>` が消え、item ごとに error 行が出ていた。**
+    # media_catalog は 5.23.0 (#4343) から既定で無効だったので誰も踏まず、
+    # **#4639 の Gate 2 の手順 3（dev26 で flip）で初めて表に出た。**
+    # ⚠ 放置して本番で flip すると、**リクエストごと × item ごとに syslog が 1 行ずつ**増える
+    # （#4549 の「日 2 万行」と同型）。
+    # ⚠ 日時は `date:`（→ `<pubDate>`）だけで足りる。
     def feed_entry
       return {
         link: uri.to_s,
         title: [name, "(#{size_str})", description].compact.join(' '),
         author: account.display_name,
-        created_at: date,
         date:,
       }
     end

--- a/test/unit/renderer/media_feed_entry.rb
+++ b/test/unit/renderer/media_feed_entry.rb
@@ -1,0 +1,82 @@
+require 'rss'
+
+module Mulukhiya
+  # `feed_entry` の全キーが RSS 2.0 の item に通ること (#4639)。
+  #
+  # ⚠⚠ **`Ginseng::Web::RSS20FeedRenderer` はキーをすべて item のセッターとして送る**
+  # （`entry.each {|k, v| item.send(:"#{k}=", v)}`）。**item に無いキーを 1 つでも
+  # 混ぜると例外になり、その後ろのキーが全部捨てられる。**
+  #
+  # 🔴 `created_at:` が混ざっていて、**`/feed/media` の全 item から `<pubDate>` が
+  # 消え、item ごとに error 行が出ていた**。media_catalog は 5.23.0 から既定で無効
+  # だったので誰も踏まず、#4639 の Gate 2 の手順 3（dev26 で flip）で初めて出た。
+  #
+  # ⚠ `feed_entry` は DB の添付を引くので、ここでは**同じ形のハッシュ**を
+  # `AttachmentMethods#feed_entry` から組み立てて検証する（DB 非依存）。
+  class MediaFeedEntryTest < TestCase
+    # `feed_entry` が参照するものだけを持つダブル。
+    class AttachmentDouble
+      include AttachmentMethods
+
+      def uri = Ginseng::URI.parse('https://example.com/media/a.webp')
+      def name = 'a.webp'
+      def size_str = '2KiB'
+      def description = nil
+      def account = Struct.new(:display_name).new('admin')
+      def date = Time.parse('2026-07-11T09:13:51+09:00')
+    end
+
+    def setup
+      @entry = AttachmentDouble.new.feed_entry
+    end
+
+    # 🔴 **本体。**全キーが item のセッターとして通る（例外にならない）。
+    def test_every_key_is_an_rss_item_setter
+      item = new_item
+
+      @entry.each_key do |key|
+        assert_respond_to(item, :"#{key}=", "RSS item に #{key}= が無い（後続のキーが捨てられる）")
+      end
+    end
+
+    # 🔴 **`<pubDate>` が出る。**`created_at` で例外になると、ここが丸ごと消えていた。
+    def test_rendered_item_has_a_pub_date
+      xml = render([@entry])
+
+      assert_match(%r{<pubDate>.+</pubDate>}, xml, 'pubDate が出ていない')
+      assert_match(%r{<title>a\.webp \(2KiB\)</title>}, xml)
+    end
+
+    # ⚠ **退行の目印。**`created_at` を戻したら落ちる。
+    def test_created_at_is_not_in_the_entry
+      refute(@entry.key?(:created_at), 'created_at が戻っている（RSS item に created_at= は無い）')
+    end
+
+    private
+
+    def new_item
+      item = nil
+      RSS::Maker.make('rss2.0') do |maker|
+        maker.channel.title = 't'
+        maker.channel.link = 'https://example.com/'
+        maker.channel.description = 'd'
+        maker.items.new_item {|i| item = i}
+      end
+      return item
+    end
+
+    # `RSS20FeedRenderer#feed` と同じ流儀（キーをすべてセッターとして送る）で組み立てる。
+    def render(entries)
+      return RSS::Maker.make('rss2.0') do |maker|
+        maker.channel.title = 't'
+        maker.channel.link = 'https://example.com/'
+        maker.channel.description = 'd'
+        entries.each do |entry|
+          maker.items.new_item do |item|
+            entry.each {|k, v| item.send(:"#{k}=", v)}
+          end
+        end
+      end.to_s
+    end
+  end
+end


### PR DESCRIPTION
Refs #4639 — ⚠ #4639 本体（Gate 2）はまだ閉じません。

## 何が起きたか

#4639 の Gate 2 の**手順 3（dev26 で media_catalog を flip して、壊れていないことだけを見る）**で、
`/feed/media` を叩いたところ syslog にこれが出ました:

```
{"error":{"message":"undefined method 'created_at=' for an instance of RSS::Maker::RSS20::Items::Item",
 "file":".../ginseng-web-9814f164d646/lib/ginseng/web/renderer/rss20_feed_renderer.rb","line":25},
 "entry":{"link":"...","title":"ede5fdaac3a58ba4.webp (2KiB)","author":"admin",
          "created_at":"2026-07-11T09:13:51.000+09:00","date":"2026-07-11T09:13:51.000+09:00"}}
```

実測（dev26）: item は 1 件載りますが、🔴 **`<title>` / `<link>` / `<author>` しかなく `<pubDate>` がありません。**

## 原因

`AttachmentMethods#feed_entry` が **`created_at:` と `date:` の両方**を返していました。

⚠⚠ **`Ginseng::Web::RSS20FeedRenderer` はキーをすべて item のセッターとして送ります**:

```ruby
entry.except(:enclosure).each {|k, v| item.send(:"#{k}=", v)}
```

RSS item に `created_at=` は無いので例外になり、🔴 **その後ろの `date`（→ `<pubDate>`）が捨てられます。**
例外は item 単位で rescue されるので、**リクエストは 200 のまま**です（＝気付きにくい）。

## なぜ今まで誰も踏まなかったか

media_catalog は **5.23.0 (#4343) から既定で無効**で、この経路は本番で走っていませんでした。
**Gate 2 の手順 3 がちょうどこれを拾うための段**でした（正本は「性能検証ではない。確認するのは
壊れていないことだけ」）。

## ⚠ 放置して本番（zugoga）で flip すると

- 🔴 **リクエストごと × item ごとに syslog が 1 行ずつ**増えます（#4549 の「日 2 万行」と同型）
- 全 item の `<pubDate>` が消えます

⚠ **手順 4（zugoga の flip）はこの PR が本番に入るまで進めません。**

## 直した点

`created_at:` を外しました。日時は `date:`（→ `<pubDate>`）だけで足ります。
`feed_entry` を使っているのはメディアフィード（Mastodon / Misskey の `Attachment.feed`）だけで、
`tag_feed_renderer` の `feed_entry` はテンプレート名なので無関係です。

## テスト（3 本・新規 `test/unit/renderer/media_feed_entry.rb`）

| テスト | 何を押さえるか |
| --- | --- |
| `test_every_key_is_an_rss_item_setter` | 🔴 **`feed_entry` の全キーが RSS item のセッターとして通る**（キーを足した瞬間に捕まえる） |
| `test_rendered_item_has_a_pub_date` | 🔴 `<pubDate>` が出る |
| `test_created_at_is_not_in_the_entry` | ⚠ 退行の目印 |

⚠ **修正前は 3 本とも落ち、本番で出たのと同じ `NoMethodError: undefined method 'created_at='` が再現します。**

## 検証

- `bundle exec rake lint` → ✅ **519 files / no offenses**、脆弱性 0
- `bundle exec rake test` → ✅ **1356 tests / 1974 assertions / 0 failures / 0 errors**
- ⚠ マージ後に dev26 へ配って、`<pubDate>` が出て error 行が消えることを確認します

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HPk2goTjvvyd5ymHUfFfc