### PR TITLE
fix: /feed/custom/*/path の pattern '^/' を外す (#4728)

### DIFF
--- a/config/schema/base.yaml
+++ b/config/schema/base.yaml
@@ -177,10 +177,12 @@ properties:
               format: uri
               type: string
             path:
-              # ⚠⚠ **`format: ^/` は format 名ですらなかった (#4597)。**未知の format は
-              # 黙って無視されるので、**1 文字の違いで完全な no-op** になっていた。
-              # 書き手の意図（「`/` で始まること」）は正規表現なので `pattern` が正しい。
-              pattern: '^/'
+              # ⚠⚠ **`pattern` を付けない (#4728)。**`CustomFeed` は
+              # `File.join('/mulukhiya/feed', path)` で組むので、**先頭 `/` 無しが正規の
+              # 書き方**（本番の `dqdai-official` / `precure/portal` 等はすべてそう）。
+              # 旧 `format: ^/` は format 名ですらなく何も検証していなかったが、#4597 で
+              # 「`/` で始まること」と読んで `pattern: '^/'` にしたら、本番の正しい設定を
+              # 全部拒否した。**効いていない制約は、意図を実物と突き合わせてから効かせる。**
               type: string
             title:
               type: string

--- a/test/unit/lib/config_format_validator.rb
+++ b/test/unit/lib/config_format_validator.rb
@@ -76,6 +76,24 @@ module Mulukhiya
       assert_empty(found, '検証実装の無い format が残っている')
     end
 
+    # 🔴 **本番の書き方のカスタムフィードを拒否しない (#4728)。**
+    # ⚠⚠ #4597 で `/feed/custom/*/path` に `pattern: '^/'` を付けたら、先頭 `/` 無しで
+    # 書かれた本番の設定（zugoga / gomander）が全部 config:lint で落ちた。
+    # `CustomFeed` は `File.join` で組むので、どちらの書き方も正しい。
+    def test_custom_feed_paths_in_both_forms_are_accepted
+      config = Config.instance
+      original = config.raw['local']
+      config.raw['local'] = {'feed' => {'custom' => [
+        {'path' => 'dqdai-official', 'command' => ['bin/dqdai-official.rb']},
+        {'path' => 'precure/portal', 'command' => ['bin/precure-portal.rb']},
+        {'path' => '/absolute', 'command' => ['bin/absolute.rb']},
+      ]}}
+
+      assert_empty(config.errors.grep(%r{#/feed/custom}), 'カスタムフィードの path を拒否している')
+    ensure
+      config.raw['local'] = original
+    end
+
     # 🔴 **`Config#errors` に届くこと（PR #4711 の Codex P1）。**
     # ⚠⚠ `Mulukhiya.validate_config` にだけ足すと、**`rake config:lint` も
     # `Config#audit` も `errors` を直に見ている**ので素通りする。`config:lint` は


### PR DESCRIPTION
Closes #4728

## 何が起きたか

5.37.0 の本番デプロイで、zugoga / gomander の `rake config:lint` が失敗した。#4597（PR #4711）で `/feed/custom/*/path` に付けた `pattern: '^/'` が、本番の正しい設定（`dqdai-official` / `precure/portal` など、先頭 `/` 無し）を拒否している。

⚠ **フィードの配信は正常**（`CustomFeed` は `File.join` でパスを組むので値は変わらない）。影響は `config:lint` の偽陽性、起動時の管理者向け通知に載る偽の「スキーマエラー」、起動時の警告行。

## 直し方

`pattern` を外す。旧 `format: ^/` の「意図」を読み違えたのが原因で、`File.join` はどちらの書き方も受けるので制約そのものが要らない。

## テスト

`test_custom_feed_paths_in_both_forms_are_accepted` — 本番の書き方 2 種と絶対パスが `Config#errors` に出ないこと。**修正前の schema では落ちる**ことを確認済み。`rake lint` 緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HPk2goTjvvyd5ymHUfFfc