### PR TITLE
fix: alert のデッドマンが KEYS を撃ち、Redis が書けないと全部黙る (5.37.0 リリース前レビューの赤)

### DIFF
--- a/app/lib/mulukhiya/controller.rb
+++ b/app/lib/mulukhiya/controller.rb
@@ -262,27 +262,40 @@ module Mulukhiya
       return throttled_alert(error)
     end
 
-    # 同じ型の失敗は窓のあいだ 1 回だけ鳴らす (#4693)。
+    # 同じ型 × 同じ発生源の失敗は、窓のあいだ 1 回だけ鳴らす (#4693)。
     #
     # ⚠ `StartupNotificationWorker#notify_failure` と同じ「連続失敗の 1 回目だけ」の
     # 考え方だが、**成功で解除する代わりに TTL で解除する。**`before` は毎リクエスト
     # 走るので、成功のたびに Redis を書くと平常時のコストが乗る。
     #
-    # ⚠⚠ **カウンタ自体が落ちたら log へ倒す。**ここへ来る主因が Redis 全断なので、
-    # 抑止できないからと鳴らす側へ倒すと**まさに避けたいスパムになる**。
-    # Redis の死は `/health` の redis 側で観測されるので、二重に鳴らす価値がない
-    # （`StartupNotificationWorker` と同じ判断）。
-    # ⚠ **厳密な排他ではない。**`Ginseng::Redis::Service#set` は `NX` を取らないので
-    # `key?` → `setex` の 2 段になる。同時に来た数本が二重に鳴ることはあるが、
-    # **抑えたいのは「全断中に毎リクエスト鳴る」**ほうなので、これで足りる。
+    # ⚠ **抑止中の log には発生源を載せる。**抑止しているあいだは syslog が唯一の
+    # 記録なので、どのルートで何件落ちたかを数えられないと意味が無い。
     def throttled_alert(error)
-      redis = Redis.new
-      key = alert_throttle_key(error)
-      return error.log(throttled: true) if redis.key?(key)
-      redis.setex(key, ALERT_THROTTLE_SECONDS, 1)
-      error.alert
+      return error.alert if acquire_alert_slot(alert_throttle_key(error))
+      return error.log(throttled: true, origin: alert_throttle_origin)
+    end
+
+    # 鳴らす権利を獲得できたか。
+    #
+    # 🔴 **5.37.0 リリース前レビューの赤。**当初は `key?` → `setex` の 2 段で、
+    # - `key?` の中身が **`KEYS`** で、**障害の最中に要求のたびに Redis を塞いでいた**
+    #   （Mastodon と共有しているインスタンス。同じリリースの #4703 が
+    #   「KEYS は本番の要求経路に乗らない」と書いたのと矛盾していた）
+    # - `setex` の再送で、書き込みを拒む Redis では **5xx のたびに約 2 秒止まった**
+    # - ⚠⚠ **書き込みを拒む Redis（ディスク満杯の MISCONF・OOM・READONLY）では、
+    #   印が永遠に書けないので全ルートのサーバー側失敗が 1 回も鳴らなくなった。**
+    #   しかも `/health` の redis は**読みしか試さない**ので OK のまま＝
+    #   「Redis の死は /health が見る」という前提が崩れていた
+    #
+    # → **`SET NX EX` を再送なしで 1 回**撃つ。⚠⚠ **書けなかったら黙らせない。**
+    # プロセス内の抑止へ倒す（`LocalAlertThrottle`）。**Redis が健全なら
+    # クラスタ全体で 1 回、壊れていればプロセスごとに 1 回**鳴る。どちらでも
+    # 「黙る」ことも「連打する」ことも無い。
+    def acquire_alert_slot(key)
+      return Redis.new.acquire(key, ALERT_THROTTLE_SECONDS)
     rescue => e
-      error.log(throttle_error: e.class.to_s)
+      logger.error(error: 'alert throttle unavailable', class: e.class.to_s, key:)
+      return LocalAlertThrottle.acquire(key, ALERT_THROTTLE_SECONDS)
     end
 
     # 抑止のバケツ。**型だけでは粗すぎる（PR #4712 の Codex P2）。**

--- a/app/lib/mulukhiya/local_alert_throttle.rb
+++ b/app/lib/mulukhiya/local_alert_throttle.rb
@@ -1,0 +1,39 @@
+module Mulukhiya
+  # プロセス内だけで効く alert の抑止（5.37.0 リリース前レビューの赤）。
+  #
+  # ⚠⚠ **Redis に印を書けないときの受け皿。**`report_error` のデッドマンは
+  # 平常時は Redis の `SET NX EX` でクラスタ全体に 1 回だけ鳴らす。だが Redis が
+  # 書き込みを拒む状態（ディスク満杯の MISCONF・OOM・READONLY）では印が書けない。
+  # そこで **log へ倒すと、全ルートのサーバー側失敗が 1 回も鳴らなくなる**
+  # （当初の実装がそうだった）。**鳴らす側へ倒すと、全断中に毎リクエスト鳴る。**
+  # どちらも避けるために、**プロセスごとに窓 1 回**まで鳴らす。
+  #
+  # ⚠ **I/O を持たない。**障害の最中に呼ばれる前提なので、ここでさらに外部へ
+  # 依存すると同じ穴に落ちる。単調時計で期限を持つ（壁時計は NTP / VM の補正で飛ぶ）。
+  # ⚠ puma のワーカー数ぶん鳴りうるが、**上限は「ワーカー数 × 窓 1 回」で有界**。
+  module LocalAlertThrottle
+    EXPIRES = Concurrent::Map.new
+
+    # 窓のあいだ一度だけ true を返す。⚠ `compute` は鍵ごとに原子的なので、
+    # 同じプロセスの複数スレッドが同時に来ても 1 本だけが獲得する。
+    def self.acquire(key, ttl)
+      now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      acquired = false
+      EXPIRES.compute(key) do |expires_at|
+        if expires_at.nil? || expires_at <= now
+          acquired = true
+          now + ttl
+        else
+          expires_at
+        end
+      end
+      return acquired
+    end
+
+    # テストで「既知の状態から始める」ための入口。
+    def self.clear(prefix = nil)
+      return EXPIRES.clear unless prefix
+      EXPIRES.each_key {|key| EXPIRES.delete(key) if key.to_s.start_with?(prefix)}
+    end
+  end
+end

--- a/app/lib/mulukhiya/redis.rb
+++ b/app/lib/mulukhiya/redis.rb
@@ -35,6 +35,19 @@ module Mulukhiya
       return redis.call('SET', create_key(key), value, 'NX') == 'OK'
     end
 
+    # 期限付きで一度だけ獲得する SET（`SET key 1 NX EX ttl`）。獲得できたとき true。
+    #
+    # ⚠⚠ **1 コマンド・再送なし（5.37.0 リリース前レビューの赤）。**
+    # `key?` → `setex` の 2 段で書いていた `report_error` のデッドマンは、
+    # - `key?` の中身が **`KEYS`**（DB 全体を O(N) で走査して Redis を塞ぐ）で、
+    #   Mastodon と共有しているインスタンスを、**障害の最中に要求のたびに**塞いでいた
+    # - `setex` は ginseng-redis の再送（1 秒 × 3 回）を踏むので、書き込みを拒む Redis
+    #   （MISCONF・OOM・READONLY）では **5xx のたびに puma のスレッドが約 2 秒止まった**
+    # ⚠ 例外は呼び出し側へ上げる（握らない）。書けないときにどう倒すかは呼び出し側が決める。
+    def acquire(key, ttl) # rubocop:disable Naming/PredicateMethod
+      return redis.call('SET', create_key(key), '1', 'NX', 'EX', ttl.to_i) == 'OK'
+    end
+
     def clear
       bar = ProgressBar.create(total: all_keys.count)
       all_keys.each do |key|

--- a/app/lib/mulukhiya/test_case.rb
+++ b/app/lib/mulukhiya/test_case.rb
@@ -70,7 +70,12 @@ module Mulukhiya
     # 「実際に alert すること」を見るテストは、必ずこれを通してから測る。
     # ⚠ キーは `<prefix>/<型>/<発生源>` (#4693・PR #4712 の Codex P2)。
     # テストからは発生源を特定しにくいので、接頭辞で総なめする。
+    # ⚠ **プロセス内の抑止も消す**（Redis に書けないときの受け皿・5.37.0 の赤）。
+    # 片方だけ消すと、Redis 側を空にしても前のテストの印がプロセスに残る。
     def clear_alert_throttle(*classes)
+      classes.each do |klass|
+        LocalAlertThrottle.clear("#{Controller::ALERT_THROTTLE_KEY_PREFIX}/#{klass}")
+      end
       redis = Redis.new
       classes.each do |klass|
         prefix = "#{Controller::ALERT_THROTTLE_KEY_PREFIX}/#{klass}"

--- a/test/unit/controller/report_error_gaps.rb
+++ b/test/unit/controller/report_error_gaps.rb
@@ -94,17 +94,84 @@ module Mulukhiya
       clear_alert_throttle(RuntimeError)
     end
 
-    # ⚠⚠ **抑止できないなら鳴らす側へ倒さない。**ここへ来る主因が Redis 全断な
-    # ので、倒すとまさに避けたいスパムになる。Redis の死は `/health` が見る。
-    def test_falls_back_to_log_when_redis_is_unavailable
-      Redis.define_singleton_method(:new) {raise Ginseng::Redis::Error, 'refused'}
+    # 🔴 **Redis に印を書けなくても黙らない（5.37.0 リリース前レビューの赤）。**
+    #
+    # ⚠⚠ **当初はここで log へ倒していた**（「Redis の死は /health が見る」前提）。
+    # だが **書き込みを拒む Redis（ディスク満杯の MISCONF・OOM・READONLY）では
+    # `/health` の redis は OK のまま**（読みしか試さない）で、印が永遠に書けないので
+    # **全ルートのサーバー側失敗が 1 回も鳴らなくなっていた**（観測性の観点が再現）。
+    # → プロセス内の抑止へ倒す。**1 回目は鳴り、2 回目以降は抑える。**
+    def test_does_not_go_silent_when_redis_refuses_writes
+      refuse_redis_writes
+      error = RuntimeError.new('db is down')
 
-      assert_equal(:log, report(RuntimeError.new('db is down')))
+      assert_equal(:alert, report(error), 'Redis に書けないと 1 回も鳴らない（黙る）')
+      assert_equal(:log, report(error), 'Redis に書けないと毎回鳴る（連打する）')
     ensure
-      Redis.singleton_class.remove_method(:new)
+      restore_redis_client
+    end
+
+    # ⚠⚠ **`KEYS` を撃たない。**`Ginseng::Redis::Service#key?` の中身は `KEYS` で、
+    # DB 全体を O(N) で走査して Redis を塞ぐ。障害の最中に要求のたびに撃つと、
+    # Mastodon と共有しているインスタンスごと障害を悪化させる。
+    def test_does_not_scan_the_keyspace
+      scanned = false
+      Redis.define_method(:keys) do |*|
+        scanned = true
+        []
+      end
+      Redis.define_method(:key?) do |*|
+        scanned = true
+        false
+      end
+
+      report(RuntimeError.new('db is down'))
+
+      refute(scanned, 'KEYS（key? / keys）を撃っている')
+    ensure
+      Redis.send(:remove_method, :keys) if Redis.method_defined?(:keys, false)
+      Redis.send(:remove_method, :key?) if Redis.method_defined?(:key?, false)
+    end
+
+    # ⚠ **再送の sleep を払わない。**ginseng-redis の `setex` は失敗すると 1 秒ずつ
+    # 待って再送するので、書き込みを拒む Redis では 5xx のたびに約 2 秒止まっていた。
+    def test_does_not_sleep_when_redis_refuses_writes
+      refuse_redis_writes
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      report(RuntimeError.new('db is down'))
+
+      assert_operator(Process.clock_gettime(Process::CLOCK_MONOTONIC) - started, :<, 0.5)
+    ensure
+      restore_redis_client
     end
 
     private
+
+    # **読みは通し、書きだけ拒む** Redis（MISCONF・OOM・READONLY の再現）。
+    #
+    # ⚠ **Redis クライアントの層で差し替える。**`Mulukhiya::Redis#acquire` を
+    # 差し替えると、`key?` → `setex` を使う旧実装の経路では何も起きず、
+    # **旧実装でもテストが通ってしまう**（実際に false negative を踏んだ）。
+    # 新旧どちらの実装も通る `redis.call` で拒めば、旧実装は実際に黙り・止まる。
+    def refuse_redis_writes
+      client = Object.new
+      client.define_singleton_method(:call) do |command, *_args|
+        raise RedisClient::CommandError, 'READONLY You can\'t write against a read only replica.' \
+          if ['SET', 'SETEX'].include?(command.to_s.upcase)
+        return [] if command.to_s.upcase == 'KEYS'
+        return nil
+      end
+      Redis.alias_method(:__orig_redis_client, :redis)
+      Redis.define_method(:redis) {client}
+    end
+
+    def restore_redis_client
+      return unless Redis.private_method_defined?(:__orig_redis_client) ||
+        Redis.method_defined?(:__orig_redis_client)
+      Redis.alias_method(:redis, :__orig_redis_client)
+      Redis.send(:remove_method, :__orig_redis_client)
+    end
 
     # 発生源（`sinatra.route`）を指定して呼ぶ。
     def report_from(error, route)

--- a/test/unit/lib/local_alert_throttle.rb
+++ b/test/unit/lib/local_alert_throttle.rb
@@ -1,0 +1,49 @@
+module Mulukhiya
+  # Redis に印を書けないときの受け皿（5.37.0 リリース前レビューの赤）。
+  #
+  # ⚠⚠ **黙らず、連打もしない。**窓のあいだ 1 回だけ獲得でき、窓が明ければまた獲得できる。
+  class LocalAlertThrottleTest < TestCase
+    PREFIX = 'local_alert_throttle_test'.freeze
+
+    def teardown
+      LocalAlertThrottle.clear(PREFIX)
+      super
+    end
+
+    # 🔴 **本体。**窓のあいだ 1 回だけ。
+    def test_acquires_once_per_window
+      assert(LocalAlertThrottle.acquire(key, 60), '1 回目が獲得できない（黙る）')
+      refute(LocalAlertThrottle.acquire(key, 60), '2 回目も獲得できる（連打する）')
+    end
+
+    # 窓が明ければまた鳴る（永遠に黙らない）。
+    def test_reacquires_after_the_window
+      assert(LocalAlertThrottle.acquire(key, 0.05))
+      sleep(0.1)
+
+      assert(LocalAlertThrottle.acquire(key, 0.05), '窓が明けても獲得できない')
+    end
+
+    # ⚠ 鍵ごとに独立（別の型・別のルートを握り潰さない）。
+    def test_keys_are_independent
+      assert(LocalAlertThrottle.acquire(key('a'), 60))
+
+      assert(LocalAlertThrottle.acquire(key('b'), 60), '別の鍵まで抑えている')
+    end
+
+    # ⚠⚠ **同じプロセスの複数スレッドが同時に来ても 1 本だけ。**
+    # `Concurrent::Map#compute` は鍵ごとに原子的。
+    def test_only_one_thread_acquires
+      winners = Concurrent::Array.new
+      Array.new(16) {Thread.new {winners.push(LocalAlertThrottle.acquire(key, 60))}}.each(&:join)
+
+      assert_equal(1, winners.count(true), '同時に来た複数スレッドが獲得している')
+    end
+
+    private
+
+    def key(suffix = 'x')
+      return "#{PREFIX}/#{suffix}"
+    end
+  end
+end


### PR DESCRIPTION
Refs #4693 / #4712 — **5.37.0 リリース前 5 観点レビューの赤（1 件のみ）**

#4693 / #4712 で入れた `report_error` のデッドマン（同じ型 × 同じ発生源は 300 秒に 1 回だけ鳴らす）に、**このリリースで持ち込んだ退行**が 3 つありました。**5 観点のうち 3 観点（API 契約・並行性・観測性）が独立に挙げています。**

## 🔴 何が起きていたか

`key?` → `setex` の 2 段で書いていました。

| | 何が起きるか |
| --- | --- |
| 1 | **`key?` の中身が `KEYS`**（`Ginseng::Redis::Service#key?` → `keys` → `KEYS`）。DB 全体を O(N) で走査して Redis を塞ぎます。これが**サーバー側の失敗のたびに要求経路で**走り、**Mastodon と共有しているインスタンスを障害の最中に**塞いでいました |
| 2 | **`setex` の再送**（`/redis/retry` 1 秒 × 3 回）で、書き込みを拒む Redis では **5xx のたびに puma のスレッドが約 2 秒止まりました** |
| 3 | ⚠⚠ **書き込みを拒む Redis（ディスク満杯の MISCONF・OOM・READONLY）では、印が永遠に書けないので全ルートのサーバー側失敗が 1 回も鳴りませんでした。**しかも `/health` の redis は**読みしか試さない**ので OK のままです |

3 は観測性の観点が再現しています:

```
result=[[:log, {throttle_error: "Ginseng::Redis::Error"}]] elapsed=2.02s
health={status: "OK"}
```

⚠ 「Redis の死は /health が見る」という前提で log へ倒していましたが、**書き込みだけ拒む状態は /health に映らない**ので、前提が崩れていました。⚠ 同じリリースの #4703 が `TaggingDictionary.invalidate_cache` に「KEYS は本番の要求経路に乗らない」と書いたのとも矛盾していました。

## 直した点

- **`Mulukhiya::Redis#acquire`** — `SET key 1 NX EX ttl` を**再送なしで 1 回**。KEYS も sleep も消え、コメントに書いていた「厳密な排他ではない」（`key?` → `setex` の非原子性）も同時に解消します
- ⚠⚠ **書けなかったら黙らせない** — **`LocalAlertThrottle`**（プロセス内・I/O 無し・単調時計・`Concurrent::Map#compute` で鍵ごとに原子的）へ倒します

| Redis の状態 | 鳴る回数（300 秒あたり・型 × ルートごと） |
| --- | --- |
| 健全 | **クラスタ全体で 1 回**（従来どおり） |
| 書き込みを拒む・落ちている | **プロセスごとに 1 回**（上限は puma ワーカー数 × 1。有界） |

**どちらでも「黙る」ことも「連打する」ことも無くなります。**

- 抑止中の log に **`origin`（ルート）** を載せます（抑止中は syslog が唯一の記録なので、どこで何件落ちたか数えられないと意味が無い。観測性の観点の緑）

⚠ **平常時の動き（300 秒・型 × ルート）は変えていません。**

## テスト

### ⚠ 新テスト 3 本は旧実装で 3 本とも落ちます

```
Failure: test_does_not_go_silent_when_redis_refuses_writes
Failure: test_does_not_scan_the_keyspace
Failure: test_does_not_sleep_when_redis_refuses_writes
14 tests, 19 assertions, 3 failures
```

⚠ **最初に書いた版は false negative でした。**`acquire` を差し替えていたので、`key?` → `setex` を使う**旧実装では何も起きず通ってしまいました。****Redis クライアントの層で「読みは通し、書きだけ拒む」**状態を作る形に直しています（新旧どちらの実装も通る `redis.call` で拒む）。

### `LocalAlertThrottle` の単体テスト（4 本）

窓のあいだ 1 回だけ・窓が明ければまた獲得できる・鍵ごとに独立・**16 スレッド同時でも 1 本だけ獲得**。

### 既存テストの置き換え

`test_falls_back_to_log_when_redis_is_unavailable` は**前提ごと変わった**（log へ倒すのをやめた）ので、`test_does_not_go_silent_when_redis_refuses_writes` に置き換えました。

## 検証

- `bundle exec rake lint` → ✅ **523 files / no offenses**、脆弱性 0
- `bundle exec rake test` → ✅ **1370 tests / 0 failures / 0 errors**（omission 326 ＝ CI の上限と一致）
- ⚠ マージ後、手順どおり **harness 両系の実走 → ステージング 4 台の再検証**をやり直します

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HPk2goTjvvyd5ymHUfFfc